### PR TITLE
fix(run): -p flag now matches provider instance id/mount name, not just module type

### DIFF
--- a/amplifier_app_cli/commands/run.py
+++ b/amplifier_app_cli/commands/run.py
@@ -212,17 +212,31 @@ def register_run_command(
             )
             providers_list = config_data.get("providers", [])
 
-            # Find the target provider
+            # Find the target provider — two-pass search:
+            # Pass 1: exact match on instance id/mount name.
+            # _map_id_to_instance_id copies id → instance_id without stripping id,
+            # so both fields co-exist on resolved entries; either leg can match.
             target_idx = None
             for i, entry in enumerate(providers_list):
-                if isinstance(entry, dict) and entry.get("module") == provider_module:
+                if isinstance(entry, dict) and (
+                    entry.get("id") == provider
+                    or entry.get("instance_id") == provider
+                ):
                     target_idx = i
                     break
 
             if target_idx is None:
+                # Pass 2: fallback — module-type match (original behavior).
+                # Preserves single-instance usage: -p anthropic → provider-anthropic.
+                for i, entry in enumerate(providers_list):
+                    if isinstance(entry, dict) and entry.get("module") == provider_module:
+                        target_idx = i
+                        break
+
+            if target_idx is None:
                 console.print(
                     f"[red]Error:[/red] Provider '{provider}' not configured\n"
-                    f"Available providers: {', '.join(p.get('module', '?').replace('provider-', '') for p in providers_list if isinstance(p, dict))}\n"
+                    f"Available providers: {', '.join(p.get('id') or p.get('instance_id') or p.get('module', '?').replace('provider-', '') for p in providers_list if isinstance(p, dict))}\n"
                     f"Run 'amplifier provider use --help' for configuration options"
                 )
                 sys.exit(1)

--- a/tests/test_provider_commands.py
+++ b/tests/test_provider_commands.py
@@ -897,3 +897,198 @@ class TestFirstRunDetection:
         source = inspect.getsource(prompt_first_run_init)
         # Should reference provider add, not old init command
         assert "provider" in source.lower() and "add" in source.lower()
+
+
+# ============================================================
+# Fix 4: -p flag matches provider instance id/mount name
+# ============================================================
+
+
+def _make_run_cli_p_flag(captured: list) -> "click.Group":
+    """Create a minimal Click CLI with the run command registered.
+
+    ``captured`` is cleared and replaced with the providers list that
+    ``execute_single`` receives, i.e. after the provider selection logic has
+    run and the selected provider has been promoted to priority 0.
+    """
+    import click
+    from amplifier_app_cli.commands.run import register_run_command
+    from unittest.mock import AsyncMock
+
+    cli = click.Group("test")
+
+    async def _execute_single(prompt, config_data, *args, **kwargs):
+        captured[:] = list(config_data.get("providers", []))
+
+    register_run_command(
+        cli,
+        interactive_chat=AsyncMock(),
+        execute_single=_execute_single,
+        get_module_search_paths=lambda: [],
+        check_first_run=lambda: False,
+        prompt_first_run_init=lambda c: False,
+    )
+    return cli
+
+
+def _invoke_run_p_flag(providers_list: list, p_flag: str):
+    """Run ``amplifier run -p <p_flag> --output-format json hello`` via CliRunner.
+
+    Mocks ``resolve_config`` to inject *providers_list* and suppresses the
+    update-check coroutine.  Returns ``(CliResult, captured_providers)`` where
+    *captured_providers* contains the providers as passed to ``execute_single``
+    — the selected provider will have ``config["priority"] == 0``.
+    """
+    from click.testing import CliRunner
+    from unittest.mock import AsyncMock, MagicMock, patch
+
+    captured: list = []
+    cli = _make_run_cli_p_flag(captured)
+
+    fake_config: dict = {"providers": list(providers_list)}
+    fake_bundle = MagicMock()
+    fake_bundle.mount_plan = {"providers": list(providers_list)}
+
+    with (
+        patch(
+            "amplifier_app_cli.commands.run.create_config_manager",
+            return_value=MagicMock(get_merged_settings=lambda: {}),
+        ),
+        patch(
+            "amplifier_app_cli.commands.run.resolve_config",
+            return_value=(fake_config, fake_bundle),
+        ),
+        patch(
+            "amplifier_app_cli.utils.startup_checker.check_and_notify",
+            new_callable=AsyncMock,
+        ),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["run", "-p", p_flag, "--output-format", "json", "hello"]
+        )
+
+    return result, captured
+
+
+class TestRunPFlag:
+    """Tests for -p/--provider flag matching provider instance id/mount name.
+
+    Validates Fix 4 from UPSTREAM-FIXES.md: ``-p`` now does a two-pass search —
+    Pass 1 matches on ``id`` or ``instance_id``; Pass 2 falls back to module type
+    (``provider-{name}``) for backward compatibility.
+    """
+
+    def test_run_p_flag_matches_instance_id(self):
+        """Pass 1: -p <id> selects the first of two same-module providers by instance id."""
+        providers = [
+            {
+                "module": "provider-anthropic",
+                "id": "spark2-gemma",
+                "config": {"priority": 2},
+            },
+            {
+                "module": "provider-anthropic",
+                "id": "r11-gemma",
+                "config": {"priority": 3},
+            },
+        ]
+        result, captured = _invoke_run_p_flag(providers, "spark2-gemma")
+
+        assert result.exit_code == 0, f"Expected success, got exit {result.exit_code}: {result.output}"
+        selected = next(p for p in captured if p.get("id") == "spark2-gemma")
+        other = next(p for p in captured if p.get("id") == "r11-gemma")
+        assert selected["config"]["priority"] == 0, (
+            f"spark2-gemma should be promoted to priority 0, "
+            f"got {selected['config']['priority']}"
+        )
+        assert other["config"]["priority"] == 3, (
+            f"r11-gemma should keep original priority 3, "
+            f"got {other['config']['priority']}"
+        )
+
+    def test_run_p_flag_matches_instance_id_non_first_position(self):
+        """Pass 1: -p <id> selects the second of two same-module providers by instance id."""
+        providers = [
+            {
+                "module": "provider-anthropic",
+                "id": "spark2-gemma",
+                "config": {"priority": 2},
+            },
+            {
+                "module": "provider-anthropic",
+                "id": "r11-gemma",
+                "config": {"priority": 3},
+            },
+        ]
+        result, captured = _invoke_run_p_flag(providers, "r11-gemma")
+
+        assert result.exit_code == 0, f"Expected success, got exit {result.exit_code}: {result.output}"
+        selected = next(p for p in captured if p.get("id") == "r11-gemma")
+        other = next(p for p in captured if p.get("id") == "spark2-gemma")
+        assert selected["config"]["priority"] == 0, (
+            f"r11-gemma should be promoted to priority 0, "
+            f"got {selected['config']['priority']}"
+        )
+        assert other["config"]["priority"] == 2, (
+            f"spark2-gemma should keep original priority 2, "
+            f"got {other['config']['priority']}"
+        )
+
+    def test_run_p_flag_falls_back_to_module_type(self):
+        """Pass 2 (fallback): -p anthropic still works for a single provider with no id."""
+        providers = [
+            {"module": "provider-anthropic", "config": {"priority": 1}},
+        ]
+        result, captured = _invoke_run_p_flag(providers, "anthropic")
+
+        assert result.exit_code == 0, (
+            f"Regression: -p anthropic no longer works via module-type fallback: "
+            f"{result.output}"
+        )
+        assert captured[0]["config"]["priority"] == 0, (
+            f"Provider should be promoted to priority 0, "
+            f"got {captured[0]['config']['priority']}"
+        )
+
+    def test_run_p_flag_end_to_end_via_resolve_bundle_config(self):
+        """Pass 1 works on providers processed by _map_id_to_instance_id (real data flow).
+
+        ``_map_id_to_instance_id`` copies ``id`` → ``instance_id`` without stripping
+        ``id``, so both fields co-exist on resolved entries.  This test uses the
+        actual mapping function to produce realistic provider dicts and verifies that
+        Pass 1 matches correctly on the resolved data, not just on synthetic dicts.
+        """
+        from amplifier_app_cli.runtime.config import _map_id_to_instance_id
+
+        raw_providers = [
+            {
+                "module": "provider-vllm",
+                "id": "r11-gemma",
+                "config": {"base_url": "http://r11:8000/v1", "priority": 1},
+            },
+            {
+                "module": "provider-vllm",
+                "id": "spark2-gemma",
+                "config": {"base_url": "http://spark2:8000/v1", "priority": 2},
+            },
+        ]
+        resolved = _map_id_to_instance_id(raw_providers)
+
+        # Confirm the mapping preserves id AND adds instance_id
+        assert resolved[0].get("id") == "r11-gemma"
+        assert resolved[0].get("instance_id") == "r11-gemma"
+
+        result, captured = _invoke_run_p_flag(resolved, "r11-gemma")
+
+        assert result.exit_code == 0, f"Expected success, got exit {result.exit_code}: {result.output}"
+        r11 = next(p for p in captured if p.get("instance_id") == "r11-gemma")
+        spark2 = next(p for p in captured if p.get("instance_id") == "spark2-gemma")
+        assert r11["config"]["priority"] == 0, (
+            f"r11-gemma should be promoted to priority 0, "
+            f"got {r11['config']['priority']}"
+        )
+        assert spark2["config"]["priority"] == 2, (
+            f"spark2-gemma should keep original priority 2, "
+            f"got {spark2['config']['priority']}"
+        )

--- a/tests/test_provider_config_error_handling.py
+++ b/tests/test_provider_config_error_handling.py
@@ -803,3 +803,100 @@ class TestPromptModelSelectionModelsParam:
 
         mock_status_ctx.__enter__.assert_called_once()
         mock_status_ctx.__exit__.assert_called_once()
+
+
+# ============================================================
+# Fix 4: -p flag error message shows instance ids
+# ============================================================
+
+
+class TestRunPFlagErrorMessage:
+    """Tests for -p flag error message listing instance ids, not module types.
+
+    Validates Fix 4 from UPSTREAM-FIXES.md: when -p <name> fails to match any
+    provider, the error message now shows ``id`` / ``instance_id`` fields instead
+    of the module type (which was repeated for every same-type instance).
+    """
+
+    def _invoke_run_bad_p(self, providers_list: list, p_flag: str):
+        """Invoke ``run -p <p_flag>`` with a flag that matches no provider.
+
+        Returns the CliResult (expect exit_code == 1).
+        """
+        import click
+        from click.testing import CliRunner
+        from unittest.mock import AsyncMock, MagicMock, patch
+        from amplifier_app_cli.commands.run import register_run_command
+
+        cli = click.Group("test")
+
+        async def _execute_single(*args, **kwargs):
+            pass  # Should not be reached for error cases
+
+        register_run_command(
+            cli,
+            interactive_chat=AsyncMock(),
+            execute_single=_execute_single,
+            get_module_search_paths=lambda: [],
+            check_first_run=lambda: False,
+            prompt_first_run_init=lambda c: False,
+        )
+
+        fake_config: dict = {"providers": list(providers_list)}
+        fake_bundle = MagicMock()
+        fake_bundle.mount_plan = {"providers": list(providers_list)}
+
+        with (
+            patch(
+                "amplifier_app_cli.commands.run.create_config_manager",
+                return_value=MagicMock(get_merged_settings=lambda: {}),
+            ),
+            patch(
+                "amplifier_app_cli.commands.run.resolve_config",
+                return_value=(fake_config, fake_bundle),
+            ),
+            patch(
+                "amplifier_app_cli.utils.startup_checker.check_and_notify",
+                new_callable=AsyncMock,
+            ),
+        ):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli, ["run", "-p", p_flag, "--output-format", "json", "hello"]
+            )
+
+        return result
+
+    def test_run_p_flag_error_shows_instance_ids(self):
+        """When -p <name> matches no provider, error lists instance ids not module types.
+
+        The original bug: with two ``provider-anthropic`` entries that have distinct
+        ``id`` fields, the error showed "Available providers: anthropic, anthropic"
+        (module type repeated).  After the fix it shows the instance ids.
+        """
+        providers = [
+            {
+                "module": "provider-anthropic",
+                "id": "spark2-gemma",
+                "config": {"priority": 1},
+            },
+            {
+                "module": "provider-anthropic",
+                "id": "r11-gemma",
+                "config": {"priority": 2},
+            },
+        ]
+        result = self._invoke_run_bad_p(providers, "nonexistent-provider")
+
+        assert result.exit_code == 1, (
+            f"Expected exit code 1 for unknown provider, got {result.exit_code}. "
+            f"Output: {result.output!r}"
+        )
+        assert "spark2-gemma" in result.output, (
+            f"Expected 'spark2-gemma' in error output (instance id should be listed), "
+            f"got: {result.output!r}"
+        )
+        assert "r11-gemma" in result.output, (
+            f"Expected 'r11-gemma' in error output (instance id should be listed), "
+            f"got: {result.output!r}"
+        )


### PR DESCRIPTION
This PR implements Fix 4 of 4 from our upstream-fixes review; see body for full design + COE revisions.

## Fix 4 — `amplifier-app-cli/commands/run.py`: `-p <name>` should match mount name, not just module type

**Problem.** `amplifier run -p r11-gemma` fails with "Provider 'r11-gemma' not configured / Available providers: anthropic, vllm, gemini, chat-completions, chat-completions, chat-completions" even though the coordinator's providers-dict contains distinct keys `spark2-gemma`, `r11-gemma`, `r13-qwen`. The `-p` flag only checks `entry.get("module")` which is the module type, not the mount name.

**Root cause.**
- `commands/run.py:210-212` — constructs `provider_module = f"provider-{provider}"` from the flag value.
- `commands/run.py:217-220` — lookup loop compares `entry.get("module") == provider_module`.
- `commands/run.py:222-228` — error message joins `p.get("module", "?").replace("provider-", "")` which shows the type, not the instance.
- `entry.get("id")` and `entry.get("instance_id")` are populated on each provider entry by `_map_id_to_instance_id` at `runtime/config.py:184-188`, but never consulted for flag lookup.

**Fix shape.** Replace the lookup at `run.py:215-228` with a two-pass search:

- **Pass 1**: iterate `providers_list`, match exact string on `entry.get("id") or entry.get("instance_id")`. If found, use it.
- **Pass 2** (fallback): existing module-type match via `f"provider-{provider}"`. Preserves single-instance behavior.
- **Error message**: join expression becomes `p.get("id") or p.get("instance_id") or p.get("module", "?").replace("provider-", "")`.

**COE-flagged correction:** `_map_id_to_instance_id` at `runtime/config.py:184-188` copies `id` → `instance_id` before `run.py` sees the providers list. Whether it **also strips `id`** determines if Pass 1's `entry.get("id")` leg is dead code or live. **Verify before merge.** If `id` is stripped, drop the `id` leg from Pass 1 and match only on `instance_id`. Test with a fully-resolved providers list (not a synthetic dict) so we're testing actual data flow, not just logic.

**Backward compatibility.** Strictly additive. Single-provider users (`-p anthropic`) keep working via Pass 2. Only new behavior activates when the flag exactly matches an instance name.

**Tests** — `tests/test_provider_config_error_handling.py` + `tests/test_provider_commands.py`:
1. `test_run_p_flag_matches_instance_id` — two `provider-anthropic` instances, `-p <first-id>` selects the first.
2. `test_run_p_flag_matches_instance_id_non_first_position` — same, selecting the second by id.
3. `test_run_p_flag_falls_back_to_module_type` — single instance no id, `-p anthropic` still works (regression guard).
4. `test_run_p_flag_error_shows_instance_ids` — two instances, bad name, error lists ids not type-repeated.
5. `test_run_p_flag_end_to_end_via_resolve_bundle_config` — use a providers list that actually went through `_map_id_to_instance_id`. Verifies Pass 1 or Pass 2 fires as expected on real data.

**Risks.**
- User defines `id: anthropic` on a `provider-anthropic` instance — Pass 1 fires first, semantically correct, low severity. Help text should note `-p` accepts either a type shorthand or an instance name.
- Pass 1 may be dead code post-resolution (see COE correction above). Verify, correct if needed.