### PR TITLE
Add session ID to /status command output

### DIFF
--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -383,6 +383,7 @@ class CommandProcessor:
     async def _get_status(self) -> str:
         """Get session status information."""
         lines = ["Session Status:"]
+        lines.append(f"  Session ID: {self.session.coordinator.session_id}")
 
         # Plan mode status
         lines.append(f"  Plan Mode: {'ON' if self.plan_mode else 'OFF'}")


### PR DESCRIPTION
## Summary

Display the session ID in the `/status` command to enable log correlation and debugging.

## Changes

- Adds one line to display the session ID in the status output
- No other functionality changes

## Example Output

**Before:**
```
Session Status:
  Plan Mode: OFF
  Messages: 5
  Providers: provider-anthropic
  Tools: 8
```

**After:**
```
Session Status:
  Session ID: d604cea8-a2ce-430c-ba78-9c63874728fd
  Plan Mode: OFF
  Messages: 5
  Providers: provider-anthropic
  Tools: 8
```

## Benefits

- ✅ Enables log correlation by showing unique session identifier
- ✅ Helps with debugging and troubleshooting
- ✅ Minimal change with no impact on existing functionality

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>