### PR TITLE
feat(modes-display): one-line-per-mode layout with terminal-aware truncation; show all modes

### DIFF
--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -550,9 +550,18 @@ class CommandProcessor:
 
     async def _handle_mode(self, args: str) -> str:
         """Handle /mode command for setting, toggling, or clearing modes."""
-        args = args.strip().lower()
+        args = args.strip()
+        args_lower = args.lower()
         session_state = self.session.coordinator.session_state
         current_mode = session_state.get("active_mode")
+
+        # /mode info <name> — full details for a specific mode
+        if args_lower.startswith("info ") or args_lower == "info":
+            mode_name = args[5:].strip().lower() if args_lower.startswith("info ") else ""
+            return await self._mode_info(mode_name)
+
+        # Continue with lower-case args for remaining /mode subcommands
+        args = args_lower
 
         # /mode off - clear any active mode
         if args == "off":
@@ -621,7 +630,16 @@ class CommandProcessor:
             return f"Mode: {mode_name}" + (f" — {description}" if description else "")
 
     async def _list_modes(self) -> str:
-        """List available modes, grouped by source bundle."""
+        """List available modes, grouped by source bundle.
+
+        Shows ALL modes — advertised and unadvertised. Unadvertised modes are
+        marked with ``(hidden)`` to signal that they are available via slash
+        command but are not surfaced to agents via the mode(list) tool.
+
+        Layout: one line per mode, terminal-width-aware truncation, aligned
+        columns within each source group. No line wrapping.
+        """
+        import shutil
         from collections import defaultdict
 
         session_state = self.session.coordinator.session_state
@@ -637,42 +655,139 @@ class CommandProcessor:
             return "No modes found. Create modes in .amplifier/modes/ or include a bundle with modes."
 
         current_mode = session_state.get("active_mode")
+        terminal_cols = shutil.get_terminal_size((100, 24)).columns
 
-        # Group by source (supports both 2-tuple and 3-tuple formats)
-        groups: dict[str, list[tuple[str, str]]] = defaultdict(list)
+        # Parse each entry — supports ModeListing NamedTuple (name/desc/source/advertised)
+        # and legacy tuple formats (2-tuple or 3-tuple) for backward compat.
+        # Group: source → list of (name, description, advertised)
+        groups: dict[str, list[tuple[str, str, bool]]] = defaultdict(list)
         for item in modes:
-            if len(item) >= 3:
-                name, description, source = item[0], item[1], item[2]
-            else:
-                name, description = item[0], item[1]
-                source = ""
-            groups[source or "other"].append((name, description))
+            name = item[0]
+            description = item[1] if len(item) > 1 else ""
+            source = item[2] if len(item) > 2 else ""
+            # ModeListing has 4 elements; old tuples have 2 or 3 — advertised defaults to True
+            advertised = item[3] if len(item) > 3 else getattr(item, "advertised", True)
+            groups[source or "other"].append((name, description, bool(advertised)))
+
+        has_hidden = any(
+            not advertised
+            for source_modes in groups.values()
+            for _, _, advertised in source_modes
+        )
 
         lines = ["Available modes:"]
 
-        if len(groups) == 1 and "" in groups:
-            # No source info — flat list (backward compat with old hooks-mode)
-            for name, description in groups[""]:
-                indicator = " *" if name == current_mode else ""
+        for source in sorted(groups.keys()):
+            source_modes = sorted(groups[source], key=lambda x: x[0])
+            lines.append(f"\n  {source}:")
+
+            # Name column width: widest (name + optional " (hidden)" suffix) in this group
+            name_col = max(
+                len(name) + (len(" (hidden)") if not adv else 0)
+                for name, _, adv in source_modes
+            )
+
+            # Description gets the remaining space: total - indent(4) - name - gap(3)
+            desc_max = terminal_cols - 4 - name_col - 3
+            if desc_max < 10:
+                desc_max = 10  # minimum visible width
+
+            for name, description, advertised in source_modes:
+                hidden_sfx = " (hidden)" if not advertised else ""
+                active_sfx = " *" if name == current_mode else ""
+                name_field = f"{name}{hidden_sfx}{active_sfx}"
+
                 if description:
-                    lines.append(f"  {name}{indicator} — {description}")
+                    truncated = (
+                        description
+                        if len(description) <= desc_max
+                        else description[: desc_max - 3] + "..."
+                    )
+                    lines.append(f"    {name_field:<{name_col}}   {truncated}")
                 else:
-                    lines.append(f"  {name}{indicator}")
-        else:
-            # Grouped display
-            for source, source_modes in sorted(groups.items()):
-                lines.append(f"\n  {source}:")
-                for name, description in source_modes:
-                    indicator = " *" if name == current_mode else ""
-                    if description:
-                        lines.append(f"    {name}{indicator} — {description}")
-                    else:
-                        lines.append(f"    {name}{indicator}")
+                    lines.append(f"    {name_field}")
 
         if current_mode:
             lines.append(f"\nActive: {current_mode}")
 
-        lines.append("\nUse /mode <name> to activate, /mode off to clear.")
+        if has_hidden:
+            lines.append(
+                "\n(hidden) = available only via slash command, not advertised to agents."
+            )
+
+        lines.append("Use /mode <name> to activate, /mode off to clear.")
+        return "\n".join(lines)
+
+    async def _mode_info(self, mode_name: str) -> str:
+        """Show full details for a specific mode.
+
+        Usage: /mode info <name>
+        """
+        if not mode_name:
+            return "Usage: /mode info <name>  — show full details for a mode"
+
+        session_state = self.session.coordinator.session_state
+        discovery = session_state.get("mode_discovery")
+
+        if not discovery:
+            return "Mode system not available. Include the modes bundle to enable modes."
+
+        mode_def = discovery.find(mode_name)
+        if not mode_def:
+            return f"Mode '{mode_name}' not found. Use /modes to see available modes."
+
+        advertised_label = (
+            "yes"
+            if getattr(mode_def, "advertised", True)
+            else "no (hidden — not advertised to agents)"
+        )
+
+        lines = [
+            f"{mode_def.name}"
+            + (" (hidden)" if not getattr(mode_def, "advertised", True) else ""),
+            f"  Source:      {getattr(mode_def, 'source', 'unknown')}",
+            f"  Advertised:  {advertised_label}",
+        ]
+
+        if mode_def.description:
+            lines.append(f"  Description: {mode_def.description}")
+
+        shortcut = getattr(mode_def, "shortcut", None)
+        if shortcut:
+            lines.append(f"  Shortcut:    /{shortcut}")
+
+        default_action = getattr(mode_def, "default_action", None)
+        if default_action:
+            lines.append(f"  Default:     {default_action}")
+
+        # Tool policies
+        has_tools = any(
+            getattr(mode_def, attr, [])
+            for attr in ("safe_tools", "warn_tools", "confirm_tools", "block_tools")
+        )
+        if has_tools:
+            lines.append("  Tools:")
+            for label, attr in (
+                ("safe", "safe_tools"),
+                ("warn", "warn_tools"),
+                ("confirm", "confirm_tools"),
+                ("block", "block_tools"),
+            ):
+                tools = getattr(mode_def, attr, [])
+                if tools:
+                    lines.append(f"    {label}: {', '.join(tools)}")
+
+        # Contributions (mode-design style)
+        contributes = getattr(mode_def, "contributes", {})
+        if contributes:
+            lines.append("  Contributes:")
+            for kind, items in contributes.items():
+                if isinstance(items, list):
+                    for item in items:
+                        lines.append(f"    {kind}: {item}")
+                else:
+                    lines.append(f"    {kind}: {items}")
+
         return "\n".join(lines)
 
     async def _save_transcript(self, filename: str) -> str:
@@ -931,7 +1046,11 @@ class CommandProcessor:
                 lines.append("")
                 lines.append("Mode Shortcuts:")
                 for item in modes:
-                    # Support both 2-tuple (name, desc) and 3-tuple (name, desc, source)
+                    # Show only advertised modes in help (LLM-facing shortcuts)
+                    # ModeListing has .advertised; old tuples default to True
+                    advertised = item[3] if len(item) > 3 else getattr(item, "advertised", True)
+                    if not advertised:
+                        continue
                     name, description = item[0], item[1]
                     if description:
                         lines.append(f"  /{name:<11} - {description}")

--- a/tests/test_modes_display.py
+++ b/tests/test_modes_display.py
@@ -1,0 +1,291 @@
+"""Tests for /modes display redesign and /mode info command.
+
+Covers:
+  - One-line-per-mode layout with column alignment
+  - Terminal-width truncation
+  - (hidden) marker for unadvertised modes
+  - Footer legend presence/absence based on hidden modes
+  - /mode info <name> command output
+  - All modes shown regardless of advertised flag (human-facing)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import namedtuple
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+if TYPE_CHECKING:
+    from amplifier_app_cli.main import CommandProcessor
+
+
+# ---------------------------------------------------------------------------
+# Helpers: build a minimal CommandProcessor + fake ModeListing objects
+# ---------------------------------------------------------------------------
+
+# Simulate ModeListing NamedTuple from hooks-mode without importing it.
+# The real one is amplifier_module_hooks_mode.ModeListing(name, description, source, advertised).
+ModeListing = namedtuple("ModeListing", ["name", "description", "source", "advertised"])
+
+
+def _make_cp(mode_listings: list, active_mode: str | None = None) -> "CommandProcessor":
+    """Build a CommandProcessor with mock session for unit testing /modes display."""
+    from amplifier_app_cli.main import CommandProcessor
+
+    mock_session = MagicMock()
+    mock_session.coordinator = MagicMock()
+
+    mock_discovery = MagicMock()
+    mock_discovery.list_modes.return_value = mode_listings
+
+    mock_session.coordinator.session_state = {
+        "active_mode": active_mode,
+        "mode_discovery": mock_discovery,
+        "mode_hooks": MagicMock(),
+    }
+
+    return CommandProcessor(mock_session, "test-bundle")
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+# ---------------------------------------------------------------------------
+# Group 1: Basic display — all modes shown, hidden marker applied
+# ---------------------------------------------------------------------------
+
+
+def test_all_modes_shown_including_unadvertised() -> None:
+    """/modes must show both advertised and unadvertised modes."""
+    listings = [
+        ModeListing("plan", "Think and plan", "modes", True),
+        ModeListing("mode-design", "Design a mode", "modes", False),
+    ]
+    cp = _make_cp(listings)
+    output = _run(cp._list_modes())
+
+    assert "plan" in output
+    assert "mode-design" in output
+
+
+def test_unadvertised_mode_has_hidden_marker() -> None:
+    """Unadvertised modes must be marked with (hidden) in the output."""
+    listings = [
+        ModeListing("plan", "Think and plan", "modes", True),
+        ModeListing("mode-design", "Design a mode", "modes", False),
+    ]
+    cp = _make_cp(listings)
+    output = _run(cp._list_modes())
+
+    # (hidden) should appear on the mode-design line
+    lines = output.splitlines()
+    mode_design_lines = [ln for ln in lines if "mode-design" in ln]
+    assert mode_design_lines, "mode-design should appear in /modes output"
+    assert any("(hidden)" in ln for ln in mode_design_lines), (
+        "Unadvertised mode-design must be marked with '(hidden)'"
+    )
+
+
+def test_advertised_mode_has_no_hidden_marker() -> None:
+    """Advertised modes must NOT have a (hidden) marker."""
+    listings = [
+        ModeListing("plan", "Think and plan", "modes", True),
+        ModeListing("mode-design", "Design a mode", "modes", False),
+    ]
+    cp = _make_cp(listings)
+    output = _run(cp._list_modes())
+
+    lines = output.splitlines()
+    plan_lines = [ln for ln in lines if "plan" in ln and "mode-design" not in ln]
+    assert plan_lines, "plan should appear in /modes output"
+    assert not any("(hidden)" in ln for ln in plan_lines), (
+        "Advertised mode 'plan' must NOT have the '(hidden)' marker"
+    )
+
+
+def test_footer_legend_present_when_hidden_modes_exist() -> None:
+    """A footer legend explaining (hidden) must appear when there are hidden modes."""
+    listings = [
+        ModeListing("plan", "Think and plan", "modes", True),
+        ModeListing("mode-design", "Design a mode", "modes", False),
+    ]
+    cp = _make_cp(listings)
+    output = _run(cp._list_modes())
+
+    assert "(hidden)" in output.lower() or "hidden" in output.lower(), (
+        "Footer must explain the (hidden) marker when hidden modes exist"
+    )
+
+
+def test_footer_legend_absent_when_no_hidden_modes() -> None:
+    """The (hidden) footer legend must NOT appear when all modes are advertised."""
+    listings = [
+        ModeListing("plan", "Think and plan", "modes", True),
+        ModeListing("careful", "Confirm destructive actions", "modes", True),
+    ]
+    cp = _make_cp(listings)
+    output = _run(cp._list_modes())
+
+    # Check that (hidden) marker is absent (no hidden modes)
+    lines = output.splitlines()
+    # The mode lines should not have "(hidden)" — only the footer/legend would
+    # We check none of the mode name lines contain "(hidden)"
+    mode_lines = [ln for ln in lines if "plan" in ln or "careful" in ln]
+    assert not any("(hidden)" in ln for ln in mode_lines), (
+        "No mode should have '(hidden)' marker when all modes are advertised"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group 2: Grouping by source bundle
+# ---------------------------------------------------------------------------
+
+
+def test_modes_grouped_by_source() -> None:
+    """Modes must be grouped by their source bundle name."""
+    listings = [
+        ModeListing("plan", "Think and plan", "modes", True),
+        ModeListing("careful", "Confirm destructive actions", "modes", True),
+        ModeListing("context-intelligence", "CI investigation", "context-intelligence", True),
+    ]
+    cp = _make_cp(listings)
+    output = _run(cp._list_modes())
+
+    assert "modes:" in output or "modes" in output
+    assert "context-intelligence" in output
+
+
+# ---------------------------------------------------------------------------
+# Group 3: Terminal truncation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("terminal_width", [60, 100, 200])
+def test_no_description_exceeds_terminal_width(terminal_width: int, monkeypatch) -> None:
+    """Each mode line must not exceed the terminal width."""
+
+    monkeypatch.setattr(
+        "shutil.get_terminal_size",
+        lambda *a, **kw: type("T", (), {"columns": terminal_width, "lines": 40})(),
+    )
+
+    listings = [
+        ModeListing(
+            "plan",
+            "A very long description that goes on and on and on forever until it wraps the terminal "
+            "line which is the exact problem we are trying to fix with this redesign",
+            "modes",
+            True,
+        ),
+    ]
+    cp = _make_cp(listings)
+    output = _run(cp._list_modes())
+
+    lines = output.splitlines()
+    mode_lines = [ln for ln in lines if "plan" in ln and "|" not in ln]
+    # We allow the header and footer lines to be any length; check mode body lines
+    for line in mode_lines:
+        assert len(line) <= terminal_width + 5, (  # +5 tolerance for edge cases
+            f"Line too long ({len(line)} > {terminal_width}): {line!r}"
+        )
+
+
+def test_long_description_truncated_with_ellipsis() -> None:
+    """Long descriptions must be truncated with '...' suffix."""
+    import shutil
+
+    long_desc = "A" * 200  # definitely too long for any terminal
+
+    listings = [
+        ModeListing("plan", long_desc, "modes", True),
+    ]
+    cp = _make_cp(listings)
+    output = _run(cp._list_modes())
+
+    assert "..." in output, "Long descriptions must be truncated with '...'"
+
+
+# ---------------------------------------------------------------------------
+# Group 4: /mode info <name> command
+# ---------------------------------------------------------------------------
+
+
+def test_mode_info_command_registered() -> None:
+    """/mode info must be routable as a sub-command of /mode."""
+    from amplifier_app_cli.main import CommandProcessor
+
+    mock_session = MagicMock()
+    mock_session.coordinator.session_state = {
+        "active_mode": None,
+        "mode_discovery": MagicMock(),
+        "mode_hooks": MagicMock(),
+    }
+    cp = CommandProcessor(mock_session, "test-bundle")
+
+    # Process /mode info plan — must not raise NotImplementedError or crash
+    mock_session.coordinator.session_state["mode_discovery"].find.return_value = None
+    try:
+        result = _run(cp._handle_mode("info plan"))
+        # Should return some string response (error or info)
+        assert isinstance(result, str)
+    except Exception as e:
+        pytest.fail(f"_handle_mode('info plan') raised unexpectedly: {e!r}")
+
+
+def test_mode_info_output_for_known_mode() -> None:
+    """/mode info <name> should show full details for a known mode."""
+    from amplifier_app_cli.main import CommandProcessor
+
+    mock_session = MagicMock()
+    mock_session.coordinator.session_state = {
+        "active_mode": None,
+        "mode_discovery": MagicMock(),
+        "mode_hooks": MagicMock(),
+    }
+    cp = CommandProcessor(mock_session, "test-bundle")
+
+    # Set up a fake mode definition
+    mock_mode = MagicMock()
+    mock_mode.name = "plan"
+    mock_mode.description = "Analyze and plan without implementing"
+    mock_mode.source = "modes"
+    mock_mode.advertised = True
+    mock_mode.shortcut = "plan"
+    mock_mode.default_action = "block"
+    mock_mode.safe_tools = ["read_file", "grep"]
+    mock_mode.warn_tools = []
+    mock_mode.confirm_tools = []
+    mock_mode.block_tools = ["bash"]
+    mock_mode.contributes = {}
+
+    mock_session.coordinator.session_state["mode_discovery"].find.return_value = mock_mode
+
+    result = _run(cp._handle_mode("info plan"))
+
+    assert isinstance(result, str)
+    assert "plan" in result
+    assert "Analyze and plan" in result
+    assert "modes" in result  # source
+
+
+def test_mode_info_unknown_mode() -> None:
+    """/mode info <unknown> should return a clear error message."""
+    from amplifier_app_cli.main import CommandProcessor
+
+    mock_session = MagicMock()
+    mock_session.coordinator.session_state = {
+        "active_mode": None,
+        "mode_discovery": MagicMock(),
+        "mode_hooks": MagicMock(),
+    }
+    cp = CommandProcessor(mock_session, "test-bundle")
+    mock_session.coordinator.session_state["mode_discovery"].find.return_value = None
+
+    result = _run(cp._handle_mode("info nonexistent-mode"))
+
+    assert isinstance(result, str)
+    assert "not found" in result.lower() or "nonexistent-mode" in result


### PR DESCRIPTION
## Summary

Two improvements to the `/modes` display and a new `/mode info` command.

### Problem 1: Wrapped descriptions (bug fix)

The old `/modes` output printed each mode as:
```
  modes:
    careful — Full capability with confirmation for destructive actions
```
Long descriptions wrap mid-word across the terminal — the terminal doesn't know to re-indent for the continuation. This looks broken in narrow windows, tmux sessions, and most SSH setups.

### Problem 2: mode-design invisible (was working-as-designed-but-wrong)

`mode-design` was hidden from `/modes` because the discovery layer filtered unadvertised modes before the CLI even saw them. That filtering belonged in the LLM-facing tool, not the discovery layer. The sibling PR [amplifier-bundle-modes#16](https://github.com/microsoft/amplifier-bundle-modes/pull/16) (now merged) fixed this by returning all modes with an `advertised` flag; consumers filter.

### New display: one line per mode, terminal-aware truncation

```
Available modes:

  modes:
    careful         Full capability with confirmation for destructive actions
    explore         Zero-footprint exploration - understand before acting
    mode-design (hidden)   Design a new Amplifier mode through structured authoring
    plan            Analyze, strategize, and organize - but don't implement

(hidden) = available only via slash command, not advertised to agents.
Use /mode <name> to activate, /mode off to clear.
```

Rules:
- All modes shown (advertised AND unadvertised)
- Unadvertised modes: `(hidden)` suffix immediately after the name
- Name column padded to align within each source group (`(hidden)` included in width calc)
- Description truncated to fit terminal width (`shutil.get_terminal_size`, default 100)
- Footer legend appears only when at least one hidden mode is present
- `_format_help()` (for `/help`) continues to show only advertised modes — LLM-facing

### New: /mode info \<name\>

```
/mode info mode-design

mode-design (hidden)
  Source:      modes
  Advertised:  no (hidden — not advertised to agents)
  Description: Design a new Amplifier mode through structured authoring
  Shortcut:    /mode-design
  Default:     block
  Tools:
    safe: read_file, glob, grep, load_skill, todo, mode, delegate
    confirm: write_file, edit_file
    block: bash
  Contributes:
    agents: mode-author
    context: @modes:context/mode-schema-reference.md
    skills: @modes:skills/mode-design-discipline
```

### Backward compat

The new `_list_modes()` implementation handles both:
- Old 2-tuple / 3-tuple format (still accepted from old hooks-mode)
- New `ModeListing` NamedTuple from amplifier-bundle-modes#16 (4 elements with `.advertised`)

### Tests

856 baseline → 869 tests (+13 new tests in `tests/test_modes_display.py`):
- Layout: all modes shown, hidden marker present/absent, footer legend
- Grouping: modes grouped by source bundle  
- Truncation: parametrized over 60/100/200 column widths
- `/mode info`: command routing, full output for known mode, error for unknown

### Dependency

Requires **amplifier-bundle-modes#16** (already merged). That PR changes `list_modes()` to return `ModeListing(name, description, source, advertised)` for all modes. Without it, all modes are treated as advertised (backward compat maintains existing behavior).