### PR TITLE
chore: release v0.1.1 — docs retcon for legacy command references

### DIFF
--- a/docs/INTERACTIVE_MODE.md
+++ b/docs/INTERACTIVE_MODE.md
@@ -2,56 +2,58 @@
 
 Interactive chat mode with slash commands for controlling execution, saving work, and managing sessions.
 
-## Two Execution Modes
+## Overview
 
+Interactive mode starts a chat session where you compose prompts, switch runtime modes (plan, brainstorm, debug, etc.), and manage session state via slash commands.
+
+```bash
+amplifier run --mode chat
+# Or simply with no prompt:
+amplifier run
 ```
-┌─────────────────────────────────────────────────────────┐
-│ Normal Mode (default)                                    │
-│ • AI reads and modifies files                           │
-│ • All tools enabled (write, edit, bash)                 │
-│ • Active development                                    │
-├─────────────────────────────────────────────────────────┤
-│ Plan Mode (/think)                                       │
-│ • Read-only - write operations blocked                  │
-│ • Analysis and planning without changes                 │
-│ • Toggle: /think (enter) | /do (exit)                   │
-└─────────────────────────────────────────────────────────┘
-```
+
+Within an interactive session, you compose prompts and issue slash commands. Runtime mode switching is provided by the [`amplifier-bundle-modes`](https://github.com/microsoft/amplifier-bundle-modes) bundle (`/mode <name>`, `/modes`, `/mode off`); other commands are app-CLI built-ins documented below.
 
 ## Slash Commands
 
 | Command | Purpose | Notes |
 |---------|---------|-------|
-| `/think` | Enter plan mode | Read-only, blocks writes |
-| `/do` | Exit plan mode | Re-enables modifications |
 | `/save [file]` | Save transcript | To session directory |
 | `/clear` | Clear history | Keeps session active |
-| `/status` | Show session info | Mode, messages, tools count |
+| `/status` | Show session info | Active mode, message count, tools count |
 | `/tools` | List tools | Shows loaded capabilities |
 | `/config` | Show configuration | Full mount plan |
 | `/help` | List commands | Quick reference |
 | `/stop` | Interrupt execution | Or use Ctrl+C |
+| `/modes` | List available modes (from `amplifier-bundle-modes`) | |
+| `/mode <name>` | Activate a runtime mode | Mode name or shortcut |
+| `/mode off` | Deactivate the current mode | |
 
-### Command Details
+The first eight are app-CLI built-ins. The `/mode*` commands come from `amplifier-bundle-modes` when that bundle is composed into your active configuration (which is the case for every standard amplifier bundle).
 
-**/think - Plan Mode** (read-only analysis):
+## Runtime Modes
+
+Runtime modes are runtime behavior overlays that modify how the assistant operates — restricting tools, contributing context, agents, or skills, and gating destructive actions. Plan mode is a common built-in:
+
 ```bash
-> /think
-✓ Plan Mode enabled
+> /mode plan
+✓ Mode 'plan' activated
 
 > Analyze auth system and suggest improvements
-[AI analyzes without changes]
+[AI analyzes without changes — writes blocked]
 
-> /do
-✓ Plan Mode disabled
+> /mode off
+✓ Mode cleared
 
 > Implement the improvements
 [AI now makes changes]
 ```
 
-**Use for**: Code review, architecture analysis, refactoring planning, security audits.
+See [`amplifier-bundle-modes`](https://github.com/microsoft/amplifier-bundle-modes) for the full list of built-in modes (`plan`, `careful`, `explore`, etc.) and how to author your own.
 
-**/save - Persist Transcript**:
+## Command Details
+
+**/save — Persist Transcript**:
 ```bash
 > /save auth_refactor.json
 ✓ Saved to ~/.amplifier/projects/<project>/sessions/<session-id>/auth_refactor.json
@@ -59,16 +61,16 @@ Interactive chat mode with slash commands for controlling execution, saving work
 
 **Saves**: All messages, session config, timestamp. **Location**: Session directory `~/.amplifier/projects/<project>/sessions/<session-id>/`.
 
-**/clear - Reset Context**:
+**/clear — Reset Context**:
 Clears conversation history, session stays active. Use when switching topics or context grows too large.
 
-**/status - Session Information**:
+**/status — Session Information**:
 ```bash
 > /status
-Plan Mode: OFF | Messages: 42 | Providers: anthropic | Tools: 8
+Mode: plan | Messages: 42 | Providers: anthropic | Tools: 8
 ```
 
-**/tools - Capability Discovery**:
+**/tools — Capability Discovery**:
 ```bash
 > /tools
 filesystem - File operations
@@ -82,14 +84,18 @@ task       - Agent delegation
 ### Pattern 1: Safe Code Review
 
 ```bash
-> /think
+> /mode plan
+✓ Mode 'plan' activated
+
 > Analyze this codebase for security vulnerabilities
 [AI provides analysis]
 
 > Show me the top 3 most critical issues
 [AI explains issues]
 
-> /do
+> /mode off
+✓ Mode cleared
+
 > Fix the SQL injection vulnerability in auth.py
 [AI makes the fix]
 ```
@@ -97,24 +103,21 @@ task       - Agent delegation
 ### Pattern 2: Iterative Refactoring
 
 ```bash
-> /think
+> /mode plan
 > Review the payment processing module for improvement opportunities
 [AI provides recommendations]
 
 > /save payment_analysis.json
 ✓ Transcript saved
 
-> /do
+> /mode off
 > Implement recommendation #1: Extract payment validation
 [AI makes changes]
 
 > /status
-Session Status:
-  Plan Mode: OFF
-  Messages: 15
-  [...]
+Mode: off | Messages: 15 | ...
 
-> /think
+> /mode plan
 > Review the changes we just made
 [AI analyzes recent changes]
 ```
@@ -123,7 +126,7 @@ Session Status:
 
 **Session 1: Planning**
 ```bash
-> /think
+> /mode plan
 > Create a plan for migrating to the new API
 [AI creates detailed plan]
 
@@ -134,7 +137,7 @@ Session Status:
 
 **Session 2: Resume and Implement**
 ```bash
-# Resume the planning session
+# Resume the most recent session
 $ amplifier continue
 Resuming session: a1b2c3d4
 Messages: 5
@@ -149,8 +152,8 @@ Messages: 5
 ```bash
 $ amplifier session list
 Recent Sessions:
-  a1b2c3d4  2024-10-15 14:30  5 messages
-  e5f6g7h8  2024-10-14 09:15  12 messages
+  a1b2c3d4  5 messages
+  e5f6g7h8  12 messages
 
 $ amplifier session resume a1b2c3d4
 # Or use: amplifier continue
@@ -164,7 +167,7 @@ Available Tools:
   filesystem, bash, web, task
 
 > /config
-[Shows that web tool is using specific config]
+[Shows the full mount plan including providers, tools, agents]
 
 > Use the web tool to fetch documentation from anthropic.com
 [AI uses web tool]
@@ -204,16 +207,13 @@ Available Tools:
 
 **Naming convention suggestions:**
 ```bash
-/save feature_name_date.json          # Feature work
-/save bug_fix_issue_123.json          # Bug fixes
-/save review_module_name.json         # Code reviews
-/save planning_migration.json         # Planning sessions
+/save feature_name.json          # Feature work
+/save bug_fix_issue_123.json     # Bug fixes
+/save review_module_name.json    # Code reviews
+/save planning_migration.json    # Planning sessions
 ```
 
-**Transcript location:**
-- Saved to `.amplifier/transcripts/`
-- Git-ignored by default (contains your conversations)
-- Can be shared with team for collaboration
+Saved to session directory at `~/.amplifier/projects/<project>/sessions/<session-id>/`.
 
 ### Interactive Mode vs Single Mode
 
@@ -225,62 +225,58 @@ Available Tools:
 
 **Use single mode when:**
 - One-off commands
-- Scripting/automation
+- Scripting / automation
 - Simple, well-defined tasks
 
-## Command Quick Reference
+```bash
+# Single shot:
+amplifier run "Reply with just OK"
 
-| Command | Purpose | Args |
-|---------|---------|------|
-| `/think` | Enter plan mode (read-only) | None |
-| `/do` | Exit plan mode | None |
-| `/save [file]` | Save transcript | Optional filename |
-| `/clear` | Clear conversation history | None |
-| `/status` | Show session info | None |
-| `/tools` | List available tools | None |
-| `/config` | Show configuration | None |
-| `/help` | Show command list | None |
-| `/stop` | Stop execution | None |
+# Interactive:
+amplifier run --mode chat
+```
 
 ## Advanced: Bundle-Based Interactive Sessions
 
 You can start interactive sessions with specific bundles:
 
 ```bash
-# Use development bundle (includes more tools)
+# Use a specific bundle
 amplifier run --bundle dev --mode chat
-
-# Use general bundle (includes logging hooks)
-amplifier run --bundle general --mode chat
 ```
 
-**→ [Bundle Guide](https://github.com/microsoft/amplifier-foundation/blob/main/docs/BUNDLE_GUIDE.md)** for bundle details.
+See:
+- [Bundle Guide](https://github.com/microsoft/amplifier-foundation/blob/main/docs/BUNDLE_GUIDE.md) — bundle composition and structure
+- [Modes Bundle](https://github.com/microsoft/amplifier-bundle-modes) — the runtime modes system
 
 ## Troubleshooting
 
-### "Command not found" Error
+### "Command not found"
 
 Slash commands only work in interactive chat mode:
 
 ```bash
 # ✗ Won't work
-amplifier run "/think analyze this code"
+amplifier run "/mode plan analyze this code"
 
 # ✓ Works
 amplifier run --mode chat
-> /think
+> /mode plan
 > analyze this code
 ```
 
-### Transcript Not Saving
+### Transcript not saving
 
-Check permissions on `.amplifier/transcripts/`:
+Check permissions on the session directory:
 
 ```bash
-mkdir -p .amplifier/transcripts
-chmod 755 .amplifier/transcripts
+ls -ld ~/.amplifier/projects/<project>/sessions/<session-id>/
 ```
 
-### Plan Mode Not Blocking Writes
+### Plan mode not blocking writes
 
-This may happen if write tools aren't properly registered. Check `/tools` output to verify filesystem/bash tools are loaded.
+Check `/tools` output to verify filesystem/bash tools are loaded. Confirm `amplifier-bundle-modes` is composed into your active bundle (it is, in every standard amplifier bundle). Verify with `/config`.
+
+## Note: Legacy `/think` and `/do` Commands
+
+Previous documentation referenced `/think` and `/do` as plan-mode toggles. These have been replaced by the unified runtime modes system (`/mode plan` and `/mode off`) provided by `amplifier-bundle-modes`. The legacy commands are no longer wired into the CLI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amplifier-app-cli"
-version = "0.1.0"
+version = "0.1.1"
 description = "Reference CLI implementation for Amplifier AI development platform"
 license = "MIT"
 readme = "README.md"


### PR DESCRIPTION
## Summary

Retcon `docs/INTERACTIVE_MODE.md` to remove stale references to legacy `/think` and `/do` commands per CONTEXT_POISONING guidance (anti-pattern #5: Historical References).

## Context

Investigation confirmed:
- `/think` and `/do` have **no code wiring** in amplifier-app-cli (grep returned zero hits)
- They are documentation-only artifacts from an earlier design phase
- The canonical runtime-modes mechanism is `/mode <name>` / `/modes` / `/mode off` (from amplifier-bundle-modes)
- Plan mode in the new system is `/mode plan` — drop-in replacement

## Changes

- Remove 'Two Execution Modes' section (legacy framing)
- Replace all `/think` / `/do` references with `/mode plan` / `/mode off`
- Add explicit 'Note: Legacy Commands' footnote explaining replacement
- Update usage patterns and quick-reference table
- Cross-link to amplifier-bundle-modes and Bundle Guide

## Scope

Documentation only; no code or behavior changes. Removes ambiguity about which mode system is canonical.

---

Generated with Amplifier