### PR TITLE
Fix Windows test compatibility issues

### DIFF
--- a/tests/test_mention_resolver_collections.py
+++ b/tests/test_mention_resolver_collections.py
@@ -66,7 +66,10 @@ def test_resolve_user_shortcut(temp_user_project_dirs):
     path = resolver.resolve("@user:custom/file.md")
     assert path is not None
     assert path.name == "file.md"
-    assert ".amplifier/custom" in str(path)
+    # Verify path structure: should be under user/.amplifier/custom/
+    user_dir = temp_user_project_dirs["user"]
+    expected_parent = user_dir / ".amplifier" / "custom"
+    assert path.is_relative_to(expected_parent), f"Expected {path} to be under {expected_parent}"
 
 
 def test_resolve_project_shortcut(temp_user_project_dirs):
@@ -77,7 +80,10 @@ def test_resolve_project_shortcut(temp_user_project_dirs):
     path = resolver.resolve("@project:notes/note.md")
     assert path is not None
     assert path.name == "note.md"
-    assert ".amplifier/notes" in str(path)
+    # Verify path structure: should be under project/.amplifier/notes/
+    project_dir = temp_user_project_dirs["project"]
+    expected_parent = project_dir / ".amplifier" / "notes"
+    assert path.is_relative_to(expected_parent), f"Expected {path} to be under {expected_parent}"
 
 
 def test_resolve_collection_not_found():

--- a/tests/test_repl_prompt.py
+++ b/tests/test_repl_prompt.py
@@ -3,7 +3,27 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from amplifier_app_cli.main import _create_prompt_session
+from prompt_toolkit import PromptSession
+from prompt_toolkit.output import DummyOutput
+
+
+@pytest.fixture(autouse=True)
+def patch_prompt_session_for_testing(monkeypatch):
+    """Auto-patch PromptSession to use DummyOutput in all tests.
+    
+    This avoids Windows console access issues during testing without
+    requiring changes to production code.
+    """
+    original_init = PromptSession.__init__
+    
+    def patched_init(self, *args, **kwargs):
+        # Force output to DummyOutput for testing
+        kwargs['output'] = DummyOutput()
+        return original_init(self, *args, **kwargs)
+    
+    monkeypatch.setattr(PromptSession, '__init__', patched_init)
 
 
 class TestPromptSession:


### PR DESCRIPTION
- Fix path separator issues in mention resolver tests using is_relative_to()
- Fix prompt_toolkit console access in REPL tests using fixture-based patching
- Add autouse fixture to inject DummyOutput for all prompt tests
- Use platform-agnostic path validation with pathlib methods