### PR TITLE
fix: load agent metadata before bundle.prepare()

### DIFF
--- a/amplifier_app_cli/lib/bundle_loader/prepare.py
+++ b/amplifier_app_cli/lib/bundle_loader/prepare.py
@@ -171,6 +171,24 @@ async def load_and_prepare_bundle(
                 logger.warning(f"Failed to compose behavior '{behavior_uri}': {e}")
                 # Continue without this behavior - notifications are optional
 
+    # 3b. Load agent metadata BEFORE prepare so the agent's declared modules
+    # (tools/providers/hooks with `source:` URIs in their .md frontmatter) are
+    # present in `mount_plan["agents"][name]` when `Bundle.prepare()` walks the
+    # agent section to pre-activate child-session modules.
+    #
+    # `_parse_agents` only puts `{"name": name}` into `bundle.agents` for each
+    # entry in `agents.include:`. The full frontmatter (tools, providers, hooks,
+    # session) lives on disk and is loaded by `load_agent_metadata()`, which
+    # uses `source_base_paths` (now fully populated after compose) to resolve
+    # each agent's .md file. Calling it here, BEFORE prepare, lets agent-side
+    # tool sources be activated at compose time alongside parent-side ones.
+    #
+    # Without this ordering, agent sub-sessions inherit the parent's prepared
+    # module set and silently fail to load any tool the parent didn't also
+    # declare. The downstream call at runtime/config.py is now redundant for
+    # description population but kept idempotent for backward safety.
+    bundle.load_agent_metadata()
+
     # 4. Prepare: download modules from git sources, install deps
     # Build source resolver callback if overrides provided
     def make_source_resolver(


### PR DESCRIPTION
## Summary

Agent-declared tools, providers, and hooks (loaded from each agent's .md frontmatter) were not being pre-activated because `bundle.load_agent_metadata()` was called AFTER `bundle.prepare()`. This meant agent-side tool sources never reached `prepare()`'s install phase, so spawned sub-sessions inherited only the parent's prepared module set.

**The bug:** `_parse_agents()` populates `bundle.agents` with just `{"name": name}` for each entry in `agents.include:`. The full frontmatter (tools, providers, hooks, session) lives on disk and is loaded by `load_agent_metadata()`. When that call happened AFTER prepare, the agent-section scan found no `source:` URIs to pre-activate, leaving child sessions with zero tools (other than the irreducible parent's todo + mode).

## Changes

Move `bundle.load_agent_metadata()` to BEFORE `bundle.prepare()` in `lib/bundle_loader/prepare.py` (line 190). This ensures `mount_plan["agents"][name]` contains the full agent spec when `prepare()` walks the agents section to install source URIs. The downstream call at `runtime/config.py` is now redundant for description population but kept idempotent for backward safety.

## Companion PR

This fix is coordinated with microsoft/amplifier-foundation#191 (namespace_root fix). Both must land together for the build-up-foundation v0.4.0 bundle and any future sub-bundle agent pattern to work end-to-end.

## Verification

- **amplifier-core e2e smoke test**: PASS with both foundation+app-cli local overrides
- **End-to-end (DTU)**: Agent sub-sessions correctly inherit their declared tool sets; forced bash use confirmed via tool logs
- **Ordering invariant**: Agent metadata loading before prepare is now enforced in the call graph

---

Generated with [Amplifier](https://github.com/microsoft/amplifier)