### PR TITLE
Add markdown rendering with left-aligned headings

### DIFF
--- a/amplifier_app_cli/console.py
+++ b/amplifier_app_cli/console.py
@@ -1,7 +1,36 @@
 """Shared Rich console instance for CLI output."""
 
 from rich.console import Console
+from rich.console import ConsoleOptions
+from rich.console import RenderResult
+from rich.markdown import Heading as RichHeading
+from rich.markdown import Markdown as RichMarkdown
+from rich.text import Text
+
+
+class LeftAlignedHeading(RichHeading):
+    """Heading with left alignment (overrides Rich's default center alignment)."""
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions) -> RenderResult:
+        """Render heading with left alignment instead of center."""
+        text = self.text
+        text.justify = "left"  # Override Rich's default "center"
+
+        # Simple rendering without Panel (no heavy borders)
+        if self.tag == "h2":
+            yield Text("")  # Blank line before h2
+        yield text
+
+
+class Markdown(RichMarkdown):
+    """Markdown with left-aligned headings."""
+
+    elements = {
+        **RichMarkdown.elements,
+        "heading_open": LeftAlignedHeading,  # Use our custom heading
+    }
+
 
 console = Console()
 
-__all__ = ["console"]
+__all__ = ["console", "Markdown"]

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -37,6 +37,7 @@ from .commands.session import register_session_commands
 from .commands.setup import setup_cmd
 from .commands.source import source as source_group
 from .commands.update import update as update_cmd
+from .console import Markdown
 from .console import console
 from .key_manager import KeyManager
 from .paths import create_module_resolver
@@ -868,7 +869,8 @@ async def interactive_chat(
                             # Handle result or cancellation
                             try:
                                 response = await execute_task
-                                console.print("\n" + response)
+                                console.print()  # Blank line before response
+                                console.print(Markdown(response))
 
                                 # Save session after each interaction
                                 context = session.coordinator.get("context")
@@ -964,7 +966,7 @@ async def execute_single(
         response = await session.execute(prompt)
         if verbose:
             console.print(f"[dim]Response type: {type(response)}, length: {len(response) if response else 0}[/dim]")
-        console.print(response)
+        console.print(Markdown(response))
         console.print()  # Add blank line after output to prevent running into shell prompt
 
         # Always save session (for debugging/archival)
@@ -1117,7 +1119,8 @@ async def interactive_chat_with_session(
                             # Handle result or cancellation
                             try:
                                 response = await execute_task
-                                console.print("\n" + response)
+                                console.print()  # Blank line before response
+                                console.print(Markdown(response))
 
                                 # Save session after each interaction
                                 if context and hasattr(context, "get_messages"):


### PR DESCRIPTION
Minimal change to render LLM responses with markdown formatting:
- Export custom Markdown class from console.py
- Override heading alignment to left (Rich defaults to centered)
- Update 3 response print locations to use console.print(Markdown(response))

Why this is safe:
- Thinking blocks are displayed separately via hooks-streaming-ui module (emitted as events during execution, printed directly to stdout)
- session.execute() returns only the response text (not thinking)
- This change only affects response rendering, thinking display unchanged

Current GFM support via Rich's MarkdownIt parser:
- ✅ Tables, strikethrough, fenced code blocks, standard markdown
- ❌ Task lists (available via mdit-py-plugins if needed later)

Total impact: ~30 lines in console.py, 1 import + 3 call sites in main.py

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)