### PR TITLE
docs: document spawn-time precedence policy

### DIFF
--- a/amplifier_app_cli/session_spawner.py
+++ b/amplifier_app_cli/session_spawner.py
@@ -211,6 +211,10 @@ async def spawn_sub_session(
     """
     Spawn sub-session with agent configuration overlay.
 
+    Precedence policy (this app's choice, not a kernel contract): see
+    ``docs/SPAWN_PRECEDENCE.md``. Other apps that register the
+    ``session.spawn`` capability may use different precedence.
+
     Args:
         agent_name: Name of agent from configuration
         instruction: Task for agent to execute

--- a/docs/SPAWN_PRECEDENCE.md
+++ b/docs/SPAWN_PRECEDENCE.md
@@ -14,6 +14,8 @@ slot; it does not enforce a precedence.
 | 2    | Agent overlay's `provider_preferences`            | Either (a) hard-pinned in the agent's `.md` frontmatter, OR (b) written by a routing hook's `session:start` event handler (e.g. `amplifier-bundle-routing-matrix` does this when the frontmatter declares `model_role`). Used only when rank 1 is not present. |
 | 3    | Parent session's mount-plan defaults              | From the user's `settings.yaml` — provider priority order + each provider's `default_model`. Used when no preferences are supplied at ranks 1 or 2.                                                                                                            |
 
+**The dual-source design at Rank 2 is intentional.** Frontmatter `provider_preferences:` is the bundle-portable fallback that flows through unchanged when no routing bundle is installed. When a routing bundle (such as `amplifier-bundle-routing-matrix`) IS installed, its `session:start` hook may overwrite that value with resolution from `model_role:`. The two fields together support graceful degradation — agents work everywhere; routing bundles enhance when present.
+
 ## How the application mechanism works
 
 When a non-None `provider_preferences` value is in play (caller-passed OR

--- a/docs/SPAWN_PRECEDENCE.md
+++ b/docs/SPAWN_PRECEDENCE.md
@@ -1,0 +1,81 @@
+# Spawn-Time Precedence Policy
+
+This document describes the spawn-time precedence policy implemented by
+`session_spawner.spawn_sub_session` in this app. The precedence is **policy,
+not contract** — other apps that register the `session.spawn` capability MAY
+choose different precedence semantics. The kernel only provides the capability
+slot; it does not enforce a precedence.
+
+## The three levels (highest wins)
+
+| Rank | Source                                            | How it enters `spawn_sub_session`                                                                                                                                                                                                                                |
+| ---- | ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1    | Caller-passed `provider_preferences` argument     | Explicit kwarg to `spawn_fn(...)` from `tool-delegate` / `tool-recipes` / `tool-skills`. Wins over everything else.                                                                                                                                            |
+| 2    | Agent overlay's `provider_preferences`            | Either (a) hard-pinned in the agent's `.md` frontmatter, OR (b) written by a routing hook's `session:start` event handler (e.g. `amplifier-bundle-routing-matrix` does this when the frontmatter declares `model_role`). Used only when rank 1 is not present. |
+| 3    | Parent session's mount-plan defaults              | From the user's `settings.yaml` — provider priority order + each provider's `default_model`. Used when no preferences are supplied at ranks 1 or 2.                                                                                                            |
+
+## How the application mechanism works
+
+When a non-None `provider_preferences` value is in play (caller-passed OR
+the fallback read from `agent_config`), `spawn_sub_session` invokes:
+
+```python
+merged_config = await apply_provider_preferences_with_resolution(
+    merged_config, provider_preferences, parent_session.coordinator
+)
+```
+
+This function lives in `amplifier_foundation.spawn_utils`. It walks the
+preference list in order, finds the first matching entry in
+`merged_config["providers"]`, promotes it to `priority: 0`, overrides
+`default_model` to the resolved model name, and protects sensitive keys per
+`PROTECTED_CONFIG_KEYS`. See foundation's `spawn_utils.py` for the precise
+semantics — including how glob patterns in `model:` fields are resolved.
+
+When `provider_preferences` is `None` and the agent overlay has no
+`provider_preferences` field either, the merged config is left as-is. The
+sub-session then inherits the parent's mount-plan defaults: provider priority
+order from `settings.yaml` and each provider's configured `default_model`.
+
+## Defense-in-depth: the agent-config fallback
+
+If the caller doesn't pass a `provider_preferences` argument,
+`spawn_sub_session` reads `agent_config["provider_preferences"]` and uses
+that. This is the mechanism by which routing-hook writes at `session:start`
+flow through to the spawn even when the caller is a direct consumer of the
+spawn capability that doesn't know about routing.
+
+Concretely: `tool-delegate` normally reads agent-level prefs itself and passes
+them as an explicit kwarg, so its path doesn't depend on this fallback. But a
+direct consumer of `coordinator.get_capability("session.spawn")` that simply
+forwards `agent_name + instruction` still gets routing-resolved preferences
+because the spawner picks them up from the merged agent config.
+
+## This is policy, not contract
+
+Another app embedding Amplifier can register its own `session.spawn`
+capability with a different policy. For example:
+
+- **Always prefer agent-overlay prefs over caller-passed.** The opposite of
+  this app — useful if an embedding wants the agent author to have final say.
+- **Never apply prefs; always inherit parent defaults.** Strips out
+  agent-level routing entirely for hosts that want strict centralized control.
+- **Merge instead of clobber.** Append matrix-resolved candidates after
+  hard-pinned ones rather than replacing.
+
+The kernel doesn't enforce any precedence. The capability contract is just
+"spawn a sub-session" — what each implementation does with provider preferences
+is its own choice.
+
+## Cross-references
+
+- `amplifier_app_cli/session_spawner.py` — reference implementation of
+  `session.spawn` for this app.
+- `amplifier_foundation.spawn_utils` — `ProviderPreference` data class and
+  `apply_provider_preferences_with_resolution` (the actual mechanism this
+  policy invokes).
+- `amplifier-bundle-routing-matrix` README — documents the matrix-strategy
+  resolver and the `session:start` write that populates rank 2 (b) above.
+- `tool-delegate/__init__.py` — delegate-level precedence: an explicit
+  `provider_preferences` argument to the delegate tool wins over its
+  `model_role` argument. Both eventually flow into spawn rank 1.


### PR DESCRIPTION
# Summary

Part of a coordinated 3-repo PR set that documents the spawn-time and resolver-time precedence policies that emerged from the recent `model_role_resolver` capability rename. No behavior change in any of the three — these are docs + dead-config cleanup.

# Context

After landing the `routing_matrix` → `model_role_resolver` rename (the prior 5-PR set), an audit surfaced that:

1. Spawn-time precedence (caller-passed prefs > agent overlay > parent defaults) was implicit in code comments + one test, never documented.
2. `hooks-routing.on_session_start` overwrites `agent_cfg["provider_preferences"]` with matrix-resolved values whenever `model_role` is declared — intentional matrix-strategy behavior, never documented.
3. Most foundation agents declared BOTH `model_role:` and `provider_preferences:` — the latter was being silently overwritten every session. Dead config.

The implicit precedence is intentional. The user's framing (per session discussion):

> Hard-pinned `provider_preferences` is the fallback when `model_role` isn't set. When `model_role` is set, the matrix wins — that's the whole point of the matrix strategy. Authors who want a fixed pin should omit `model_role`.

This PR set codifies that contract in the appropriate place per repo ownership:
- The **spawner** (app-cli) owns spawn-time precedence policy.
- The **matrix-strategy bundle** (routing-matrix) owns the clobber policy. Future routing-strategy bundles registering `model_role_resolver` MAY choose different interaction semantics.
- The **foundation agent set** is updated to match the documented invariant.

# Cross-repo PR set

- microsoft/amplifier-app-cli#??? — spawn-time precedence doc
- microsoft/amplifier-bundle-routing-matrix#??? — clobber policy doc
- microsoft/amplifier-foundation#??? — dead-config cleanup

Merge order doesn't matter (no consumer breaks). Land together for clarity.

# What changed in this repo

**Spawn-time precedence documentation.**

- **NEW**: `docs/SPAWN_PRECEDENCE.md` (81 lines, 569 words) — documents the 3-level precedence policy implemented by `session_spawner.spawn_sub_session`:
  1. Caller-passed `provider_preferences` kwarg (highest)
  2. Agent overlay `provider_preferences` (hard-pinned frontmatter OR routing-hook `session:start` write)
  3. Parent session mount-plan defaults (user settings.yaml)

  Documents the `apply_provider_preferences_with_resolution` mechanism and the defense-in-depth fallback. Cross-references foundation's `spawn_utils` and the routing-matrix bundle's matrix-strategy docs. Explicit note that precedence is policy, not kernel contract — alternative apps registering `session.spawn` may use different policies.

- **MODIFIED**: `amplifier_app_cli/session_spawner.py` — 4-line docstring note at the top of `spawn_sub_session(...)` pointing to the new doc.

# Verification

Docs-only change. No tests required.

# Follow-up

After this set merges, plan is to empirically verify the documented precedence via context-intelligence graph queries on a DTU session — check `provider:request` events against the documented contract to confirm the implementation matches the words. That's a separate dispatch, not part of this PR set.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
