### PR TITLE
fix: filter redundant sub-bundles from update list

### DIFF
--- a/amplifier_app_cli/lib/bundle_loader/discovery.py
+++ b/amplifier_app_cli/lib/bundle_loader/discovery.py
@@ -92,6 +92,32 @@ WELL_KNOWN_BUNDLES: dict[str, dict[str, str | bool]] = {
 }
 
 
+def _normalize_bundle_base_uri(uri: str) -> str:
+    """Normalize a git URI for base-repo comparison.
+
+    Strips the ``git+`` prefix, ``@branch`` suffix (except for ``file://`` URIs),
+    and any trailing slash so that two URIs pointing to the same upstream repo
+    compare equal regardless of how they were specified.
+
+    Examples::
+
+        git+https://github.com/microsoft/amplifier-bundle-foo@main
+        -> https://github.com/microsoft/amplifier-bundle-foo
+
+        https://github.com/microsoft/amplifier-bundle-foo
+        -> https://github.com/microsoft/amplifier-bundle-foo
+
+        file:///home/user/my-bundle  (trailing slash stripped only)
+        -> file:///home/user/my-bundle
+    """
+    if uri.startswith("git+"):
+        uri = uri[4:]
+    # Preserve @ref for file:// URIs (they may use it as a path component)
+    if not uri.startswith("file://") and "@" in uri:
+        uri = uri.split("@")[0]
+    return uri.rstrip("/")
+
+
 class AppBundleDiscovery:
     """CLI-specific bundle discovery with filesystem search paths.
 
@@ -430,14 +456,13 @@ class AppBundleDiscovery:
         - User-added bundles from settings.yaml
 
         Filters out:
-        - Subdirectory bundles (#subdirectory= in URI) since those share
-          a repo with their parent and updating the parent updates them too
-        - Exception: user-added bundles (bundle.added in settings.yaml) are
-          ALWAYS included even if their URI contains #subdirectory=. When the
-          user explicitly adds a behavior bundle via `amplifier bundle add
-          ...#subdirectory=...`, there is no separate parent being tracked —
-          the subdirectory bundle IS the thing to update. Filtering it out
-          would silently break `amplifier update` for those bundles.
+        - Subdirectory bundles (#subdirectory= in URI) whose underlying repo is
+          already represented by another root bundle in the list (e.g.
+          ``amplifier-tester-behavior`` is filtered when ``amplifier-tester``
+          is also present because they share the same git repo).
+        - Exception: if a sub-bundle is the ONLY entry for its repo (i.e. no
+          non-subdirectory root bundle with the same base URI exists), it is
+          kept — it is the thing to update.
 
         This is used by `amplifier update` to check for updates on ALL locally
         cached root bundles, not just the filtered list shown to users.
@@ -484,24 +509,57 @@ class AppBundleDiscovery:
         except Exception as e:
             logger.debug(f"Could not read bundles from settings: {e}")
 
-        # 4. Filter out subdirectory bundles from registry roots
-        # (registry stores URI, check it for subdirectory marker)
-        # User-added bundles are exempt: they were explicitly added and must
-        # always appear in update checks regardless of their registry URI.
+        # 4. Filter out sub-bundles that are redundant with already-tracked root bundles.
+        #
+        # A sub-bundle (URI contains #subdirectory=) is redundant when another root
+        # bundle in the list points to the same underlying git repo (same base URI
+        # before the # fragment).  In that case updating the root bundle covers the
+        # sub-bundle too, so showing the sub-bundle is just noise.
+        #
+        # A sub-bundle is KEPT when its underlying repo is not yet tracked by any
+        # non-subdirectory root bundle — it is the only update-checkable entry for
+        # that repo (e.g. the user added only a behaviour bundle, not the root).
+        #
+        # URI priority for resolving a bundle's URI:
+        #   registry data > user-added settings (added_bundles) > WELL_KNOWN_BUNDLES
         registry_path = Path.home() / ".amplifier" / "registry.json"
         if registry_path.exists():
             try:
                 with open(registry_path, encoding="utf-8") as f:
                     data = json.load(f)
-                user_added_names = set(added_bundles.keys())
+
+                def _get_uri(name: str) -> str:
+                    """Best-available URI for *name* using registry > added_bundles > well-known priority."""
+                    uri: str = data.get("bundles", {}).get(name, {}).get("uri", "")
+                    if not uri:
+                        uri = added_bundles.get(name, "")
+                    if not uri:
+                        wk = WELL_KNOWN_BUNDLES.get(name, {})
+                        raw = wk.get("remote", "")
+                        uri = str(raw) if raw else ""
+                    return uri
+
+                # Build the set of normalized base URIs for all non-subdirectory bundles
+                # currently in root_bundles — these are the "tracked" repos.
+                tracked_base_uris: set[str] = set()
+                for name in root_bundles:
+                    uri = _get_uri(name)
+                    if uri and "#subdirectory=" not in uri:
+                        tracked_base_uris.add(_normalize_bundle_base_uri(uri))
+
+                # Discard any sub-bundle whose base repo URI is already tracked.
                 for name in list(root_bundles):
-                    if name in user_added_names:
-                        # Explicitly user-added — never filter out
-                        continue
-                    bundle_data = data.get("bundles", {}).get(name, {})
-                    uri = bundle_data.get("uri", "")
-                    if "#subdirectory=" in uri:
+                    uri = _get_uri(name)
+                    if "#subdirectory=" not in uri:
+                        continue  # Not a sub-bundle — nothing to filter
+                    base_uri = _normalize_bundle_base_uri(uri.split("#")[0])
+                    if base_uri in tracked_base_uris:
+                        logger.debug(
+                            f"Filtering redundant sub-bundle '{name}': "
+                            f"base repo already tracked by another root bundle"
+                        )
                         root_bundles.discard(name)
+                    # base_uri not tracked → keep the sub-bundle (it IS the update target)
             except Exception as e:
                 logger.debug(f"Could not filter subdirectory bundles: {e}")
 

--- a/tests/lib/bundle_loader/test_discovery.py
+++ b/tests/lib/bundle_loader/test_discovery.py
@@ -1,10 +1,14 @@
 """Tests for AppBundleDiscovery.list_cached_root_bundles().
 
-Focuses on the subdirectory-filter exemption for user-added bundles:
-- Bundles added via `amplifier bundle add ...#subdirectory=...` must survive
-  both Step 3 (the former skip) and Step 4 (the registry URI filter).
-- Auto-discovered nested bundles (not in bundle.added) must still be filtered
-  out when their registry URI contains #subdirectory=.
+Validates the Step 4 subdirectory filter which uses base-URI comparison:
+
+- A sub-bundle (URI contains #subdirectory=) is filtered when another root
+  bundle in the list points to the same underlying git repo (same base URI).
+- A sub-bundle is KEPT when its underlying repo is NOT tracked by any other
+  root bundle — it is the only update-checkable entry for that repo.
+
+The old exemption was "user-added bundles are NEVER filtered."
+The new rule is "filter only when the root repo IS already tracked."
 """
 
 import json
@@ -93,10 +97,12 @@ class TestListCachedRootBundlesSubdirectoryFilter:
         )
 
     def test_non_user_added_subdirectory_bundle_is_filtered_out(self, tmp_path: Path):
-        """A bundle NOT in bundle.added whose registry URI has #subdirectory= must be filtered.
+        """A sub-bundle is filtered when its root repo IS tracked by another root bundle.
 
-        This preserves the original behaviour: auto-discovered nested bundles
-        share a repo with their parent; updating the parent is sufficient.
+        Under the new URI-comparison logic, filtering is triggered by the presence of
+        a non-subdirectory root bundle pointing to the same underlying repo — not by
+        whether the bundle was user-added.  Here ``some-bundle`` (clean URI) tracks
+        the repo, so ``nested-behavior`` (#subdirectory=) is redundant and filtered.
         """
         _write_registry(
             tmp_path,
@@ -104,7 +110,11 @@ class TestListCachedRootBundlesSubdirectoryFilter:
                 "nested-behavior": {
                     "uri": "git+https://github.com/microsoft/some-bundle@main#subdirectory=behaviors/nested.yaml",
                     "is_root": True,
-                }
+                },
+                "some-bundle": {
+                    "uri": "git+https://github.com/microsoft/some-bundle@main",
+                    "is_root": True,
+                },
             },
         )
 
@@ -114,7 +124,7 @@ class TestListCachedRootBundlesSubdirectoryFilter:
             patch.object(
                 discovery,
                 "_get_root_and_nested_bundles",
-                return_value=({"nested-behavior"}, set()),
+                return_value=({"nested-behavior", "some-bundle"}, set()),
             ),
             patch(
                 "amplifier_app_cli.lib.bundle_loader.discovery.WELL_KNOWN_BUNDLES",
@@ -123,21 +133,25 @@ class TestListCachedRootBundlesSubdirectoryFilter:
             patch("amplifier_app_cli.lib.settings.AppSettings") as MockSettings,
             patch("pathlib.Path.home", return_value=tmp_path),
         ):
-            # User did NOT explicitly add this bundle
+            # User did NOT explicitly add these bundles
             MockSettings.return_value.get_added_bundles.return_value = {}
             result = discovery.list_cached_root_bundles()
 
         assert "nested-behavior" not in result, (
-            "nested-behavior is not user-added and its registry URI has "
-            "#subdirectory=, so it must be filtered out (parent repo update covers it)"
+            "nested-behavior has #subdirectory= and its root repo is tracked by "
+            "some-bundle, so it must be filtered out as redundant"
+        )
+        assert "some-bundle" in result, (
+            "some-bundle is the root-repo entry and must remain"
         )
 
     def test_multiple_bundles_mixed_filtering(self, tmp_path: Path):
         """Correct bundles survive and are filtered in a realistic mixed scenario.
 
-        - env-all: user-added, #subdirectory= in registry → INCLUDED
-        - digital-twin-universe-behavior: user-added, #subdirectory= in registry → INCLUDED
-        - auto-nested: auto-discovered, #subdirectory= in registry → FILTERED
+        - env-all: user-added, #subdirectory=, root NOT tracked → INCLUDED (only update target)
+        - digital-twin-universe-behavior: user-added, #subdirectory=, root NOT tracked → INCLUDED
+        - auto-nested: auto-discovered, #subdirectory=, root IS tracked → FILTERED
+        - some-bundle: root entry for auto-nested's repo → INCLUDED
         - parallax-discovery: user-added, clean URI → INCLUDED
         """
         _write_registry(
@@ -153,6 +167,11 @@ class TestListCachedRootBundlesSubdirectoryFilter:
                 },
                 "auto-nested": {
                     "uri": "git+https://github.com/microsoft/some-bundle@main#subdirectory=behaviors/auto.yaml",
+                    "is_root": True,
+                },
+                # Root bundle for auto-nested's repo — this is what triggers the filter
+                "some-bundle": {
+                    "uri": "git+https://github.com/microsoft/some-bundle@main",
                     "is_root": True,
                 },
                 "parallax-discovery": {
@@ -179,6 +198,7 @@ class TestListCachedRootBundlesSubdirectoryFilter:
                         "env-all",
                         "digital-twin-universe-behavior",
                         "auto-nested",
+                        "some-bundle",
                         "parallax-discovery",
                     },
                     set(),
@@ -194,28 +214,41 @@ class TestListCachedRootBundlesSubdirectoryFilter:
             MockSettings.return_value.get_added_bundles.return_value = added_bundles
             result = discovery.list_cached_root_bundles()
 
-        assert "env-all" in result, "user-added subdirectory bundle must be included"
+        assert "env-all" in result, (
+            "env-all root repo is not tracked by any other bundle → kept"
+        )
         assert "digital-twin-universe-behavior" in result, (
-            "user-added subdirectory bundle must be included"
+            "digital-twin-universe-behavior root repo not tracked → kept"
         )
         assert "parallax-discovery" in result, (
-            "user-added clean-URI bundle must be included"
+            "parallax-discovery is a clean-URI root bundle → kept"
+        )
+        assert "some-bundle" in result, (
+            "some-bundle is the root-repo entry → kept"
         )
         assert "auto-nested" not in result, (
-            "auto-discovered subdirectory bundle must be filtered out"
+            "auto-nested #subdirectory= bundle filtered because some-bundle tracks the same repo"
         )
 
-    def test_settings_read_failure_still_filters_non_user_bundles(self, tmp_path: Path):
-        """If settings.yaml can't be read, auto-discovered subdirectory bundles are still filtered.
+    def test_settings_read_failure_still_filters_sub_bundle_when_root_tracked(
+        self, tmp_path: Path
+    ):
+        """Sub-bundle filtering still works via URI comparison even when settings.yaml is unreadable.
 
-        When AppSettings raises, added_bundles stays empty ({}), so no bundles
-        are protected and the normal subdirectory filter applies to everything.
+        When AppSettings raises, added_bundles falls back to {}.  The filter still
+        fires because ``some-bundle`` (clean URI) is in the registry and its normalised
+        base URI matches the base of ``auto-nested`` (#subdirectory=).  This confirms
+        the filter is driven by URI comparison, not by the user-added list.
         """
         _write_registry(
             tmp_path,
             {
                 "auto-nested": {
                     "uri": "git+https://github.com/microsoft/some-bundle@main#subdirectory=behaviors/auto.yaml",
+                    "is_root": True,
+                },
+                "some-bundle": {
+                    "uri": "git+https://github.com/microsoft/some-bundle@main",
                     "is_root": True,
                 },
             },
@@ -227,7 +260,7 @@ class TestListCachedRootBundlesSubdirectoryFilter:
             patch.object(
                 discovery,
                 "_get_root_and_nested_bundles",
-                return_value=({"auto-nested"}, set()),
+                return_value=({"auto-nested", "some-bundle"}, set()),
             ),
             patch(
                 "amplifier_app_cli.lib.bundle_loader.discovery.WELL_KNOWN_BUNDLES",
@@ -242,8 +275,173 @@ class TestListCachedRootBundlesSubdirectoryFilter:
             result = discovery.list_cached_root_bundles()
 
         assert "auto-nested" not in result, (
-            "when settings can't be read, auto-discovered subdirectory bundles "
-            "must still be filtered (no bundles are protected)"
+            "auto-nested must be filtered: some-bundle tracks the same repo "
+            "and this check uses only registry URIs — settings failure is irrelevant"
+        )
+        assert "some-bundle" in result, "some-bundle is the root entry and must remain"
+
+    # -----------------------------------------------------------------------
+    # New tests covering the base-URI comparison logic (spec cases a, b, c)
+    # -----------------------------------------------------------------------
+
+    def test_sub_bundle_filtered_when_root_repo_tracked(self, tmp_path: Path):
+        """(spec case a) Sub-bundle filtered when the root repo is already tracked.
+
+        Mirrors the real pair that triggered the bug report:
+        amplifier-tester (clean URI) + amplifier-tester-behavior (#subdirectory=).
+        Both point to the same github repo.  The behavior bundle must vanish from
+        the update list because updating amplifier-tester covers it.
+        """
+        _write_registry(
+            tmp_path,
+            {
+                "amplifier-tester": {
+                    "uri": "git+https://github.com/microsoft/amplifier-bundle-amplifier-tester@main",
+                    "is_root": True,
+                },
+                "amplifier-tester-behavior": {
+                    "uri": "git+https://github.com/microsoft/amplifier-bundle-amplifier-tester@main#subdirectory=behaviors/amplifier-tester.yaml",
+                    "is_root": True,
+                },
+            },
+        )
+
+        added_bundles = {
+            "amplifier-tester-behavior": "git+https://github.com/microsoft/amplifier-bundle-amplifier-tester@main#subdirectory=behaviors/amplifier-tester.yaml",
+        }
+
+        discovery = _make_discovery()
+
+        with (
+            patch.object(
+                discovery,
+                "_get_root_and_nested_bundles",
+                return_value=({"amplifier-tester", "amplifier-tester-behavior"}, set()),
+            ),
+            patch(
+                "amplifier_app_cli.lib.bundle_loader.discovery.WELL_KNOWN_BUNDLES",
+                {},
+            ),
+            patch("amplifier_app_cli.lib.settings.AppSettings") as MockSettings,
+            patch("pathlib.Path.home", return_value=tmp_path),
+        ):
+            MockSettings.return_value.get_added_bundles.return_value = added_bundles
+            result = discovery.list_cached_root_bundles()
+
+        assert "amplifier-tester" in result, (
+            "amplifier-tester is the root entry and must be kept"
+        )
+        assert "amplifier-tester-behavior" not in result, (
+            "amplifier-tester-behavior is redundant: amplifier-tester tracks the same repo"
+        )
+
+    def test_sub_bundle_kept_when_root_repo_not_tracked(self, tmp_path: Path):
+        """(spec case b) Sub-bundle kept when no non-subdirectory root tracks its repo.
+
+        When a user added ONLY a behavior bundle (and not the root bundle), the
+        sub-bundle must appear in the update list — it is the only update target
+        for that repo.  Filtering it would silently break `amplifier update`.
+        """
+        _write_registry(
+            tmp_path,
+            {
+                "reality-check-behavior": {
+                    "uri": "git+https://github.com/microsoft/amplifier-bundle-reality-check@main#subdirectory=behaviors/reality-check.yaml",
+                    "is_root": True,
+                },
+                # Note: no "reality-check" root bundle — only the behavior was added
+            },
+        )
+
+        added_bundles = {
+            "reality-check-behavior": "git+https://github.com/microsoft/amplifier-bundle-reality-check@main#subdirectory=behaviors/reality-check.yaml",
+        }
+
+        discovery = _make_discovery()
+
+        with (
+            patch.object(
+                discovery,
+                "_get_root_and_nested_bundles",
+                return_value=({"reality-check-behavior"}, set()),
+            ),
+            patch(
+                "amplifier_app_cli.lib.bundle_loader.discovery.WELL_KNOWN_BUNDLES",
+                {},
+            ),
+            patch("amplifier_app_cli.lib.settings.AppSettings") as MockSettings,
+            patch("pathlib.Path.home", return_value=tmp_path),
+        ):
+            MockSettings.return_value.get_added_bundles.return_value = added_bundles
+            result = discovery.list_cached_root_bundles()
+
+        assert "reality-check-behavior" in result, (
+            "reality-check-behavior must be kept: no root bundle tracks amplifier-bundle-reality-check, "
+            "so this IS the update target for that repo"
+        )
+
+    def test_multiple_sub_bundles_same_repo_all_filtered_when_root_tracked(
+        self, tmp_path: Path
+    ):
+        """(spec case c) Multiple sub-bundles of the same repo are ALL filtered when root tracked.
+
+        Mirrors the env-all / behavior-env-all / execution-environments scenario:
+        two different behavior bundles both point to amplifier-bundle-execution-environments.
+        The root ``execution-environments`` bundle is also tracked, so both sub-bundles
+        are redundant and must be removed.
+        """
+        _write_registry(
+            tmp_path,
+            {
+                "execution-environments": {
+                    "uri": "git+https://github.com/microsoft/amplifier-bundle-execution-environments@main",
+                    "is_root": True,
+                },
+                "env-all": {
+                    "uri": "git+https://github.com/microsoft/amplifier-bundle-execution-environments@main#subdirectory=behaviors/env-all.yaml",
+                    "is_root": True,
+                },
+                "behavior-env-all": {
+                    "uri": "git+https://github.com/microsoft/amplifier-bundle-execution-environments@main#subdirectory=behaviors/env-all.yaml",
+                    "is_root": True,
+                },
+            },
+        )
+
+        added_bundles = {
+            "env-all": "git+https://github.com/microsoft/amplifier-bundle-execution-environments@main#subdirectory=behaviors/env-all.yaml",
+            "behavior-env-all": "git+https://github.com/microsoft/amplifier-bundle-execution-environments@main#subdirectory=behaviors/env-all.yaml",
+        }
+
+        discovery = _make_discovery()
+
+        with (
+            patch.object(
+                discovery,
+                "_get_root_and_nested_bundles",
+                return_value=(
+                    {"execution-environments", "env-all", "behavior-env-all"},
+                    set(),
+                ),
+            ),
+            patch(
+                "amplifier_app_cli.lib.bundle_loader.discovery.WELL_KNOWN_BUNDLES",
+                {},
+            ),
+            patch("amplifier_app_cli.lib.settings.AppSettings") as MockSettings,
+            patch("pathlib.Path.home", return_value=tmp_path),
+        ):
+            MockSettings.return_value.get_added_bundles.return_value = added_bundles
+            result = discovery.list_cached_root_bundles()
+
+        assert "execution-environments" in result, (
+            "execution-environments is the root entry and must be kept"
+        )
+        assert "env-all" not in result, (
+            "env-all is redundant: execution-environments tracks the same repo"
+        )
+        assert "behavior-env-all" not in result, (
+            "behavior-env-all is redundant: execution-environments tracks the same repo"
         )
 
     def test_result_is_sorted(self, tmp_path: Path):


### PR DESCRIPTION
## Summary

Fixes the issue where `amplifier update` command lists both root bundles and their behavior/sub-bundles with identical SHAs (e.g., `amplifier-tester` + `amplifier-tester-behavior`, `digital-twin-universe` + `digital-twin-universe-behavior`, `execution-environments` + `env-all` + `behavior-env-all`). Users expect only root bundles since those are what get loaded; behavior bundles are nested dependencies.

## Root Cause

`list_cached_root_bundles()` in `amplifier_app_cli/lib/bundle_loader/discovery.py` had a Step 4 filter to discard `#subdirectory=` URIs (sub-bundles), but it blanket-exempted ALL user-added bundles. This kept user-added sub-bundles even when the same underlying repo was already represented by a root bundle entry.

## Fix

Replaced the blanket exemption with smarter URI-based logic:

1. **New helper function** `_normalize_bundle_base_uri()` — normalizes git URIs (strips `git+` prefix, `@branch` suffix except for `file://`, trailing slashes) so URIs from different sources can be reliably compared.

2. **Step 4 re-implemented** — now builds a set of normalized base repo URIs from all non-subdirectory bundles, then:
   - For each `#subdirectory=` bundle: computes its base URI
   - **Discards** if the base is already tracked by a root bundle (redundant noise removed)
   - **Keeps** if the repo is not yet tracked elsewhere (it IS the only update target)

## Result

- ✓ Redundant sub-bundles filtered when root tracked (`amplifier-tester-behavior` hidden when `amplifier-tester` shown)
- ✓ Solo sub-bundles kept if no root tracked (they are the only update target for that repo)
- ✓ Canonical root bundle always shown
- ✓ User expectations aligned: only root bundles appear in the list

## Test Coverage

- **3 new tests** covering bug scenarios:
  - Sub-bundle filtered when root tracked
  - Sub-bundle kept when no root tracked
  - Multiple sub-bundles for same repo all filtered when root tracked

- **3 existing tests** updated to reflect new filter semantics

- **All 8 tests** in `tests/lib/bundle_loader/test_discovery.py` pass
- `python_check` introduced zero new errors

## Files Changed
- `amplifier_app_cli/lib/bundle_loader/discovery.py` — new helper + Step 4 logic
- `tests/lib/bundle_loader/test_discovery.py` — 3 new tests + 3 updated

Generated with [Amplifier](https://github.com/microsoft/amplifier)