### PR TITLE
fix(session-spawner): propagate runtime overlay agents and skill capability to child sessions (#233)

### DIFF
--- a/amplifier_app_cli/session_spawner.py
+++ b/amplifier_app_cli/session_spawner.py
@@ -3,6 +3,7 @@
 Implements sub-session creation with configuration inheritance and overlays.
 """
 
+import copy
 import logging
 import sys
 from pathlib import Path
@@ -10,6 +11,7 @@ from pathlib import Path
 from amplifier_core import AmplifierSession
 from amplifier_foundation import generate_sub_session_id
 from amplifier_foundation import bridge_child_cost
+from amplifier_foundation import RUNTIME_SKILL_OVERLAY_CAPABILITY
 
 from .agent_config import merge_configs
 
@@ -258,6 +260,35 @@ async def spawn_sub_session(
     # Merge parent config with agent overlay
     merged_config = merge_configs(parent_session.config, agent_config)
 
+    # === Issue #233 fix: propagate live agent registry to child ===
+    #
+    # parent_session.config is the STATIC snapshot captured at session-init.
+    # Runtime additions (mode contributions via RuntimeOverlay) live in
+    # parent_session.coordinator.config["agents"] and are NOT in the static
+    # snapshot. Without this propagation, mode-contributed agents cannot
+    # delegate to same-mode siblings.
+    #
+    # Design: read coordinator.config directly (source of truth), not from
+    # any caller-supplied parameter. This ensures the fix works regardless
+    # of which code path invoked spawn (tool-delegate, recipe orchestrator,
+    # programmatic spawn, etc.). Local (agent_config) declarations win over
+    # inherited live registry — never overwrite.
+    #
+    # Snapshot semantics: child gets a deep-copy at spawn time. Subsequent
+    # mode changes in the parent do NOT propagate to an already-running child.
+    parent_coord = getattr(parent_session, "coordinator", None)
+    if parent_coord is not None:
+        try:
+            live_agents = (parent_coord.config or {}).get("agents") or {}
+        except AttributeError:
+            live_agents = {}
+        if live_agents:
+            child_agents = merged_config.setdefault("agents", {})
+            for name, cfg in live_agents.items():
+                if name not in child_agents:
+                    child_agents[name] = copy.deepcopy(cfg)
+    # === end issue #233 fix (agents) ===
+
     # Apply tool inheritance filtering if specified
     if tool_inheritance and "tools" in merged_config:
         # Get agent's explicit tool modules to preserve them
@@ -482,6 +513,33 @@ async def spawn_sub_session(
     # Initialize child session (mounts modules per merged config)
     # Now the resolver is available for loading modules with source: directives
     await child_session.initialize()
+
+    # === Issue #233 fix: propagate runtime_skill_overlay capability ===
+    #
+    # Mode-contributed skills are registered as a coordinator capability
+    # (RUNTIME_SKILL_OVERLAY_CAPABILITY) rather than in static config.
+    # tool-skills in a sub-session reads its OWN coordinator's capability,
+    # which is empty unless we propagate from parent here.
+    #
+    # Note: RUNTIME_CONTEXT_OVERLAY_CAPABILITY is intentionally NOT propagated.
+    # Mode-contributed context belongs to "the mode is active here" — that state
+    # is root-session only (hooks-mode's provider:request handler lives there).
+    # Skills are different: they're discoverable resources, not mode state.
+    child_coord = getattr(child_session, "coordinator", None)
+    if parent_coord is not None and child_coord is not None:
+        try:
+            overlay_skills = parent_coord.get_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY)
+        except (AttributeError, KeyError):
+            overlay_skills = None
+        if overlay_skills:
+            try:
+                child_coord.register_capability(
+                    RUNTIME_SKILL_OVERLAY_CAPABILITY,
+                    list(overlay_skills),  # snapshot copy
+                )
+            except AttributeError:
+                pass  # child coordinator without capability support; safe to skip
+    # === end issue #233 fix (skill capability) ===
 
     # Note: Parent context inheritance is now handled by tool-task formatting
     # the parent messages directly into the instruction text. This ensures the

--- a/tests/test_session_spawner_issue_233.py
+++ b/tests/test_session_spawner_issue_233.py
@@ -1,0 +1,425 @@
+"""Issue #233 regression tests: runtime overlay propagation in spawn_sub_session.
+
+Verifies that mode-contributed agents and skill capabilities in the parent's
+LIVE coordinator state are visible to spawned child sessions.
+
+ROOT CAUSE (confirmed by bug-hunter):
+  - merge_configs(parent_session.config, agent_config) reads from the STATIC
+    session-init snapshot. Mode-contributed agents live only in
+    parent_session.coordinator.config["agents"] (the live registry).
+  - Without the fix, same-mode siblings cannot delegate to each other even
+    if they were contributed by the same mode activation.
+
+SCENARIOS:
+  S1 — top-level baseline (regression guard): parent has bundle-declared
+       agents in session.config; child must see them (never broken).
+  S2 — same-mode siblings (headline bug): mode contributes agents A and B
+       in coordinator.config (not in session.config); spawning A must give
+       child visibility of B.
+  S3 — mixed: parent has X in session.config, mode contributes A in
+       coordinator.config; spawning A; child sees both X and A.
+  S4 — caller-independence: spawn called programmatically (not via
+       tool-delegate); same expectations as S2 — fix must not rely on
+       caller passing extra context.
+  S5 — skill capability propagation: parent's coordinator has
+       runtime_skill_overlay capability; child coordinator inherits it.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from amplifier_foundation import RUNTIME_SKILL_OVERLAY_CAPABILITY
+
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_parent_session(
+    session_config_agents: dict | None = None,
+    coordinator_config_agents: dict | None = None,
+    coordinator_skills_capability: list | None = None,
+) -> MagicMock:
+    """Build a MagicMock parent session with configurable agent visibility.
+
+    Args:
+        session_config_agents:     Agents in the STATIC session.config snapshot.
+        coordinator_config_agents: Agents in the LIVE coordinator.config registry.
+                                   These are mode-contributed agents that are NOT
+                                   in the static snapshot.
+        coordinator_skills_capability: Skills registered in coordinator via
+                                       runtime_skill_overlay capability.
+    """
+    parent = MagicMock()
+
+    # Static session config snapshot (what merge_configs reads from)
+    static_agents = dict(session_config_agents or {})
+    parent.config = {
+        "agents": static_agents,
+        "session": {"orchestrator": "loop-basic"},
+    }
+
+    # Live coordinator config (what RuntimeOverlay writes to)
+    live_agents = dict(coordinator_config_agents or {})
+    parent.coordinator = MagicMock()
+    parent.coordinator.config = {"agents": live_agents}
+
+    # Capability store on coordinator
+    cap_store: dict = {}
+    if coordinator_skills_capability is not None:
+        cap_store[RUNTIME_SKILL_OVERLAY_CAPABILITY] = list(coordinator_skills_capability)
+
+    def _get_capability(name: str):
+        return cap_store.get(name)
+
+    parent.coordinator.get_capability = MagicMock(side_effect=_get_capability)
+
+    # Other attributes spawn_sub_session accesses
+    parent.session_id = "parent-session-id"
+    parent.coordinator.display_system = MagicMock()
+    parent.coordinator.approval_system = MagicMock()
+    parent.coordinator.cancellation = MagicMock()
+    parent.coordinator.cancellation.register_child = MagicMock()
+    parent.coordinator.cancellation.unregister_child = MagicMock()
+    parent.coordinator.get = MagicMock(return_value=None)
+    parent.loader = None
+
+    return parent
+
+
+def _make_child_session_mock() -> MagicMock:
+    """Build a MagicMock child session for AmplifierSession() return value."""
+    child = MagicMock()
+    child.session_id = "child-session-id"
+
+    # Capability store on child coordinator
+    cap_store: dict = {}
+
+    def _register_capability(name: str, value) -> None:
+        cap_store[name] = value
+
+    def _get_capability(name: str):
+        return cap_store.get(name)
+
+    child.coordinator = MagicMock()
+    child.coordinator.register_capability = MagicMock(side_effect=_register_capability)
+    child.coordinator.get_capability = MagicMock(side_effect=_get_capability)
+    child.coordinator.get = MagicMock(return_value=None)
+    child.coordinator.cancellation = MagicMock()
+    child.coordinator.mount = AsyncMock()
+    child.coordinator.display_system = MagicMock()
+    child.coordinator.hooks = MagicMock()
+    child.coordinator.hooks.emit = AsyncMock()
+    child.coordinator.hooks.register = MagicMock(return_value=MagicMock())
+    child.initialize = AsyncMock()
+    child.execute = AsyncMock(return_value="agent output")
+    child.cleanup = AsyncMock()
+    child.coordinator.approval_system = MagicMock()
+
+    return child
+
+
+async def _run_spawn(
+    parent_session: MagicMock,
+    agent_configs: dict,
+    child_session_mock: MagicMock,
+    agent_name: str = "mode_agent_A",
+    captured_config: dict | None = None,
+) -> MagicMock:
+    """Run spawn_sub_session with all heavy dependencies mocked.
+
+    Returns the child_session mock for inspection.
+    Optionally captures the merged_config passed to AmplifierSession constructor.
+    """
+    from amplifier_app_cli.session_spawner import spawn_sub_session
+
+    def _make_session(config, **kwargs):
+        if captured_config is not None:
+            captured_config.clear()
+            captured_config.update(config)
+        return child_session_mock
+
+    # Patch all heavy dependencies so the test runs fast and deterministically.
+    # Key: we capture 'config' in _make_session to inspect agents propagation.
+    # AmplifierSession is imported at module level in session_spawner.py, so
+    # we patch it in the session_spawner module namespace.
+    with (
+        patch("amplifier_app_cli.session_spawner.AmplifierSession", side_effect=_make_session),
+        patch(
+            "amplifier_app_cli.session_spawner.generate_sub_session_id",
+            return_value="child-session-id",
+        ),
+        patch(
+            "amplifier_app_cli.session_spawner.bridge_child_cost",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "amplifier_app_cli.session_spawner._extract_bundle_context",
+            return_value=None,
+        ),
+        patch("amplifier_app_cli.session_store.SessionStore"),
+        patch(
+            "amplifier_app_cli.lib.mention_loading.app_resolver.AppMentionResolver"
+        ),
+        patch(
+            "amplifier_app_cli.paths.create_foundation_resolver",
+            return_value=MagicMock(),
+        ),
+        patch("amplifier_foundation.mentions.ContentDeduplicator"),
+    ):
+        await spawn_sub_session(
+            agent_name=agent_name,
+            instruction="Do something",
+            parent_session=parent_session,
+            agent_configs=agent_configs,
+        )
+
+    return child_session_mock
+
+
+# ---------------------------------------------------------------------------
+# S1 — Top-level baseline (regression guard)
+# ---------------------------------------------------------------------------
+
+
+class TestS1Baseline:
+    """Bundle-declared agents in session.config must be visible in child."""
+
+    @pytest.mark.asyncio
+    async def test_bundle_agent_in_session_config_visible_in_child(self) -> None:
+        """Agents declared in session.config (bundle baseline) must reach child."""
+        parent = _make_parent_session(
+            session_config_agents={
+                "baseline_agent": {"description": "bundle-declared agent"},
+                "mode_agent_A": {"description": "Agent A"},
+            },
+            coordinator_config_agents={
+                "baseline_agent": {"description": "bundle-declared agent"},
+                "mode_agent_A": {"description": "Agent A"},
+            },
+        )
+        child = _make_child_session_mock()
+        captured: dict = {}
+
+        await _run_spawn(
+            parent,
+            {"mode_agent_A": {"description": "Agent A"}},
+            child,
+            "mode_agent_A",
+            captured,
+        )
+
+        assert "baseline_agent" in captured.get("agents", {}), (
+            "Agents in session.config must be visible in child merged_config. "
+            f"agents in child config: {list(captured.get('agents', {}).keys())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# S2 — Same-mode siblings (headline bug #233)
+# ---------------------------------------------------------------------------
+
+
+class TestS2SameModeSiblings:
+    """Mode-contributed agents in coordinator.config must be visible in child."""
+
+    @pytest.mark.asyncio
+    async def test_mode_contributed_sibling_visible_in_child(self) -> None:
+        """mode_agent_B contributed by a mode must be reachable from mode_agent_A's sub-session.
+
+        This is the headline bug: mode_agent_B is in coordinator.config["agents"]
+        (the live registry, written by RuntimeOverlay._mount) but NOT in
+        parent_session.config["agents"] (the static init snapshot).
+
+        Without the fix: merge_configs(parent_session.config, ...) reads the
+        static snapshot → mode_agent_B absent → delegation fails.
+
+        With the fix: propagation block reads coordinator.config["agents"] →
+        mode_agent_B is copied into merged_config → delegation works.
+        """
+        parent = _make_parent_session(
+            # Static snapshot: only baseline + A; mode_agent_B is NOT in snapshot
+            session_config_agents={
+                "baseline_agent": {"description": "bundle agent"},
+                "mode_agent_A": {"description": "Agent A"},
+            },
+            # Live registry: both A and B (mode contributed both)
+            coordinator_config_agents={
+                "baseline_agent": {"description": "bundle agent"},
+                "mode_agent_A": {"description": "Agent A"},
+                "mode_agent_B": {"description": "Agent B — mode-contributed sibling"},
+            },
+        )
+        child = _make_child_session_mock()
+        captured: dict = {}
+
+        await _run_spawn(
+            parent,
+            {
+                "mode_agent_A": {"description": "Agent A"},
+                "mode_agent_B": {"description": "Agent B — mode-contributed sibling"},
+            },
+            child,
+            "mode_agent_A",
+            captured,
+        )
+
+        assert "mode_agent_B" in captured.get("agents", {}), (
+            "mode_agent_B is a mode-contributed sibling. It exists in "
+            "coordinator.config['agents'] (live registry) but NOT in "
+            "parent_session.config['agents'] (static snapshot). "
+            "After the issue #233 fix, spawn must propagate live registry agents "
+            "into child merged_config so same-mode siblings can delegate. "
+            f"agents in child config: {list(captured.get('agents', {}).keys())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# S3 — Mixed: session baseline + mode contribution
+# ---------------------------------------------------------------------------
+
+
+class TestS3Mixed:
+    """Child must see both static and live-registry agents."""
+
+    @pytest.mark.asyncio
+    async def test_child_sees_both_static_and_mode_contributed_agents(self) -> None:
+        """After propagation, child sees bundle-declared X AND mode-contributed A."""
+        parent = _make_parent_session(
+            # Static snapshot: only X
+            session_config_agents={
+                "agent_X": {"description": "Bundle-declared agent X"},
+            },
+            # Live registry: X AND mode-contributed A
+            coordinator_config_agents={
+                "agent_X": {"description": "Bundle-declared agent X"},
+                "mode_agent_A": {"description": "Mode-contributed agent A"},
+            },
+        )
+        child = _make_child_session_mock()
+        captured: dict = {}
+
+        await _run_spawn(
+            parent,
+            {"mode_agent_A": {"description": "Mode-contributed agent A"}},
+            child,
+            "mode_agent_A",
+            captured,
+        )
+
+        assert "agent_X" in captured.get("agents", {}), (
+            "Bundle-declared agent X must remain visible in child after propagation. "
+            f"agents in child config: {list(captured.get('agents', {}).keys())}"
+        )
+        assert "mode_agent_A" in captured.get("agents", {}), (
+            "Mode-contributed agent A must be visible in child after propagation. "
+            f"agents in child config: {list(captured.get('agents', {}).keys())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# S4 — Caller-independence
+# ---------------------------------------------------------------------------
+
+
+class TestS4CallerIndependence:
+    """Fix must work regardless of how spawn is invoked (not caller-specific)."""
+
+    @pytest.mark.asyncio
+    async def test_propagation_works_without_extra_caller_context(self) -> None:
+        """Propagation reads coordinator.config directly, not from caller parameters.
+
+        This test verifies the architectural decision: the fix reads from
+        parent_session.coordinator.config (source of truth) not from any
+        caller-supplied parameter. The fix-report's symptom fix relied on
+        a caller-supplied 'agent_configs' parameter which would silently
+        regress when spawn is called from a non-tool-delegate path.
+        """
+        parent = _make_parent_session(
+            # Static snapshot: only the spawned agent (not the sibling)
+            session_config_agents={
+                "agent_spawned": {"description": "The agent being spawned"},
+            },
+            # Live registry: both spawned agent AND sibling
+            coordinator_config_agents={
+                "agent_spawned": {"description": "The agent being spawned"},
+                "mode_sibling": {"description": "Sibling from same mode"},
+            },
+        )
+        child = _make_child_session_mock()
+        captured: dict = {}
+
+        # Note: agent_configs only contains the spawned agent,
+        # NOT the sibling. The fix must discover the sibling from coordinator.config.
+        await _run_spawn(
+            parent,
+            {"agent_spawned": {"description": "The agent being spawned"}},
+            child,
+            "agent_spawned",
+            captured,
+        )
+
+        assert "mode_sibling" in captured.get("agents", {}), (
+            "mode_sibling exists in coordinator.config['agents'] (live registry) "
+            "but was NOT passed in agent_configs. "
+            "The fix must read from coordinator.config directly — not rely on "
+            "the caller passing all relevant agents. "
+            f"agents in child config: {list(captured.get('agents', {}).keys())}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# S5 — Skill capability propagation
+# ---------------------------------------------------------------------------
+
+
+class TestS5SkillCapabilityPropagation:
+    """runtime_skill_overlay capability must be propagated to child coordinator."""
+
+    @pytest.mark.asyncio
+    async def test_skill_capability_propagated_to_child_coordinator(self) -> None:
+        """Child coordinator inherits runtime_skill_overlay capability from parent.
+
+        Without this propagation, a mode-contributed agent running in a child
+        session cannot discover the skills contributed by the same mode — the
+        child's tool-skills module reads from its OWN coordinator's capability,
+        which is empty unless we copy it.
+        """
+        skills_list = ["@modes:skills/mode-design-discipline"]
+        parent = _make_parent_session(
+            session_config_agents={
+                "mode_agent_A": {"description": "Agent A"},
+            },
+            coordinator_config_agents={
+                "mode_agent_A": {"description": "Agent A"},
+            },
+            coordinator_skills_capability=skills_list,
+        )
+        child = _make_child_session_mock()
+
+        await _run_spawn(
+            parent,
+            {"mode_agent_A": {"description": "Agent A"}},
+            child,
+            "mode_agent_A",
+        )
+
+        # Inspect child coordinator capability registrations
+        registered = child.coordinator.get_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY)
+
+        assert registered is not None, (
+            f"Child coordinator must have '{RUNTIME_SKILL_OVERLAY_CAPABILITY}' "
+            "capability registered after spawn. Without this, tool-skills in "
+            "the child session cannot discover mode-contributed skills. "
+            "All registered capabilities: "
+            f"{[c.args[0] for c in child.coordinator.register_capability.call_args_list if c.args]}"
+        )
+        assert set(registered) == set(skills_list), (
+            f"Child coordinator's '{RUNTIME_SKILL_OVERLAY_CAPABILITY}' capability "
+            f"must contain the same skills as the parent. "
+            f"Expected {skills_list!r}, got {registered!r}"
+        )


### PR DESCRIPTION
## Summary

Fixes microsoft-amplifier/amplifier-support#233: same-mode sibling agents are not reachable from each other's sub-sessions.

## Root cause

`spawn_sub_session` builds the child's config from `parent_session.config` — the STATIC snapshot captured at session-init. Runtime additions (mode contributions via RuntimeOverlay) live only in `parent_session.coordinator.config["agents"]` and are invisible to that read.

The static-snapshot read also handles the agents-filter via `merge_configs` internal logic, which means even an explicit `agents: [sibling_b]` declaration in agent A's config wouldn't reach sibling_b — the source dict is the wrong one.

## Architectural fix (not the symptom fix)

Reads `parent_session.coordinator.config["agents"]` directly after `merge_configs`. Two key properties:

1. **Caller-independent.** Works for ALL spawn callers — tool-delegate, recipe orchestrator, programmatic spawn, future bundle helpers — because we read from the source of truth, not from a caller-supplied parameter. (An alternative "pass `agent_configs` through" symptom fix was considered and rejected; it depends on caller cooperation and would silently fail for non-tool-delegate paths.)

2. **Snapshot semantics preserved.** Child gets a deep-copy at spawn time. Subsequent parent-side mode changes do NOT propagate to in-flight children. Local agent_config declarations win over inherited live registry (never overwrite).

A second block propagates the `runtime_skill_overlay` capability from parent coordinator to child coordinator so the child's tool-skills can resolve contributed skill URIs. `runtime_context_overlay` is intentionally NOT propagated — context injection is root-session-only, since sub-sessions execute their own agent's task and shouldn't inherit "you are in mode X" framing.

Companion to:
- microsoft/amplifier-foundation#203 (capability rename, merged)
- microsoft/amplifier-bundle-modes#<NUMBER> (hooks-mode consumer)
- microsoft/amplifier-bundle-skills#<NUMBER> (tool-skills consumer)

## What this does NOT do

- Does NOT propagate mode policies (tool gates) to sub-sessions
- Does NOT propagate the mode body / system reminder to sub-sessions
- Does NOT propagate `runtime_context_overlay` (contributed context) to sub-sessions

Mode-contributed capabilities (agents, skills) propagate because they're additive resources. Mode policies and prompt context belong to the root session and stay there. This matches how `bundle.app`-declared agents already propagate today — the fix just extends the same rule to runtime additions.

## Test plan

- [x] 5 new tests in `test_session_spawner_issue_233.py`:
  - S1: top-level baseline (regression guard) — GREEN before and after
  - S2: same-mode siblings (the headline) — RED→GREEN
  - S3: mixed (bundle-declared + mode-contributed) — RED→GREEN
  - S4: caller-independence (programmatic spawn, no `agent_configs` parameter) — RED→GREEN
  - S5: skill capability propagation — RED→GREEN
- [x] Full app-cli test suite green, no regressions
- [x] DTU end-to-end with real Anthropic LLM: 3/3 validation scenarios pass; events.jsonl confirms sibling-b in sub-session A's agent registry; runtime_skill_overlay capability present in child coordinator events. Cost: ~$2.40

## One operational note for users

For full LLM-driven A→delegate(B) call chains, the spawned agent's frontmatter must include the `delegate` tool in its tool list. The fix makes B reachable in A's REGISTRY; the agent's tool COMPOSITION is a separate concern (agent author responsibility). Without `delegate` in A's tools, the LLM in A's sub-session sees B in the registry but has no tool to call it — which the structural validation confirms is exactly the right separation.

Closes microsoft-amplifier/amplifier-support#233 (jointly with companion PRs).
