### PR TITLE
fix(merge_utils): normalize string-shorthand entries in merge_module_lists

### DIFF
--- a/amplifier_app_cli/lib/merge_utils.py
+++ b/amplifier_app_cli/lib/merge_utils.py
@@ -9,6 +9,43 @@ This module provides app-level policy for how configs should be merged:
 from typing import Any
 
 
+# ===== Module Entry Normalization =====
+
+
+def _normalize_module_entry(
+    item: Any, key_field: str = "module"
+) -> dict[str, Any] | None:
+    """Normalize a module list entry to dict-form.
+
+    Agents may declare tools/hooks/providers using bare-string shorthand, e.g.:
+
+        tools: [terminal_inspector]
+
+    rather than full dict-form:
+
+        tools: [{module: terminal_inspector}]
+
+    This helper converts string entries to ``{key_field: <string>}`` so the
+    rest of the merge logic can call ``.get()`` on every entry uniformly.
+
+    Args:
+        item: A list entry — either a dict (pass-through), a str (normalised
+              to ``{key_field: item}``), or anything else (returns ``None`` so
+              callers can silently discard it rather than crash).
+        key_field: The dict key to use when normalising a bare string.
+                   Defaults to ``"module"``.
+
+    Returns:
+        A ``dict[str, Any]`` or ``None`` for un-normalisable entries.
+    """
+    if isinstance(item, str):
+        return {key_field: item}
+    if isinstance(item, dict):
+        return item
+    # Silently drop garbage (None, int, …) rather than crash.
+    return None
+
+
 # ===== Provider Identity =====
 
 
@@ -41,24 +78,45 @@ def deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
 
 
 def merge_module_lists(
-    base: list[dict[str, Any]],
-    overlay: list[dict[str, Any]],
+    base: list[Any],
+    overlay: list[Any],
     key_field: str = "module",
 ) -> list[dict[str, Any]]:
     """Merge module lists by module ID, with overlay configs merged into base.
 
     If a module appears in both lists, configs are deep-merged (overlay wins).
     Modules only in overlay are appended.
+
+    Both ``base`` and ``overlay`` may contain bare strings as shorthand for
+    ``{key_field: <string>}`` — e.g. ``tools: [terminal_inspector]`` in an
+    agent frontmatter.  :func:`_normalize_module_entry` converts them to
+    dict-form before any ``.get()`` calls are made.  Non-string, non-dict
+    entries are silently dropped rather than causing an ``AttributeError``.
     """
+    # Normalise all entries to dict-form first.
+    # This handles:
+    #   - bare strings ("terminal_inspector" → {"module": "terminal_inspector"})
+    #   - garbage entries (None, int, …) → dropped (None returned by helper)
+    norm_base: list[dict[str, Any]] = [
+        n
+        for n in (_normalize_module_entry(i, key_field) for i in base)
+        if n is not None
+    ]
+    norm_overlay: list[dict[str, Any]] = [
+        n
+        for n in (_normalize_module_entry(i, key_field) for i in overlay)
+        if n is not None
+    ]
+
     # Index base by key (id wins over key_field for multi-instance entries)
     base_by_key: dict[str, dict[str, Any]] = {}
-    for item in base:
+    for item in norm_base:
         if key_field in item:
             key = item.get("id") or item[key_field]
             base_by_key[key] = item.copy()
 
     # Merge overlay
-    for item in overlay:
+    for item in norm_overlay:
         key = item.get("id") or item.get(key_field)
         if key and key in base_by_key:
             # Merge configs

--- a/tests/test_merge_utils.py
+++ b/tests/test_merge_utils.py
@@ -28,6 +28,115 @@ def _write_providers_to_scope(
     settings._write_scope(scope, scope_settings)  # type: ignore[arg-type]
 
 
+class TestMergeModuleListsStringShorthand:
+    """Tests for merge_module_lists() string-shorthand normalization.
+
+    Agents may declare tools/hooks/providers using bare-string shorthand:
+        tools: [terminal_inspector]
+    instead of full dict form:
+        tools: [{module: terminal_inspector}]
+
+    Both forms must be accepted; strings are normalized to {key_field: <string>}.
+    """
+
+    def test_string_overlay_single_entry(self):
+        """String-shorthand overlay entry is normalized to dict-form."""
+        result = merge_module_lists([], ["bash"])
+        assert result == [{"module": "bash"}]
+
+    def test_string_overlay_multiple_entries(self):
+        """Multiple string-shorthand overlay entries are all normalized."""
+        result = merge_module_lists([], ["bash", "filesystem"])
+        assert result == [{"module": "bash"}, {"module": "filesystem"}]
+
+    def test_string_overlay_merges_into_existing_base(self):
+        """String-shorthand overlay merges into matching dict-form base entry."""
+        base = [{"module": "bash", "config": {"timeout": 30}}]
+        result = merge_module_lists(base, ["bash"])
+        # 'bash' string normalises to {"module": "bash"}, which matches the base entry
+        assert len(result) == 1
+        # base config preserved (string overlay carries no extra keys to clobber it)
+        assert result[0]["config"]["timeout"] == 30
+
+    def test_string_overlay_appends_new_entry(self):
+        """String-shorthand overlay entry not in base is appended as dict-form."""
+        base = [{"module": "bash", "config": {"timeout": 30}}]
+        result = merge_module_lists(base, ["filesystem"])
+        assert len(result) == 2
+        modules = [r["module"] for r in result]
+        assert "bash" in modules
+        assert "filesystem" in modules
+
+    def test_mixed_overlay_strings_and_dicts(self):
+        """Overlay list may mix bare strings and full dicts; both are handled."""
+        base: list[dict] = []
+        overlay: list = [
+            "bash",
+            {"module": "filesystem", "config": {"allowed_write_paths": ["/tmp"]}},
+        ]
+        result = merge_module_lists(base, overlay)
+        assert len(result) == 2
+        bash_entry = next(r for r in result if r["module"] == "bash")
+        assert bash_entry == {"module": "bash"}
+        fs_entry = next(r for r in result if r["module"] == "filesystem")
+        assert fs_entry["config"]["allowed_write_paths"] == ["/tmp"]
+
+    def test_string_base_single_entry(self):
+        """String-shorthand base entry is normalized to dict-form."""
+        result = merge_module_lists(["bash"], [])
+        assert result == [{"module": "bash"}]
+
+    def test_string_base_multiple_entries(self):
+        """Multiple string-shorthand base entries are all normalized."""
+        result = merge_module_lists(["bash", "filesystem"], [])
+        assert len(result) == 2
+        modules = {r["module"] for r in result}
+        assert modules == {"bash", "filesystem"}
+
+    def test_mixed_base_strings_and_dicts(self):
+        """Base list may mix bare strings and full dicts; both are handled."""
+        base: list = [
+            "bash",
+            {"module": "filesystem", "config": {"allowed_write_paths": ["/tmp"]}},
+        ]
+        result = merge_module_lists(base, [])
+        assert len(result) == 2
+        bash_entry = next(r for r in result if r["module"] == "bash")
+        assert bash_entry == {"module": "bash"}
+
+    def test_string_base_merged_with_dict_overlay(self):
+        """String base entry is normalized; dict overlay deep-merges into it."""
+        base = ["bash"]
+        overlay = [{"module": "bash", "config": {"timeout": 60}}]
+        result = merge_module_lists(base, overlay)
+        assert len(result) == 1
+        assert result[0]["module"] == "bash"
+        assert result[0]["config"]["timeout"] == 60
+
+    def test_real_world_terminal_inspector(self):
+        """Regression: tools: [terminal_inspector] in agent frontmatter does not crash."""
+        # This is the exact value from reality-check/agents/terminal-tester.md
+        base: list[dict] = []
+        overlay = ["terminal_inspector"]
+        result = merge_module_lists(base, overlay)
+        assert result == [{"module": "terminal_inspector"}]
+
+    def test_key_field_respected_for_string_normalization(self):
+        """String shorthand respects key_field parameter (e.g., 'module' vs custom field)."""
+        result = merge_module_lists([], ["my-hook"], key_field="module")
+        assert result == [{"module": "my-hook"}]
+
+    def test_empty_lists(self):
+        """Empty base and overlay produce empty result without crash."""
+        result = merge_module_lists([], [])
+        assert result == []
+
+    def test_garbage_entries_silently_dropped(self):
+        """Non-string, non-dict entries (e.g., None, int) are silently dropped."""
+        result = merge_module_lists([], [None, 42, "bash"])  # type: ignore[list-item]
+        assert result == [{"module": "bash"}]
+
+
 class TestMergeModuleLists:
     """Tests for merge_module_lists() multi-instance provider behavior."""
 


### PR DESCRIPTION
## Summary

Fixes `AttributeError: 'str' object has no attribute 'get'` raised at
`merge_utils.py:62` (and symmetrically in the `base` loop) when a
`hooks` / `tools` / `providers` list contains string-shorthand entries
instead of dict-shape entries.

## Root cause

**String-shorthand is intentional** — agent `.md` files declare module
dependencies using a bare YAML list of strings, e.g.:

```yaml
# reality-check/agents/terminal-tester.md, line 38
tools: [terminal_inspector]
```

rather than the full dict form:

```yaml
tools:
  - module: terminal_inspector
```

The YAML parser returns `["terminal_inspector"]` (a `list[str]`). When
this agent config is overlaid onto the parent session config,
`merge_agent_dicts` routes the `tools` key to `merge_module_lists`,
which unconditionally called `.get()` on each list element — crashing
immediately for strings.

This pattern is used across multiple bundles:

- `reality-check/agents/terminal-tester.md` → `tools: [terminal_inspector]`
- `terminal-tester/agents/terminal-operator.md` → `tools: [terminal_inspector]`
- `terminal-tester/agents/terminal-visual-tester.md` → `tools: [terminal_inspector]`
- `terminal-tester/agents/terminal-debugger.md` → `tools: [terminal_inspector]`

The fix belongs in `merge_module_lists`: normalize at the merge boundary,
not in every caller or every YAML author. No upstream caller change is
needed because all authors are writing intentional shorthand, not bugs.

## Fix

Added `_normalize_module_entry()` helper that:
- Converts `str` → `{key_field: <string>}` (e.g. `"bash"` → `{"module": "bash"}`)
- Passes `dict` through unchanged
- Returns `None` for anything else (silently dropped, rather than raising)

`merge_module_lists` now applies this normalization to **both** `base`
and `overlay` before any `.get()` calls, via a single comprehension pass.
The type signature is widened from `list[dict[str, Any]]` to `list[Any]`
on both parameters (return type remains `list[dict[str, Any]]`).

## Why this is hard to find

The exception is caught at `_execute_recipe`'s broad `except Exception as e:`
in `amplifier-bundle-recipes/__init__.py:464`, which converts it to a string
without the traceback. Resolving this required reproducing in a manual
interactive `amplifier tool invoke recipes` invocation with the outer except
patched to print `traceback.format_exc()`, in order to find the actual line
in `merge_utils.py:62`.

PR `microsoft/amplifier-bundle-recipes#71` (`isinstance(agent_cfg, dict)`
guards) addressed a similar class of bug but in `executor.py:1785/1803` —
two-and-a-half stack frames upstream of this one. The defense-in-depth
pattern needs to be applied throughout the merge chain.

## Test

Adds `TestMergeModuleListsStringShorthand` with 13 cases covering:

| Test | Scenario |
|------|----------|
| `test_string_overlay_single_entry` | `overlay=["bash"]` → `[{"module": "bash"}]` |
| `test_string_overlay_multiple_entries` | Multiple strings normalized |
| `test_string_overlay_merges_into_existing_base` | String normalised, merges into matching dict base |
| `test_string_overlay_appends_new_entry` | String not in base is appended |
| `test_mixed_overlay_strings_and_dicts` | Mixed overlay handled correctly |
| `test_string_base_single_entry` | `base=["bash"]` → `[{"module": "bash"}]` |
| `test_string_base_multiple_entries` | Multiple string base entries |
| `test_mixed_base_strings_and_dicts` | Mixed base handled correctly |
| `test_string_base_merged_with_dict_overlay` | String base + dict overlay deep-merges |
| `test_real_world_terminal_inspector` | Exact regression: `["terminal_inspector"]` |
| `test_key_field_respected_for_string_normalization` | `key_field` param propagates |
| `test_empty_lists` | Empty lists → no crash |
| `test_garbage_entries_silently_dropped` | `None`, `int` dropped gracefully |

## Upstream fix

No upstream fix was needed — the strings come from intentional YAML authoring
conventions, not from a serialization bug. The normalization at the merge
boundary is the correct and complete fix.

## Discovered while

Running the `amplifier-bundle-reality-check` recipe inside an Amplifier-Resolve
reality-check runner sub-container. Step 2 (terminal-validation) consistently
failed in ~11ms because spawning the `reality-check:terminal-tester` agent
(which declares `tools: [terminal_inspector]`) crashed in `merge_module_lists`
before the agent session could start.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
