### PR TITLE
feat: pre-install provider-chat-completions as a well-known provider

### DIFF
--- a/amplifier_app_cli/provider_manager.py
+++ b/amplifier_app_cli/provider_manager.py
@@ -27,6 +27,7 @@ _PROVIDER_DISPLAY_NAMES = {
     "ollama": "Ollama",
     "github-copilot": "GitHub Copilot",
     "vllm": "vLLM",
+    "chat-completions": "OpenAI-Compatible",
 }
 
 
@@ -392,9 +393,9 @@ class ProviderManager:
                     # Git source: install with deps on-demand, then retry import.
                     # On a clean install none of the provider SDK dependencies
                     # (anthropic, openai, google-generativeai, …) are present, so
-                    # the initial import always fails.  Installing here makes all 7
-                    # well-known providers appear in the picker regardless of
-                    # installation state.
+                    # the initial import always fails.  Installing here makes all
+                    # entries from DEFAULT_PROVIDER_SOURCES appear in the picker
+                    # regardless of installation state.
                     logger.debug(
                         f"Git provider {module_id} not importable, attempting install: {e}"
                     )

--- a/amplifier_app_cli/provider_sources.py
+++ b/amplifier_app_cli/provider_sources.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_PROVIDER_SOURCES = {
     "provider-anthropic": "git+https://github.com/microsoft/amplifier-module-provider-anthropic@main",
     "provider-azure-openai": "git+https://github.com/microsoft/amplifier-module-provider-azure-openai@main",
+    "provider-chat-completions": "git+https://github.com/microsoft/amplifier-module-provider-chat-completions@main",
     "provider-gemini": "git+https://github.com/microsoft/amplifier-module-provider-gemini@main",
     "provider-github-copilot": "git+https://github.com/microsoft/amplifier-module-provider-github-copilot@main",
     "provider-ollama": "git+https://github.com/microsoft/amplifier-module-provider-ollama@main",

--- a/tests/test_chat_completions_registration.py
+++ b/tests/test_chat_completions_registration.py
@@ -1,0 +1,126 @@
+"""Tests for OpenAI-Compatible (chat-completions) well-known provider registration.
+
+Provider: amplifier-module-provider-chat-completions
+  https://github.com/microsoft/amplifier-module-provider-chat-completions
+
+Security-critical invariants are enforced in this file as regression guards.
+Modifying them requires understanding the original security rationale — see
+test docstrings before adjusting.
+"""
+
+from amplifier_app_cli.provider_env_detect import PROVIDER_CREDENTIAL_VARS
+from amplifier_app_cli.provider_manager import _PROVIDER_DISPLAY_NAMES
+from amplifier_app_cli.provider_sources import DEFAULT_PROVIDER_SOURCES
+from amplifier_app_cli.provider_sources import PROVIDER_DEPENDENCIES
+
+
+class TestChatCompletionsRegistration:
+    """Verify Chat Completions is correctly registered in all well-known provider dicts."""
+
+    def test_registered_in_provider_sources(self):
+        """provider-chat-completions must be in DEFAULT_PROVIDER_SOURCES with the standalone repo URL.
+
+        Invariant also enforced: the app-cli key here MUST match the entry-point
+        name declared in the module's pyproject.toml:
+
+            [project.entry-points."amplifier.modules"]
+            provider-chat-completions = "amplifier_module_provider_chat_completions:mount"
+
+        If this app-cli key and that entry-point name diverge, the provider installs
+        successfully but never appears in `amplifier provider list` — silent failure
+        in the picker. There is no cross-repo integration test today; this comment
+        documents the contract.
+        """
+        assert "provider-chat-completions" in DEFAULT_PROVIDER_SOURCES
+        url = DEFAULT_PROVIDER_SOURCES["provider-chat-completions"]
+        assert (
+            url
+            == "git+https://github.com/microsoft/amplifier-module-provider-chat-completions@main"
+        )
+        # Regression guard: must NOT use the old bundle-subdirectory URL shape.
+        # The provider was extracted to its own top-level repo; accidentally
+        # reverting would break every CLI install.
+        assert "#subdirectory=" not in url, (
+            f"provider-chat-completions source URL must not use #subdirectory= "
+            f"(the module is now standalone). Got: {url}"
+        )
+        assert "amplifier-bundle-chat-completions" not in url, (
+            f"provider-chat-completions source URL must point at the standalone "
+            f"amplifier-module-provider-chat-completions repo, not the deprecated "
+            f"amplifier-bundle-chat-completions. Got: {url}"
+        )
+
+    def test_registered_in_display_names(self):
+        """provider-chat-completions must have a display name entry.
+
+        Note the key is WITHOUT the `provider-` prefix — `_get_provider_display_name()`
+        in provider_manager.py:42 strips the prefix before the lookup.
+
+        The chosen display name "OpenAI-Compatible" matches what the module itself
+        reports via ChatCompletionsProvider.get_info().display_name, so users see
+        the same string whether the provider is freshly installed or hits the
+        fallback display-name path.
+        """
+        assert "chat-completions" in _PROVIDER_DISPLAY_NAMES
+        assert _PROVIDER_DISPLAY_NAMES["chat-completions"] == "OpenAI-Compatible"
+
+    def test_NOT_in_credential_vars_SECURITY(self):
+        """SSRF/exfiltration regression guard: MUST NOT be in PROVIDER_CREDENTIAL_VARS.
+
+        Why this test exists (SECURITY):
+        --------------------------------
+        `CHAT_COMPLETIONS_BASE_URL` is a user-supplied endpoint, not a cloud API key.
+        Adding it to `PROVIDER_CREDENTIAL_VARS` would enable silent auto-configuration
+        in non-TTY environments via `auto_init_from_env()` in commands/init.py — which
+        would permanently write the env-var-resolved URL into `~/.amplifier/settings.yaml`
+        on first startup. Attack surface:
+
+          - Conversation content routed to an attacker-controlled server
+          - SSRF to internal services (e.g. http://169.254.169.254/v1 for cloud metadata)
+          - Leak of `CHAT_COMPLETIONS_API_KEY` via the `Authorization: Bearer` header
+          - Prompt injection via attacker-controlled model responses
+          - Persistent foothold — written to settings survives future CLI upgrades
+
+        This provider is protected in TWO layers and both must remain:
+          1. Absence from PROVIDER_CREDENTIAL_VARS (this test) — keeps
+             auto_init_from_env() from picking it silently.
+          2. mount() silent-skip in __init__.py:1148 — provider returns None if
+             `base_url` is not explicitly configured, so a user who never
+             configures it cannot accidentally use it.
+
+        Precedent: `provider-vllm` is also absent from PROVIDER_CREDENTIAL_VARS for
+        the same "user-configured endpoint, not a detectable cloud credential"
+        reason.
+
+        If this test starts failing, DO NOT just update the expected value. Re-read
+        the security rationale above and the bundle repo's deprecation README, and
+        confirm with a security reviewer before touching.
+        """
+        assert "provider-chat-completions" not in PROVIDER_CREDENTIAL_VARS, (
+            "provider-chat-completions MUST NOT be in PROVIDER_CREDENTIAL_VARS — "
+            "this is a security regression guard. See test docstring for the "
+            "SSRF/exfiltration rationale before 'fixing' by adding it."
+        )
+
+        # Also guard the env-var name itself — someone could register
+        # CHAT_COMPLETIONS_BASE_URL under a different provider key and achieve the
+        # same auto-init effect. Per zen-architect COE review.
+        for provider_id, env_vars in PROVIDER_CREDENTIAL_VARS.items():
+            assert "CHAT_COMPLETIONS_BASE_URL" not in env_vars, (
+                f"CHAT_COMPLETIONS_BASE_URL must not appear under any provider "
+                f"(found under {provider_id}). See SSRF rationale above."
+            )
+            assert "CHAT_COMPLETIONS_API_KEY" not in env_vars, (
+                f"CHAT_COMPLETIONS_API_KEY must not appear under any provider "
+                f"(found under {provider_id}). See SSRF rationale above."
+            )
+
+    def test_no_provider_dependencies(self):
+        """Chat Completions has no cross-provider inheritance; must not appear in PROVIDER_DEPENDENCIES.
+
+        Unlike provider-azure-openai (which subclasses OpenAIProvider at runtime),
+        provider-chat-completions is self-contained — its only external dependency
+        is the `openai` Python SDK (for the OpenAI-compatible HTTP client).
+        Listing it here would imply an install-order requirement that doesn't exist.
+        """
+        assert "provider-chat-completions" not in PROVIDER_DEPENDENCIES

--- a/tests/test_discover_providers_clean_install.py
+++ b/tests/test_discover_providers_clean_install.py
@@ -183,11 +183,19 @@ class TestGitProviderFallbackOnInstallFailure:
             "provider-anthropic": "Anthropic",
             "provider-openai": "OpenAI",
             "provider-azure-openai": "Azure OpenAI",
+            "provider-chat-completions": "OpenAI-Compatible",
             "provider-gemini": "Google Gemini",
             "provider-ollama": "Ollama",
             "provider-github-copilot": "GitHub Copilot",
             "provider-vllm": "vLLM",
         }
+        # Self-audit: this test uses a hardcoded dict (NOT auto-scaling). Without
+        # this guard a forgotten entry would silently pass — see bug-hunter COE
+        # review P1-B for rationale.
+        assert len(expected_names) == len(DEFAULT_PROVIDER_SOURCES), (
+            "expected_names is out of sync with DEFAULT_PROVIDER_SOURCES — "
+            "add the missing entry below with its display name."
+        )
         manager = _make_manager()
         ordered = [(mid, uri) for mid, uri in expected_names.items()]
 
@@ -220,15 +228,15 @@ class TestGitProviderFallbackOnInstallFailure:
 
 
 # ---------------------------------------------------------------------------
-# All 7 well-known providers appear on clean install (integration-style)
+# All known providers appear on clean install (integration-style)
 # ---------------------------------------------------------------------------
 
 
-class TestAllSevenProvidersOnCleanInstall:
-    """All 7 DEFAULT_PROVIDER_SOURCES appear in the list regardless of install outcome."""
+class TestAllKnownProvidersOnCleanInstall:
+    """All DEFAULT_PROVIDER_SOURCES entries appear in the list regardless of install outcome."""
 
     def test_all_providers_appear_when_all_installs_fail(self):
-        """Worst case: every install fails — all 7 providers still appear via fallback."""
+        """Worst case: every install fails — every known provider still appears via fallback."""
         manager = _make_manager()
         ordered = list(DEFAULT_PROVIDER_SOURCES.items())
 
@@ -258,7 +266,7 @@ class TestAllSevenProvidersOnCleanInstall:
             )
 
     def test_all_providers_appear_when_all_installs_succeed(self):
-        """Happy path: every install succeeds — all 7 providers appear with full info."""
+        """Happy path: every install succeeds — every known provider appears with full info."""
         manager = _make_manager()
         ordered = list(DEFAULT_PROVIDER_SOURCES.items())
 


### PR DESCRIPTION
## Summary

Adds `amplifier-module-provider-chat-completions` to `DEFAULT_PROVIDER_SOURCES` so every Amplifier install gets the OpenAI-Compatible provider pre-installed alongside anthropic, openai, azure-openai, gemini, ollama, vllm, and github-copilot.

Eliminates the old "`bundle add` + `module add --source …#subdirectory=…`" incantation previously required to use chat-completions-compatible servers (llama.cpp, vLLM, SGLang, LM Studio, LocalAI, text-generation-inference, etc.). The bundle that hosted this provider is now marked DEPRECATED and will be retired after a grace period.

## Changes

| File | Change |
|---|---|
| `amplifier_app_cli/provider_sources.py` | +1 line — `provider-chat-completions` entry inserted alphabetically |
| `amplifier_app_cli/provider_manager.py` | +1 line in `_PROVIDER_DISPLAY_NAMES` (`"chat-completions": "OpenAI-Compatible"`); updated hardcoded "all 7" comment |
| `amplifier_app_cli/provider_env_detect.py` | **NOT modified** — intentional SSRF guard (see test below) |
| `tests/test_discover_providers_clean_install.py` | Added entry to `expected_names` dict; added `len()` self-audit assertion; renamed `TestAllSevenProvidersOnCleanInstall` → `TestAllKnownProvidersOnCleanInstall` and removed all "all 7" references |
| `tests/test_chat_completions_registration.py` **(new)** | 4 registration invariants with a dedicated SSRF regression guard |

## Design decisions

### `PROVIDER_CREDENTIAL_VARS` — intentionally NOT updated (SECURITY)

`CHAT_COMPLETIONS_BASE_URL` is a user-supplied endpoint, not a cloud API key. Adding it to `PROVIDER_CREDENTIAL_VARS` would enable silent auto-configuration in non-TTY environments via `auto_init_from_env()` — SSRF, conversation exfiltration, and `Authorization`-header key leak vectors. This follows the `provider-vllm` precedent (also absent from that dict).

The decision is enforced by `test_NOT_in_credential_vars_SECURITY` in the new test file, which asserts both:
1. `provider-chat-completions` is not a key in `PROVIDER_CREDENTIAL_VARS`
2. Neither `CHAT_COMPLETIONS_BASE_URL` nor `CHAT_COMPLETIONS_API_KEY` appear under _any_ provider's credential list (prevents aliasing under a different key)

The test's docstring documents the threat model and names the two protection layers (this dict + `mount()`'s silent-skip guard in the module).

### Display name "OpenAI-Compatible"

Chosen over `"Chat Completions"` and `"OpenAI-Compatible (self-hosted)"` because:
- Distinguishes clearly from `"OpenAI"` (which is the Responses API provider for `api.openai.com`) and `"Azure OpenAI"` (for Azure-hosted deployments)
- Doesn't over-qualify — LocalAI / Together / Fireworks / Groq can be public or self-hosted
- Fits grid alignment (18 chars, same ballpark as "GitHub Copilot")

Matches what the standalone module reports via `ChatCompletionsProvider.get_info().display_name` — reconciled in [microsoft/amplifier-module-provider-chat-completions@6d38c21](https://github.com/microsoft/amplifier-module-provider-chat-completions/commit/6d38c21).

### `PROVIDER_DEPENDENCIES` — no entry needed

provider-chat-completions is self-contained. Its only external dependency is the `openai` Python SDK (for the OpenAI-compatible HTTP client). Unlike `provider-azure-openai` (which subclasses `OpenAIProvider` at runtime), there's no cross-provider inheritance. `test_no_provider_dependencies` enforces this.

## COE review

Planning + testing reviewed by zen-architect, bug-hunter, and foundation-expert in parallel. Pre-merge fixes applied:

| ID | Reviewer | Fix |
|---|---|---|
| P1-A | bug-hunter | Module's `get_info().display_name` reconciled with CLI fallback (separate commit to the standalone repo) |
| P1-B | bug-hunter | Added `len(expected_names) == len(DEFAULT_PROVIDER_SOURCES)` self-audit so future entries can't silently bypass coverage |
| P1-C | bug-hunter | Removed all 6 "all 7" references from production source + test docstrings; renamed test class to drop hardcoded count |
| P1-D | bug-hunter | Documented app-cli-key ↔ entry-point-name invariant in `test_registered_in_provider_sources` |
| — | zen-architect | Added env-var-name absence check in SSRF test (closes "aliased under different provider key" loophole) |
| — | foundation-expert | Kept `_PROVIDER_DISPLAY_NAMES` existing popularity order; did not bundle cosmetic re-sort into this feature commit |

## Rollout sequence

1. ✅ `microsoft/amplifier-module-provider-chat-completions` — standalone repo live, audit passed
2. ✅ `microsoft/amplifier-bundle-chat-completions` — marked DEPRECATED with migration guide
3. **⬅️ This PR** — adds to `DEFAULT_PROVIDER_SOURCES`
4. Docs PR in `microsoft/amplifier` — Providers + Bundles table rows in MODULES.md (follows this PR)
5. After grace period: delete `modules/` from the bundle repo, archive it

## Testing

Adds 4 new registration tests. Existing `test_discover_providers_clean_install.py` tests that iterate `DEFAULT_PROVIDER_SOURCES` auto-scale to 8 providers. The one hardcoded-dict test (`test_provider_display_names_are_correct_for_all_fallbacks`) gets its new entry plus the `len()` self-audit assertion.

Pre-existing pyright warnings about `AppSettings` import paths (lines 113, 271, 403 of `provider_manager.py`) are unrelated to this PR.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)