### PR TITLE
fix: remove unnecessary restart message after update

### DIFF
--- a/amplifier_app_cli/utils/update_executor.py
+++ b/amplifier_app_cli/utils/update_executor.py
@@ -338,7 +338,7 @@ async def execute_self_update(umbrella_info: UmbrellaInfo) -> ExecutionResult:
             return ExecutionResult(
                 success=True,
                 updated=["amplifier"],
-                messages=["Amplifier updated successfully", "Restart amplifier to use new version"],
+                messages=["Amplifier updated successfully"],
             )
         error_msg = result.stderr.strip() or "Unknown error"
         return ExecutionResult(


### PR DESCRIPTION
## Summary
- Removes the "Restart amplifier to use new version" message after running `amplifier update`
- The CLI runs as a one-shot command, so there's no restart needed

## Test plan
- [ ] Run `amplifier update` and verify only "Amplifier updated successfully" is shown

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>