### PR TITLE
fix(update): always route umbrella upgrade through uv; add --force cache clean

### DIFF
--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -1018,19 +1018,21 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
 
     # Check umbrella first
     from ..utils.umbrella_discovery import discover_umbrella_source
-    from ..utils.update_executor import check_umbrella_dependencies_for_updates
+    from ..utils.update_executor import check_umbrella_dependencies_for_updates  # noqa: F401 — kept for future reporting use; no longer gates execution
 
     umbrella_info = discover_umbrella_source()
     has_umbrella_updates = False
 
     if umbrella_info:
-        if force:
-            has_umbrella_updates = True  # Force update umbrella
-        else:
-            console.print("  Checking Amplifier dependencies...")
-            has_umbrella_updates = asyncio.run(
-                check_umbrella_dependencies_for_updates(umbrella_info)
-            )
+        # Always route the umbrella update through uv. The previous
+        # check_umbrella_dependencies_for_updates() check only inspected
+        # git-sourced deps and silently missed PyPI version bumps
+        # (e.g. amplifier-core), causing `amplifier update` to report
+        # "All sources up to date" while actually being stale.
+        # uv knows the full dependency tree and will decide what (if anything)
+        # needs upgrading. The cost is one extra `uv tool install` call per
+        # `amplifier update`; the alternative is silent staleness.
+        has_umbrella_updates = True
 
     # Check modules
     if not force:
@@ -1155,6 +1157,7 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
                 report,
                 umbrella_info=umbrella_info if has_umbrella_updates else None,
                 progress_callback=_on_update_progress,
+                force=force,
             )
         )
 

--- a/amplifier_app_cli/utils/update_executor.py
+++ b/amplifier_app_cli/utils/update_executor.py
@@ -418,6 +418,7 @@ def _invalidate_modules_with_missing_deps() -> tuple[int, int]:
 async def execute_self_update(
     umbrella_info: UmbrellaInfo,
     progress_callback: Callable[[str, str], None] | None = None,
+    force: bool = False,
 ) -> ExecutionResult:
     """Delegate to 'uv tool install --upgrade --reinstall'.
 
@@ -429,9 +430,19 @@ async def execute_self_update(
     are still satisfied.
 
     Progress reporting: The progress_callback receives two kinds of phase values:
-    - Structured keywords: "installing", "checking_deps" (stable, mapped by caller)
+    - Structured keywords: "installing", "checking_deps", "clearing" (stable, mapped by caller)
     - Raw uv output lines: e.g. "Resolved 15 packages in 2.31s" (streamed from stderr)
     The caller's format function should handle both (see _format_update_progress).
+
+    Args:
+        umbrella_info: Discovered umbrella source info (URL and ref).
+        progress_callback: Optional callback(name, phase) for progress reporting.
+        force: When True, run `uv cache clean` before installing. `--upgrade`/
+            `--reinstall` imply `--refresh`, but `--refresh` is a conditional
+            revalidation that PyPI's CDN can satisfy with a stale 304 during a
+            release rollout window. `uv cache clean` is unconditional — matching
+            what `amplifier reset` does (the only update path users currently
+            report as reliable).
     """
     url = f"git+{umbrella_info.url}@{umbrella_info.ref}"
 
@@ -463,6 +474,27 @@ async def execute_self_update(
                     progress_callback("amplifier", clean)
 
     try:
+        # In --force mode, run `uv cache clean` to unconditionally invalidate
+        # uv's HTTP metadata cache. `--upgrade`/`--reinstall` imply `--refresh`,
+        # but `--refresh` is a conditional revalidation that can be defeated by
+        # a PyPI CDN serving 304 Not Modified during a release rollout window.
+        # `uv cache clean` matches what `amplifier reset` does, which is the
+        # only update path users currently report as reliable.
+        if force:
+            if progress_callback:
+                progress_callback("amplifier", "clearing")
+            try:
+                subprocess.run(
+                    ["uv", "cache", "clean"],
+                    check=False,
+                    capture_output=True,
+                    timeout=60,
+                )
+            except Exception:
+                # Cache clean is defense-in-depth; never block the update on
+                # its failure.
+                pass
+
         # Remove orphaned lock file before running uv. A stale uv.lock (from
         # a killed uv process) causes uv tool install to hang indefinitely
         # waiting to acquire it — same guard applied in reset._clean_uv_cache().
@@ -556,6 +588,7 @@ async def execute_updates(
     report: UpdateReport,
     umbrella_info: UmbrellaInfo | None = None,
     progress_callback: Callable[[str, str], None] | None = None,
+    force: bool = False,
 ) -> ExecutionResult:
     """Orchestrate all updates based on report.
 
@@ -565,6 +598,8 @@ async def execute_updates(
         report: Update status report from check_all_sources
         umbrella_info: Optional umbrella info if already checked for updates
         progress_callback: Optional callback(name, phase) for progress reporting
+        force: When True, forwarded to execute_self_update to enable unconditional
+            cache-clean before the uv install step.
     """
     all_updated = []
     all_failed = []
@@ -592,7 +627,9 @@ async def execute_updates(
     if umbrella_info:
         logger.info("Updating Amplifier (umbrella dependencies have updates)...")
         result = await execute_self_update(
-            umbrella_info, progress_callback=progress_callback
+            umbrella_info,
+            progress_callback=progress_callback,
+            force=force,
         )
 
         all_updated.extend(result.updated)

--- a/tests/test_update_executor.py
+++ b/tests/test_update_executor.py
@@ -1,5 +1,6 @@
 """Tests for execute_self_update in update_executor."""
 
+import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -51,4 +52,247 @@ async def test_execute_self_update_uses_upgrade_reinstall_not_force():
     )
     assert "--reinstall" in captured_cmd, (
         "uv must use --reinstall to fully refresh packages"
+    )
+
+
+# ---------------------------------------------------------------------------
+# New tests for force=True / force=False behaviour (fix/update-pypi-deps-blind)
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_subprocess_trackers():
+    """Return (calls_list, fake_run_fn, FakePopen_class) for subprocess mocking.
+
+    All subprocess invocations append their argv to calls_list so tests can
+    assert on ordering and content.
+    """
+    calls: list[list[str]] = []
+
+    def fake_run(argv, *args, **kwargs):
+        calls.append(list(argv))
+        return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+    class FakePopen:
+        def __init__(self, argv, *args, **kwargs):
+            calls.append(list(argv))
+            self.args = argv
+            self.stderr = iter([])  # no output lines — keeps _drain_stderr fast
+            self.returncode = 0
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            pass
+
+        def poll(self):
+            return 0
+
+    return calls, fake_run, FakePopen
+
+
+@pytest.mark.asyncio
+async def test_execute_self_update_force_runs_cache_clean(monkeypatch):
+    """When force=True, uv cache clean must run BEFORE uv tool install.
+
+    This ensures that PyPI's CDN cannot serve a stale 304 response during a
+    release rollout window. `--upgrade`/`--reinstall` imply `--refresh` which
+    is a conditional revalidation; `uv cache clean` is unconditional — matching
+    what `amplifier reset` does (the only update path users report as reliable).
+    """
+    calls, fake_run, FakePopen = _make_fake_subprocess_trackers()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.update_executor.remove_stale_uv_lock",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.update_executor._invalidate_modules_with_missing_deps",
+        lambda: (0, 0),
+    )
+
+    result = await execute_self_update(_FAKE_UMBRELLA, force=True)
+
+    assert result.success, f"Expected success, got: {result}"
+    # First subprocess call must be `uv cache clean`
+    assert calls, "Expected at least one subprocess invocation"
+    assert calls[0][:3] == ["uv", "cache", "clean"], (
+        f"Expected `uv cache clean` as the first subprocess call, got: {calls[0]}"
+    )
+    # uv tool install must follow
+    assert any(c[:4] == ["uv", "tool", "install", "--upgrade"] for c in calls), (
+        f"Expected `uv tool install --upgrade ...` in subprocess calls, got: {calls}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_self_update_no_force_skips_cache_clean(monkeypatch):
+    """When force=False (default), uv cache clean must NOT be run.
+
+    Normal updates rely on uv's own --upgrade/--reinstall behaviour and must
+    not incur the extra cache-wipe overhead.
+    """
+    calls, fake_run, FakePopen = _make_fake_subprocess_trackers()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.update_executor.remove_stale_uv_lock",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.update_executor._invalidate_modules_with_missing_deps",
+        lambda: (0, 0),
+    )
+
+    result = await execute_self_update(_FAKE_UMBRELLA, force=False)
+
+    assert result.success, f"Expected success, got: {result}"
+    cache_clean_calls = [c for c in calls if c[:3] == ["uv", "cache", "clean"]]
+    assert not cache_clean_calls, (
+        f"`uv cache clean` must NOT be called when force=False, but it ran: {calls}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_updates_forwards_force_to_execute_self_update(monkeypatch):
+    """execute_updates must forward the force flag to execute_self_update.
+
+    This is the plumbing test: execute_updates(force=True) → execute_self_update(force=True).
+    If the flag is swallowed here, the cache-clean logic in execute_self_update
+    never fires even when --force is passed from the CLI.
+    """
+    from amplifier_app_cli.utils.source_status import UpdateReport
+    from amplifier_app_cli.utils.update_executor import ExecutionResult, execute_updates
+
+    captured: dict = {}
+
+    async def fake_execute_self_update(
+        umbrella_info, progress_callback=None, force=False
+    ):
+        captured["force"] = force
+        captured["umbrella_info"] = umbrella_info
+        return ExecutionResult(success=True, updated=["amplifier"], messages=[])
+
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.update_executor.execute_self_update",
+        fake_execute_self_update,
+    )
+
+    empty_report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+
+    await execute_updates(empty_report, umbrella_info=_FAKE_UMBRELLA, force=True)
+
+    assert "force" in captured, (
+        "execute_self_update was not called; execute_updates may not be passing umbrella_info"
+    )
+    assert captured["force"] is True, (
+        f"Expected execute_self_update to receive force=True, got force={captured['force']!r}"
+    )
+
+
+def test_update_command_passes_umbrella_info_despite_no_git_updates():
+    """Regression: PyPI dep bumps must trigger the umbrella self-update.
+
+    Before the fix, check_umbrella_dependencies_for_updates() returned False
+    for PyPI version bumps (e.g. amplifier-core 1.5.1 → 1.5.2). The
+    has_umbrella_updates gate set it to False, which caused nothing_to_update
+    to be True, and execute_updates was never called. Users stayed stuck on
+    the old version with no error message.
+
+    After the fix, has_umbrella_updates=True whenever umbrella_info is
+    discovered, so execute_updates is always called with umbrella_info.
+    """
+    from click.testing import CliRunner
+
+    from amplifier_app_cli.commands.update import update
+    from amplifier_app_cli.utils.source_status import UpdateReport
+    from amplifier_app_cli.utils.update_executor import ExecutionResult
+
+    fake_info = UmbrellaInfo(
+        url="https://github.com/microsoft/amplifier",
+        ref="main",
+        commit_id=None,
+    )
+    captured: dict = {}
+
+    async def fake_execute_updates(
+        report, umbrella_info=None, progress_callback=None, force=False
+    ):
+        captured["umbrella_info"] = umbrella_info
+        captured["force"] = force
+        return ExecutionResult(success=True, updated=["amplifier"], messages=[])
+
+    # Simulates the bug condition: no git-sourced dep has updates,
+    # so the old check_umbrella_dependencies_for_updates returns False.
+    async def fake_check_umbrella_deps_false(info):
+        return False
+
+    empty_report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+
+    async def fake_check_all_sources(**kwargs):
+        return empty_report
+
+    async def fake_check_all_bundle_status():
+        return {}
+
+    async def fake_get_umbrella_dep_details(info):
+        return []
+
+    with (
+        patch(
+            "amplifier_app_cli.utils.umbrella_discovery.discover_umbrella_source",
+            return_value=fake_info,
+        ),
+        patch(
+            "amplifier_app_cli.utils.update_executor.check_umbrella_dependencies_for_updates",
+            side_effect=fake_check_umbrella_deps_false,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.check_all_sources",
+            side_effect=fake_check_all_sources,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update._check_all_bundle_status",
+            side_effect=fake_check_all_bundle_status,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update._get_umbrella_dependency_details",
+            side_effect=fake_get_umbrella_dep_details,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.execute_updates",
+            side_effect=fake_execute_updates,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update._refresh_skills_cache",
+            return_value=None,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.save_update_last_check",
+            return_value=None,
+        ),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(update, ["--yes"])
+
+    # If the command exited with an unexpected exception, surface it.
+    if result.exception and not isinstance(result.exception, SystemExit):
+        import traceback
+
+        raise AssertionError(
+            f"update command raised an exception:\n"
+            f"{''.join(traceback.format_exception(type(result.exception), result.exception, result.exception.__traceback__))}\n"
+            f"Output:\n{result.output}"
+        )
+
+    assert captured.get("umbrella_info") is not None, (
+        "execute_updates was called with umbrella_info=None (or was never called).\n"
+        "This means the PyPI-dep gate was NOT fixed — `amplifier update` still ignores\n"
+        "PyPI version bumps and reports 'All sources up to date' when only amplifier-core\n"
+        "(or another PyPI dep) has a newer version.\n"
+        f"captured={captured!r}\n"
+        f"Command output:\n{result.output}"
     )


### PR DESCRIPTION
## What

Fixes `amplifier update` silently failing to upgrade PyPI dependencies — most visibly, `amplifier-core 1.5.1 → 1.5.2`. Users on the previous release reported being stuck at 1.5.1 with `amplifier update` reporting `✓ All sources up to date` and `amplifier update --force` also failing to upgrade. The only working path was `amplifier reset`, which is destructive.

## Root cause

`check_umbrella_dependencies_for_updates()` in `utils/update_executor.py` is structurally PyPI-blind:

1. It enumerates deps only from `[tool.uv.sources]` (`fetch_umbrella_dependencies`), which by definition only contains git-sourced deps.
2. Even within `all_deps`, it explicitly `continue`s past any package whose `direct_url.json` lacks `vcs_info`.

`amplifier-core` is a normal PyPI install — never in `[tool.uv.sources]`, no `vcs_info`. It was structurally invisible to this check.

Because this function's return value gated whether `execute_self_update` ran, a PyPI version bump produced `has_umbrella_updates = False` → `nothing_to_update = True` → early return with `✓ All sources up to date`.

Separately, `amplifier update --force` was occasionally reported to also fail. Cause: `--upgrade`/`--reinstall` imply `--refresh`, but `--refresh` is a *conditional* revalidation that PyPI's CDN can defeat with a `304 Not Modified` during a release rollout window. `amplifier reset` works because `uv cache clean` is unconditional.

## Fix

Minimal, two files:

- **`commands/update.py`** — `has_umbrella_updates = True` whenever `umbrella_info` is discovered. Stop second-guessing uv; let it decide what (if anything) to upgrade. Cost: one `uv tool install` invocation per `amplifier update`; the alternative is silent staleness. The `check_umbrella_dependencies_for_updates` import is preserved (`# noqa: F401`) for potential future report-table use; a follow-up issue will rip it out alongside the broader cleanup of reimplementing uv's resolution.
- **`utils/update_executor.py`** — `execute_updates` and `execute_self_update` gain a `force: bool` parameter. When `force=True`, run `uv cache clean` before `uv tool install`. This mirrors what `amplifier reset` does (the only update path users currently report as reliable).

## Tests

4 new tests in `tests/test_update_executor.py`, TDD:

- `test_execute_self_update_force_runs_cache_clean` — verifies `uv cache clean` is the first subprocess call when `force=True`.
- `test_execute_self_update_no_force_skips_cache_clean` — verifies it is NOT called when `force=False`.
- `test_execute_updates_forwards_force_to_execute_self_update` — plumbing test.
- `test_update_command_passes_umbrella_info_despite_no_git_updates` — the regression: the old gate would set `umbrella_info=None` when `check_umbrella_dependencies_for_updates` returned `False`; the new code always passes it through.

Red-green verified in /verify mode: reverting the two source files in the working tree makes `test_update_command_passes_umbrella_info_despite_no_git_updates` fail with `AssertionError: assert None is not None`. Restoring the fix makes it pass.

Full suite: **856 passed in 0.80s**, zero regressions.
pyright: **0 errors, 0 warnings, 0 informations**.
ruff check + format: **All checks passed!** / `3 files already formatted`.

## End-to-end DTU verification

Stood up a Digital Twin Universe instance (`amplifier-tester-update-fix`) with the patched `amplifier-app-cli` served via Gitea mirror and `amplifier-core` resolving from real PyPI.

| Scenario | Setup | Action | Result |
|---|---|---|---|
| **A** | pin `amplifier-core==1.5.1` | `amplifier update --yes` | `core 1.5.1` → **`core 1.5.2`** ✓ |
| **B** | pin `amplifier-core==1.5.1` | `amplifier update --yes --force` | `core 1.5.1` → **`core 1.5.2`** ✓ |

`uv` cache delta on the `--force` path: **162M → 141M**, confirming the `uv cache clean` step fires.

## Out of scope

The broader cleanup — deleting `check_umbrella_dependencies_for_updates` / `fetch_umbrella_dependencies` / `fetch_library_git_dependencies` and switching to uv's own state as the source of truth for the report table — is intentionally **not** in this PR. It is a separate refactor about ownership and rendering, not a bug fix, and should not be coupled to a regression. A follow-up issue captures that work.

## Test plan

Reviewer should be able to reproduce locally without the DTU:

```bash
cd amplifier-app-cli
git checkout fix/update-pypi-deps-blind
uv run pytest tests/test_update_executor.py -v   # 5 passed
uv run pytest tests/                              # 856 passed
uv run pyright amplifier_app_cli/commands/update.py amplifier_app_cli/utils/update_executor.py
uv run ruff check amplifier_app_cli/ tests/test_update_executor.py
```