### PR TITLE
fix(config): _apply_hook_overrides appends absent hooks; routing override carries settings.overrides.*.config; guard against duplicate injection

### DIFF
--- a/amplifier_app_cli/runtime/config.py
+++ b/amplifier_app_cli/runtime/config.py
@@ -221,10 +221,28 @@ async def resolve_bundle_config(
             routing_hook_override["config"]["default_matrix"] = routing_config["matrix"]
         if "overrides" in routing_config:
             routing_hook_override["config"]["overrides"] = routing_config["overrides"]
+        # Change A: Enrich with any extra keys from overrides.hooks-routing.config.
+        # Routing-section keys (default_matrix, overrides) always take precedence over
+        # whatever came from the general config overrides block, so the routing-built keys
+        # are written AFTER the extra keys in the merge — later keys win in {**a, **b}.
+        hooks_routing_extra = {
+            k: v
+            for k, v in config_overrides.get("hooks-routing", {}).items()
+            if k not in ("default_matrix", "overrides")
+        }
+        routing_hook_override["config"] = {
+            **hooks_routing_extra,
+            **routing_hook_override["config"],
+        }
         if routing_hook_override["config"]:
             hook_overrides.append(routing_hook_override)
 
-    if hook_overrides and bundle_config.get("hooks"):
+    # Apply hook overrides: merge in-place for hooks already in the bundle, and
+    # append any overrides whose module is absent from the bundle hooks list.
+    # Guard now initialises hooks to [] when absent so the append-missing path can fire
+    # even for bundles that ship with no hooks section at all.
+    if hook_overrides:
+        bundle_config.setdefault("hooks", [])
         bundle_config["hooks"] = _apply_hook_overrides(
             bundle_config["hooks"], hook_overrides
         )
@@ -442,12 +460,23 @@ def _apply_hook_overrides(
     This enables settings like ntfy topic for hooks-notify-push
     to be applied from user settings.
 
+    Hooks that are present in ``overrides`` but absent from the bundle
+    ``hooks`` list are **appended** to the result, mirroring the behaviour
+    of :func:`_apply_tool_overrides`.  This means a routing config
+    (``hooks-routing``) supplied via settings will reach the session even
+    when the active bundle does not pre-register that hook.
+
+    Note on hook execution order: list position does not control execution
+    order.  ``hooks-routing`` registers with explicit ``priority`` values
+    (5 and 15), so appending at the end of the list is safe.
+
     Args:
         hooks: List of hook configurations from bundle
         overrides: List of hook override dicts with module and config keys
 
     Returns:
-        Merged list of hook configurations
+        Merged list of hook configurations (in-place merges first, then
+        any absent hooks appended in override order)
     """
     if not overrides:
         return hooks
@@ -458,7 +487,7 @@ def _apply_hook_overrides(
         if isinstance(override, dict) and "module" in override:
             override_map[override["module"]] = override
 
-    # Apply overrides to matching hooks
+    # Apply overrides to matching hooks (in-place merge path)
     result = []
     for hook in hooks:
         if isinstance(hook, dict) and hook.get("module") in override_map:
@@ -473,6 +502,19 @@ def _apply_hook_overrides(
             result.append(merged)
         else:
             result.append(hook)
+
+    # Change B: Append overrides whose module is absent from the original bundle
+    # hooks list.  Using the *original* hooks set means a hook that was merged
+    # in-place above is NOT in existing_modules and would be double-added — but
+    # that cannot happen because the in-place merge path consumed it first, so
+    # the set must be built from the original ``hooks`` argument, not ``result``.
+    existing_modules = {h.get("module") for h in hooks if isinstance(h, dict)}
+    for override in overrides:
+        if (
+            isinstance(override, dict)
+            and override.get("module") not in existing_modules
+        ):
+            result.append(override)
 
     return result
 

--- a/tests/test_general_config_overrides.py
+++ b/tests/test_general_config_overrides.py
@@ -301,6 +301,188 @@ class TestFullPipelineIntegration:
         assert result["tools"][0]["config"]["t_new"] is True
         assert result["hooks"][0]["config"]["h_new"] is True
 
+    # ------------------------------------------------------------------ #
+    # Fix 3 tests: _apply_hook_overrides appends absent hooks             #
+    # ------------------------------------------------------------------ #
+
+    def test_apply_hook_overrides_appends_absent_hook(self):
+        """Change B: _apply_hook_overrides appends a hook that is not in the bundle.
+
+        When the override list contains a module that isn't present in the
+        bundle hooks list, _apply_hook_overrides should append the override
+        entry to the result — matching the _apply_tool_overrides behaviour.
+        """
+        hooks = [{"module": "hooks-notify", "config": {"topic": "alerts"}}]
+        overrides = [
+            {"module": "hooks-routing", "config": {"default_matrix": "balanced"}}
+        ]
+
+        result = _apply_hook_overrides(hooks, overrides)
+
+        assert len(result) == 2, f"Expected 2 hooks, got {len(result)}: {result}"
+        routing_entries = [h for h in result if h.get("module") == "hooks-routing"]
+        assert len(routing_entries) == 1, "Expected exactly one hooks-routing entry"
+        assert routing_entries[0]["config"]["default_matrix"] == "balanced"
+        # Original hook must be untouched
+        assert result[0]["config"]["topic"] == "alerts"
+
+    def test_existing_hooks_unchanged_when_no_overrides(self):
+        """Regression guard: no overrides → hooks returned as-is.
+
+        _apply_hook_overrides must short-circuit cleanly when overrides is
+        empty, returning the original hooks list unchanged.
+        """
+        hooks = [
+            {"module": "hooks-ci", "config": {"url": "http://ci.local"}},
+            {"module": "hooks-notify", "config": {"topic": "dev"}},
+        ]
+        result = _apply_hook_overrides(hooks, [])
+
+        assert result == hooks
+        assert len(result) == 2
+
+    @pytest.mark.asyncio
+    async def test_routing_config_injected_when_hook_absent_from_bundle(self):
+        """Integration: routing.matrix + overrides.hooks-routing.config._bundle_root reach
+        the final bundle even when the active bundle has no hooks-routing entry.
+
+        Both routing-section keys (default_matrix from routing.matrix) and extra
+        config keys (_bundle_root from overrides.hooks-routing.config) must appear
+        in the injected hooks-routing entry.
+        """
+        mount_plan = {
+            # Bundle deliberately has no hooks-routing entry
+            "hooks": [{"module": "hooks-ci", "config": {"enabled": True}}],
+        }
+        mock_prepared = MagicMock()
+        mock_prepared.mount_plan = mount_plan
+        mock_prepared.bundle.load_agent_metadata = MagicMock()
+
+        settings = _make_app_settings(
+            config_overrides={"hooks-routing": {"_bundle_root": "/project/.amplifier"}},
+            routing_config={"matrix": "my-matrix"},
+        )
+
+        with (
+            patch(
+                "amplifier_app_cli.lib.bundle_loader.prepare.load_and_prepare_bundle",
+                new_callable=AsyncMock,
+                return_value=mock_prepared,
+            ),
+            patch("amplifier_app_cli.paths.get_bundle_search_paths", return_value=[]),
+            patch("amplifier_app_cli.lib.bundle_loader.AppBundleDiscovery"),
+        ):
+            result, _ = await resolve_bundle_config(
+                bundle_name="test", app_settings=settings
+            )
+
+        routing_entries = [
+            h for h in result["hooks"] if h.get("module") == "hooks-routing"
+        ]
+        assert len(routing_entries) == 1, (
+            f"Expected exactly one hooks-routing entry, got {routing_entries}"
+        )
+        cfg = routing_entries[0]["config"]
+        assert cfg.get("default_matrix") == "my-matrix", (
+            f"Expected default_matrix='my-matrix', got {cfg}"
+        )
+        assert cfg.get("_bundle_root") == "/project/.amplifier", (
+            f"Expected _bundle_root='/project/.amplifier', got {cfg}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_routing_config_preserved_when_hook_present_in_bundle(self):
+        """Integration: when hooks-routing IS already in the bundle, the same
+        settings (routing.matrix + overrides.hooks-routing.config._bundle_root)
+        must be merged onto the existing entry — and no duplicate must appear.
+        """
+        mount_plan = {
+            "hooks": [
+                {
+                    "module": "hooks-routing",
+                    "config": {"existing_key": "original_value"},
+                }
+            ],
+        }
+        mock_prepared = MagicMock()
+        mock_prepared.mount_plan = mount_plan
+        mock_prepared.bundle.load_agent_metadata = MagicMock()
+
+        settings = _make_app_settings(
+            config_overrides={"hooks-routing": {"_bundle_root": "/project/.amplifier"}},
+            routing_config={"matrix": "my-matrix"},
+        )
+
+        with (
+            patch(
+                "amplifier_app_cli.lib.bundle_loader.prepare.load_and_prepare_bundle",
+                new_callable=AsyncMock,
+                return_value=mock_prepared,
+            ),
+            patch("amplifier_app_cli.paths.get_bundle_search_paths", return_value=[]),
+            patch("amplifier_app_cli.lib.bundle_loader.AppBundleDiscovery"),
+        ):
+            result, _ = await resolve_bundle_config(
+                bundle_name="test", app_settings=settings
+            )
+
+        routing_entries = [
+            h for h in result["hooks"] if h.get("module") == "hooks-routing"
+        ]
+        assert len(routing_entries) == 1, (
+            f"Expected exactly one hooks-routing entry (no dup), got {routing_entries}"
+        )
+        cfg = routing_entries[0]["config"]
+        assert cfg.get("default_matrix") == "my-matrix"
+        assert cfg.get("_bundle_root") == "/project/.amplifier"
+        assert cfg.get("existing_key") == "original_value", (
+            f"Original hook config key must be preserved: {cfg}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_routing_keys_beat_overrides_on_collision(self):
+        """Integration: when routing.matrix and overrides.hooks-routing.config.default_matrix
+        both set default_matrix, the routing-section value must win.
+
+        Change A merges extra keys from config_overrides BEFORE the routing-built
+        keys, so {**extra, **routing} means routing always takes precedence.
+        """
+        mount_plan = {
+            "hooks": [],
+        }
+        mock_prepared = MagicMock()
+        mock_prepared.mount_plan = mount_plan
+        mock_prepared.bundle.load_agent_metadata = MagicMock()
+
+        settings = _make_app_settings(
+            # Collision: overrides sets default_matrix to "foo"
+            config_overrides={"hooks-routing": {"default_matrix": "foo"}},
+            # Routing section sets it to "bar" — must win
+            routing_config={"matrix": "bar"},
+        )
+
+        with (
+            patch(
+                "amplifier_app_cli.lib.bundle_loader.prepare.load_and_prepare_bundle",
+                new_callable=AsyncMock,
+                return_value=mock_prepared,
+            ),
+            patch("amplifier_app_cli.paths.get_bundle_search_paths", return_value=[]),
+            patch("amplifier_app_cli.lib.bundle_loader.AppBundleDiscovery"),
+        ):
+            result, _ = await resolve_bundle_config(
+                bundle_name="test", app_settings=settings
+            )
+
+        routing_entries = [
+            h for h in result["hooks"] if h.get("module") == "hooks-routing"
+        ]
+        assert len(routing_entries) == 1
+        assert routing_entries[0]["config"]["default_matrix"] == "bar", (
+            f"routing.matrix ('bar') must beat overrides.hooks-routing.config.default_matrix "
+            f"('foo'), got: {routing_entries[0]['config']}"
+        )
+
     @pytest.mark.asyncio
     async def test_dedicated_overrides_win_in_full_pipeline(self):
         """Dedicated override takes precedence over general in full pipeline."""

--- a/tests/test_routing_commands.py
+++ b/tests/test_routing_commands.py
@@ -2358,3 +2358,67 @@ class TestRoutingEditMatrix:
         assert "[q]" in rendered, (
             f"Expected '[q]' action letter in menu, got output:\n{rendered}"
         )
+
+
+# ============================================================
+# Fix 3: append-missing guard — no duplicate when hook already present
+# ============================================================
+
+
+class TestApplyHookOverridesGuard:
+    """Explicit guard test for the COE-required already-present check.
+
+    Change B adds a trailing 'append missing' block to _apply_hook_overrides.
+    The guard is the set-based check against the *original* hooks list.  When
+    a hook module is already present in the bundle, the in-place merge path
+    handles it and the append block must NOT fire — producing exactly one
+    entry in the result.
+    """
+
+    def test_append_block_skipped_when_hook_already_present(self):
+        """COE guard: no duplicate hooks-routing when hook is already in the bundle.
+
+        Scenario:
+          - Bundle hooks list already contains a hooks-routing entry.
+          - An override for hooks-routing is provided (as happens when the user
+            sets routing.matrix in settings.yaml).
+
+        Expected:
+          - Exactly one hooks-routing entry in the result.
+          - The config from both the bundle and the override are merged onto it.
+          - The append block does NOT produce a second entry.
+        """
+        from amplifier_app_cli.runtime.config import _apply_hook_overrides
+
+        hooks = [
+            {
+                "module": "hooks-routing",
+                "config": {"existing_key": "existing_val"},
+            },
+            {"module": "hooks-notify", "config": {"topic": "alerts"}},
+        ]
+        overrides = [
+            {
+                "module": "hooks-routing",
+                "config": {"default_matrix": "balanced", "_bundle_root": "/some/path"},
+            }
+        ]
+
+        result = _apply_hook_overrides(hooks, overrides)
+
+        routing_entries = [h for h in result if h.get("module") == "hooks-routing"]
+        assert len(routing_entries) == 1, (
+            f"COE guard failed: expected exactly 1 hooks-routing entry, "
+            f"got {len(routing_entries)}: {routing_entries}"
+        )
+        cfg = routing_entries[0]["config"]
+        # In-place merge: base keys + override keys must all be present
+        assert cfg.get("existing_key") == "existing_val", (
+            f"Original config key should be preserved: {cfg}"
+        )
+        assert cfg.get("default_matrix") == "balanced", f"Override key missing: {cfg}"
+        assert cfg.get("_bundle_root") == "/some/path", f"Override key missing: {cfg}"
+        # Unrelated hook must be untouched
+        notify_entries = [h for h in result if h.get("module") == "hooks-notify"]
+        assert len(notify_entries) == 1
+        assert notify_entries[0]["config"]["topic"] == "alerts"


### PR DESCRIPTION
This PR implements Fix 3 of 4 from our upstream-fixes review; see body for full design + COE revisions.

## Fix 3 — `amplifier-app-cli/runtime/config.py`: `_apply_hook_overrides` drops hook configs when hook not in bundle

**Problem.** When a user sets `routing.matrix: my-matrix` in `settings.yaml` and the active bundle doesn't already include `hooks-routing` in its hooks list, the routing config is silently discarded. No error, no warning; the session runs with the bundle default provider and nobody knows why. Root cause is two independent code paths that both skip when the hook isn't pre-registered.

**Root cause.**
- `runtime/config.py:154-167` — general override loop iterates `bundle_config["hooks"]` and merges configs in-place. If `hooks-routing` isn't in the list, no-op.
- `runtime/config.py:213-225` — routing-matrix injection builds a fresh `routing_hook_override = {"module": "hooks-routing", "config": {...}}` and appends to `hook_overrides`.
- `runtime/config.py:227` — guard `if hook_overrides and bundle_config.get("hooks"):` — BOTH must be truthy. A bundle without hooks silently drops all overrides.
- `runtime/config.py:436-477` — `_apply_hook_overrides` iterates existing hooks and merges; no "append missing" block. Compare `_apply_tool_overrides:520-527` which has one.

**Fix shape.** Two changes in `config.py`:

**Change A**: Enrich `routing_hook_override` at L213-225 by shallow-merging `config_overrides.get("hooks-routing", {})` into its `config` dict, with routing-section keys (`default_matrix`, `overrides`) taking precedence. This ensures `_bundle_root` and other user-specified hook config keys reach the final config even when the routing path is the only one firing.

**Change B**: Add a trailing "append missing hooks" block to `_apply_hook_overrides` after L475, mirroring `_apply_tool_overrides:520-527`. Build a set of existing hook module IDs; for any override in `override_map` whose module ID isn't in that set, append to the result list.

**COE-required addition**: the "already present?" guard is not optional. When the bundle DOES include `hooks-routing` AND the routing-section is set AND the append block fires, two entries could be produced — the `override_map` iteration order becomes the non-deterministic deciding factor. Pattern:

```
check = any(h.get("module") == "hooks-routing" for h in bundle_config.get("hooks", []))
if not check and routing_hook_override["config"]:
    # append path
```

Promote this from "recommendation" to "required" in the PR description and the commit message. Without it the fix is itself a bug.

**Backward compatibility.**
- Users whose bundles already include `hooks-routing`: no change (Change A is a no-op when routing-section keys take precedence over the already-merged base_config; Change B doesn't fire because the hook is present).
- Users whose `routing.matrix` settings were silently dropped (bundles without `hooks-routing`): start seeing the routing behavior. **This is a correct behavior change and must go in the CHANGELOG** — an upgrade could surface previously-dead settings.

**Hook ordering concern (COE — deprioritized).** Appending at end of hooks list sounds like it could reorder hook execution. In practice hooks-routing registers with explicit `priority=5` and `priority=15` (see `hooks-routing/__init__.py:157-167`), so list position in the mount plan doesn't control execution order. Priority field does. Document this fact in the PR to preempt the question.

**Tests** — `amplifier_app_cli/tests/test_general_config_overrides.py` + `tests/test_routing_commands.py`:
1. `test_apply_hook_overrides_appends_absent_hook` — unit test of Change B.
2. `test_routing_config_injected_when_hook_absent_from_bundle` — integration-ish: settings with `routing.matrix` + `overrides.hooks-routing.config._bundle_root`, bundle without hooks-routing, assert final hooks list has a hooks-routing entry with both keys.
3. `test_routing_config_preserved_when_hook_present_in_bundle` — same settings, bundle WITH hooks-routing, assert the hook has both keys merged onto its existing config, no duplicate entries.
4. `test_routing_keys_beat_overrides_on_collision` — `overrides.hooks-routing.config.default_matrix: foo` AND `routing.matrix: bar`, assert `default_matrix == bar`.
5. `test_existing_hooks_unchanged_when_no_overrides` — regression guard for the unchanged path.
6. **COE-added**: `test_append_block_skipped_when_hook_already_present` — explicit test of the already-present guard.

**Risks.**
- Behavior change on upgrade for users with dead settings (addressed via CHANGELOG).
- Kernel module loader warning if `hooks-routing` is appended but the bundle's module source list can't satisfy it. Graceful (warning + continue), but surfaces as a confusing log. Document.
- **COE aside**: audit other call sites of `hook_overrides.append()` for similar silently-dropped-config bugs. This asymmetry between `_apply_tool_overrides` (appends) and `_apply_hook_overrides` (didn't) suggests the same shape may exist elsewhere.