### PR TITLE
fix(update): stop claiming spurious dependency updates on every invocation

### DIFF
--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -176,8 +176,9 @@ async def _get_umbrella_dependency_details(umbrella_info) -> list[dict]:
 
     Uses recursive discovery to find ALL packages with [tool.uv.sources] entries,
     then enriches each with local installation info and remote SHA for comparison.
-    Also appends entries for the ``amplifier`` and ``amplifier-core`` PyPI packages
-    so the table shows the same source of truth that drives the update prompt.
+    Also appends an entry for ``amplifier-core`` (the only Amplifier ecosystem
+    package published to PyPI) so the table shows the same source of truth that
+    drives the update prompt.
 
     Returns:
         List of dicts with {name, local_sha, remote_sha, source_url, has_update,
@@ -258,9 +259,10 @@ async def _get_umbrella_dependency_details(umbrella_info) -> list[dict]:
                     }
                 )
 
-            # Append PyPI packages so the table matches what drives the prompt.
+            # Append amplifier-core (the only PyPI-published ecosystem package)
+            # so the table matches what drives the update prompt.
             # display_type="version" tells the renderer not to truncate to 7 chars.
-            for pypi_pkg in ["amplifier", "amplifier-core"]:
+            for pypi_pkg in ["amplifier-core"]:
                 try:
                     installed_ver = importlib.metadata.version(pypi_pkg)
                 except PackageNotFoundError:

--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -176,12 +176,21 @@ async def _get_umbrella_dependency_details(umbrella_info) -> list[dict]:
 
     Uses recursive discovery to find ALL packages with [tool.uv.sources] entries,
     then enriches each with local installation info and remote SHA for comparison.
+    Also appends entries for the ``amplifier`` and ``amplifier-core`` PyPI packages
+    so the table shows the same source of truth that drives the update prompt.
 
     Returns:
         List of dicts with {name, local_sha, remote_sha, source_url, has_update,
-                           is_local, path, has_changes}
+                           is_local, path, has_changes}.
+        PyPI entries carry an additional ``display_type: "version"`` key that
+        tells the renderer to show the full version string rather than a
+        truncated 7-character SHA.
     """
+    import importlib.metadata
+    from importlib.metadata import PackageNotFoundError
+
     import httpx
+    from packaging.version import InvalidVersion, Version
 
     from ..utils.source_status import _get_github_commit_sha
     from ..utils.umbrella_discovery import discover_ecosystem_packages
@@ -246,6 +255,46 @@ async def _get_umbrella_dependency_details(umbrella_info) -> list[dict]:
                         "is_local": is_local,
                         "path": path,
                         "has_changes": has_changes,
+                    }
+                )
+
+            # Append PyPI packages so the table matches what drives the prompt.
+            # display_type="version" tells the renderer not to truncate to 7 chars.
+            for pypi_pkg in ["amplifier", "amplifier-core"]:
+                try:
+                    installed_ver = importlib.metadata.version(pypi_pkg)
+                except PackageNotFoundError:
+                    continue
+
+                latest_ver: str | None = None
+                try:
+                    resp = await client.get(
+                        f"https://pypi.org/pypi/{pypi_pkg}/json",
+                        timeout=5.0,
+                    )
+                    resp.raise_for_status()
+                    latest_ver = resp.json()["info"]["version"]
+                except Exception:
+                    latest_ver = "unknown"
+
+                pypi_has_update = False
+                if latest_ver and latest_ver != "unknown":
+                    try:
+                        pypi_has_update = Version(installed_ver) < Version(latest_ver)
+                    except InvalidVersion:
+                        pass  # leave has_update=False on unparseable versions
+
+                details.append(
+                    {
+                        "name": f"{pypi_pkg} (PyPI)",
+                        "local_sha": installed_ver,
+                        "remote_sha": latest_ver or "unknown",
+                        "source_url": f"https://pypi.org/project/{pypi_pkg}/",
+                        "has_update": pypi_has_update,
+                        "is_local": False,
+                        "path": None,
+                        "has_changes": False,
+                        "display_type": "version",
                     }
                 )
 
@@ -517,6 +566,15 @@ def _show_concise_report(
                     dep["local_sha"], dep["local_sha"], dep.get("has_changes", False)
                 )
                 remote_display = Text("-", style="dim")
+            elif dep.get("display_type") == "version":
+                # PyPI package: show full version strings, not 7-char SHA truncation.
+                # The "Local" column shows installed version; "Remote" shows PyPI latest.
+                name_display = dep["name"]
+                local_display = Text(dep["local_sha"] or "unknown", style="dim")
+                remote_display = Text(dep["remote_sha"] or "unknown", style="dim")
+                status_symbol = create_status_symbol(
+                    dep["local_sha"], dep["remote_sha"]
+                )
             else:
                 # Standard git install - compare local vs remote
                 name_display = dep["name"]
@@ -1018,21 +1076,27 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
 
     # Check umbrella first
     from ..utils.umbrella_discovery import discover_umbrella_source
-    from ..utils.update_executor import check_umbrella_dependencies_for_updates  # noqa: F401 — kept for future reporting use; no longer gates execution
+    from ..utils.update_executor import check_umbrella_dependencies_for_updates  # noqa: F401 — kept for future reporting use; checks git-sourced deps only
+    from ..utils.update_executor import check_pypi_packages_for_updates
 
     umbrella_info = discover_umbrella_source()
     has_umbrella_updates = False
 
     if umbrella_info:
-        # Always route the umbrella update through uv. The previous
-        # check_umbrella_dependencies_for_updates() check only inspected
-        # git-sourced deps and silently missed PyPI version bumps
+        # Ask PyPI whether amplifier or amplifier-core has a newer release.
+        # check_umbrella_dependencies_for_updates() only walks git-sourced deps
+        # via direct_url.json and silently misses PyPI version bumps
         # (e.g. amplifier-core), causing `amplifier update` to report
         # "All sources up to date" while actually being stale.
-        # uv knows the full dependency tree and will decide what (if anything)
-        # needs upgrading. The cost is one extra `uv tool install` call per
-        # `amplifier update`; the alternative is silent staleness.
-        has_umbrella_updates = True
+        #
+        # check_pypi_packages_for_updates() queries the PyPI JSON API for both
+        # `amplifier` and `amplifier-core` and uses packaging.version.Version
+        # for correct semantic comparison.
+        #
+        # Failure policy: returns True (assume stale) on any network / parse
+        # error to avoid the v1.0.7 silent-staleness pattern.
+        # See: CORE_RELEASE_MANDATE.
+        has_umbrella_updates = asyncio.run(check_pypi_packages_for_updates())
 
     # Check modules
     if not force:

--- a/amplifier_app_cli/utils/update_executor.py
+++ b/amplifier_app_cli/utils/update_executor.py
@@ -261,24 +261,31 @@ async def check_umbrella_dependencies_for_updates(umbrella_info: UmbrellaInfo) -
 
 
 async def check_pypi_packages_for_updates() -> bool:
-    """Check if ``amplifier`` or ``amplifier-core`` has a newer version on PyPI.
+    """Check if ``amplifier-core`` has a newer version on PyPI.
 
-    Compares the installed version of each package against the PyPI JSON API.
+    Only ``amplifier-core`` is published to PyPI (per CORE_RELEASE_MANDATE).
+    The umbrella ``amplifier`` package is git-sourced; its version is already
+    covered by the ``amplifier-app-cli`` / ``amplifier-foundation`` git rows in
+    the Amplifier table — do not add it here.
+
     Uses ``packaging.version.Version`` for correct semantic ordering — avoids
     the string-compare bug where ``"1.4.10" < "1.4.9"`` under lexicographic
     ordering.
 
-    **Failure policy — assume stale:**
-    On any failure (network error, timeout, malformed JSON, PyPI 5xx, version
-    parse error) this function returns ``True`` (update assumed available).
-    Rationale: the conservative direction avoids the v1.0.7 silent-staleness
-    pattern where a PyPI dependency bump went undetected and users stayed on
-    the stale version indefinitely.  See: CORE_RELEASE_MANDATE.
+    **Failure policy:**
+    - HTTP 404 → ``False`` (package definitively not on PyPI; skip silently).
+    - HTTP 5xx / 429 / other HTTP error → ``True`` (assume stale, log WARNING).
+    - Transport error (timeout, DNS, connect) → ``True`` (assume stale, log WARNING).
+    - Parse error (bad JSON, missing key, invalid version string) → ``True``
+      (assume stale, log WARNING).
+    Rationale: conservative on uncertainty avoids the v1.0.7 silent-staleness
+    pattern; 404 is a definitive answer, not an outage.  See: CORE_RELEASE_MANDATE.
 
     Returns:
-        ``True``  — at least one package has a newer version on PyPI, **or**
+        ``True``  — ``amplifier-core`` has a newer version on PyPI, **or**
                     PyPI was unreachable / returned an unparseable response.
-        ``False`` — both installed versions are confirmed current.
+        ``False`` — installed version is confirmed current, **or** PyPI returned 404
+                    (package not found — not an error condition worth prompting for).
     """
     import importlib.metadata
     from importlib.metadata import PackageNotFoundError
@@ -286,7 +293,8 @@ async def check_pypi_packages_for_updates() -> bool:
     import httpx
     from packaging.version import InvalidVersion, Version
 
-    _PYPI_PACKAGES = ["amplifier", "amplifier-core"]
+    # Only amplifier-core is published to PyPI. The umbrella is git-sourced.
+    _PYPI_PACKAGES = ["amplifier-core"]
 
     try:
         async with httpx.AsyncClient(timeout=5.0) as client:
@@ -302,12 +310,36 @@ async def check_pypi_packages_for_updates() -> bool:
                     resp = await client.get(f"https://pypi.org/pypi/{package}/json")
                     resp.raise_for_status()
                     latest_str = resp.json()["info"]["version"]
-                except Exception as exc:
-                    # Assume stale on any network / parse failure to avoid
-                    # the v1.0.7 silent-staleness pattern (see CORE_RELEASE_MANDATE).
+                except httpx.HTTPStatusError as exc:
+                    if exc.response.status_code == 404:
+                        # Package not on PyPI — definitive answer, not an outage.
+                        logger.info(
+                            "Package %s not found on PyPI; skipping update check.",
+                            package,
+                        )
+                        continue
+                    # Any other HTTP error (5xx, 429, etc.) — treat as uncertain.
+                    logger.warning(
+                        "PyPI returned HTTP %s for %s — "
+                        "assuming stale to avoid silent-staleness.",
+                        exc.response.status_code,
+                        package,
+                    )
+                    return True
+                except httpx.TransportError as exc:
+                    # Timeout, DNS failure, connection refused, etc.
                     logger.warning(
                         "Could not reach PyPI to check %s for updates: %s — "
                         "assuming stale to avoid silent-staleness.",
+                        package,
+                        exc,
+                    )
+                    return True
+                except Exception as exc:
+                    # JSONDecodeError, KeyError on ["info"]["version"], etc.
+                    logger.warning(
+                        "Unexpected error fetching PyPI data for %s: %s — "
+                        "assuming stale.",
                         package,
                         exc,
                     )

--- a/amplifier_app_cli/utils/update_executor.py
+++ b/amplifier_app_cli/utils/update_executor.py
@@ -260,6 +260,91 @@ async def check_umbrella_dependencies_for_updates(umbrella_info: UmbrellaInfo) -
         return False
 
 
+async def check_pypi_packages_for_updates() -> bool:
+    """Check if ``amplifier`` or ``amplifier-core`` has a newer version on PyPI.
+
+    Compares the installed version of each package against the PyPI JSON API.
+    Uses ``packaging.version.Version`` for correct semantic ordering — avoids
+    the string-compare bug where ``"1.4.10" < "1.4.9"`` under lexicographic
+    ordering.
+
+    **Failure policy — assume stale:**
+    On any failure (network error, timeout, malformed JSON, PyPI 5xx, version
+    parse error) this function returns ``True`` (update assumed available).
+    Rationale: the conservative direction avoids the v1.0.7 silent-staleness
+    pattern where a PyPI dependency bump went undetected and users stayed on
+    the stale version indefinitely.  See: CORE_RELEASE_MANDATE.
+
+    Returns:
+        ``True``  — at least one package has a newer version on PyPI, **or**
+                    PyPI was unreachable / returned an unparseable response.
+        ``False`` — both installed versions are confirmed current.
+    """
+    import importlib.metadata
+    from importlib.metadata import PackageNotFoundError
+
+    import httpx
+    from packaging.version import InvalidVersion, Version
+
+    _PYPI_PACKAGES = ["amplifier", "amplifier-core"]
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            for package in _PYPI_PACKAGES:
+                # Skip packages not present in this environment.
+                try:
+                    installed_str = importlib.metadata.version(package)
+                except PackageNotFoundError:
+                    continue
+
+                # Fetch latest version from PyPI.
+                try:
+                    resp = await client.get(f"https://pypi.org/pypi/{package}/json")
+                    resp.raise_for_status()
+                    latest_str = resp.json()["info"]["version"]
+                except Exception as exc:
+                    # Assume stale on any network / parse failure to avoid
+                    # the v1.0.7 silent-staleness pattern (see CORE_RELEASE_MANDATE).
+                    logger.warning(
+                        "Could not reach PyPI to check %s for updates: %s — "
+                        "assuming stale to avoid silent-staleness.",
+                        package,
+                        exc,
+                    )
+                    return True
+
+                # Compare with semantic version ordering, not string ordering.
+                # "1.4.10" > "1.4.9" under Version() but < under str comparison.
+                try:
+                    if Version(installed_str) < Version(latest_str):
+                        logger.info(
+                            "%s: installed %s < PyPI latest %s",
+                            package,
+                            installed_str,
+                            latest_str,
+                        )
+                        return True
+                except InvalidVersion as exc:
+                    logger.warning(
+                        "Could not parse version strings for %s (%r vs %r): %s — "
+                        "assuming stale.",
+                        package,
+                        installed_str,
+                        latest_str,
+                        exc,
+                    )
+                    return True
+
+    except Exception as exc:
+        logger.warning(
+            "Unexpected error checking PyPI packages for updates: %s — assuming stale.",
+            exc,
+        )
+        return True
+
+    return False
+
+
 def _extract_dependencies_from_pyproject(pyproject_path: Path) -> list[str]:
     """Extract dependency package names from a pyproject.toml file.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "pyyaml>=6.0.3",
     "prompt-toolkit>=3.0.52",
     "httpx[socks]>=0.28.1",
+    "packaging>=24.0",
 ]
 
 [project.scripts]

--- a/tests/test_update_executor.py
+++ b/tests/test_update_executor.py
@@ -194,16 +194,15 @@ async def test_execute_updates_forwards_force_to_execute_self_update(monkeypatch
 
 
 def test_update_command_passes_umbrella_info_despite_no_git_updates():
-    """Regression: PyPI dep bumps must trigger the umbrella self-update.
+    """Regression: a real PyPI update triggers the umbrella self-update.
 
-    Before the fix, check_umbrella_dependencies_for_updates() returned False
-    for PyPI version bumps (e.g. amplifier-core 1.5.1 → 1.5.2). The
-    has_umbrella_updates gate set it to False, which caused nothing_to_update
-    to be True, and execute_updates was never called. Users stayed stuck on
-    the old version with no error message.
+    Scenario: no git-sourced dep has changes, but check_pypi_packages_for_updates()
+    detects that amplifier-core has a new release on PyPI.  execute_updates must
+    be called with umbrella_info so the CLI performs `uv tool install --upgrade`.
 
-    After the fix, has_umbrella_updates=True whenever umbrella_info is
-    discovered, so execute_updates is always called with umbrella_info.
+    This guards against the v1.0.7 silent-staleness regression: the old code
+    only walked git deps (direct_url.json) and never noticed PyPI bumps, so
+    execute_updates was never called and the user stayed on the stale version.
     """
     from click.testing import CliRunner
 
@@ -225,10 +224,9 @@ def test_update_command_passes_umbrella_info_despite_no_git_updates():
         captured["force"] = force
         return ExecutionResult(success=True, updated=["amplifier"], messages=[])
 
-    # Simulates the bug condition: no git-sourced dep has updates,
-    # so the old check_umbrella_dependencies_for_updates returns False.
-    async def fake_check_umbrella_deps_false(info):
-        return False
+    # check_pypi_packages_for_updates returns True → amplifier-core has a new release.
+    async def fake_pypi_has_update():
+        return True
 
     empty_report = UpdateReport(local_file_sources=[], cached_git_sources=[])
 
@@ -247,8 +245,15 @@ def test_update_command_passes_umbrella_info_despite_no_git_updates():
             return_value=fake_info,
         ),
         patch(
+            # Still present in the import (noqa: F401) but no longer gates execution.
             "amplifier_app_cli.utils.update_executor.check_umbrella_dependencies_for_updates",
-            side_effect=fake_check_umbrella_deps_false,
+        ),
+        patch(
+            # The new PyPI preflight — imported inside the update() body from
+            # update_executor, so patch the source module attribute.
+            # Returns True (update available) to simulate amplifier-core having a release.
+            "amplifier_app_cli.utils.update_executor.check_pypi_packages_for_updates",
+            side_effect=fake_pypi_has_update,
         ),
         patch(
             "amplifier_app_cli.commands.update.check_all_sources",
@@ -290,9 +295,295 @@ def test_update_command_passes_umbrella_info_despite_no_git_updates():
 
     assert captured.get("umbrella_info") is not None, (
         "execute_updates was called with umbrella_info=None (or was never called).\n"
-        "This means the PyPI-dep gate was NOT fixed — `amplifier update` still ignores\n"
-        "PyPI version bumps and reports 'All sources up to date' when only amplifier-core\n"
-        "(or another PyPI dep) has a newer version.\n"
+        "check_pypi_packages_for_updates() returned True but the update gate did not\n"
+        "forward umbrella_info to execute_updates — PyPI update detection is broken.\n"
         f"captured={captured!r}\n"
         f"Command output:\n{result.output}"
+    )
+
+
+def test_update_command_exits_early_when_pypi_is_current():
+    """When PyPI reports both packages are current, the early-exit path fires.
+
+    This is the anti-regression test for the original bug:
+      `amplifier update` prompted and ran `uv tool install` on every invocation
+      even when all SHAs matched, because has_umbrella_updates was unconditionally
+      set to True.
+
+    After the fix, check_pypi_packages_for_updates() returning False means
+    nothing_to_update=True and execute_updates must NOT be called.
+    """
+    from click.testing import CliRunner
+
+    from amplifier_app_cli.commands.update import update
+    from amplifier_app_cli.utils.source_status import UpdateReport
+
+    fake_info = UmbrellaInfo(
+        url="https://github.com/microsoft/amplifier",
+        ref="main",
+        commit_id=None,
+    )
+    execute_updates_called = False
+
+    async def fake_execute_updates(
+        report, umbrella_info=None, progress_callback=None, force=False
+    ):
+        nonlocal execute_updates_called
+        execute_updates_called = True
+        from amplifier_app_cli.utils.update_executor import ExecutionResult
+
+        return ExecutionResult(success=True, updated=[], messages=[])
+
+    # check_pypi_packages_for_updates returns False → everything is current.
+    async def fake_pypi_all_current():
+        return False
+
+    empty_report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+
+    async def fake_check_all_sources(**kwargs):
+        return empty_report
+
+    async def fake_check_all_bundle_status():
+        return {}
+
+    async def fake_get_umbrella_dep_details(info):
+        return []
+
+    with (
+        patch(
+            "amplifier_app_cli.utils.umbrella_discovery.discover_umbrella_source",
+            return_value=fake_info,
+        ),
+        patch(
+            # Imported inside the update() body from update_executor —
+            # patch the source module attribute.
+            "amplifier_app_cli.utils.update_executor.check_pypi_packages_for_updates",
+            side_effect=fake_pypi_all_current,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.check_all_sources",
+            side_effect=fake_check_all_sources,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update._check_all_bundle_status",
+            side_effect=fake_check_all_bundle_status,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update._get_umbrella_dependency_details",
+            side_effect=fake_get_umbrella_dep_details,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.execute_updates",
+            side_effect=fake_execute_updates,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.save_update_last_check",
+            return_value=None,
+        ),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(update, ["--yes"])
+
+    if result.exception and not isinstance(result.exception, SystemExit):
+        import traceback
+
+        raise AssertionError(
+            f"update command raised an exception:\n"
+            f"{''.join(traceback.format_exception(type(result.exception), result.exception, result.exception.__traceback__))}\n"
+            f"Output:\n{result.output}"
+        )
+
+    assert not execute_updates_called, (
+        "execute_updates was called when check_pypi_packages_for_updates() returned False.\n"
+        "The early-exit path ('All sources up to date') must fire when PyPI confirms\n"
+        "both packages are current — the spurious prompt bug has regressed.\n"
+        f"Command output:\n{result.output}"
+    )
+    assert "up to date" in result.output.lower(), (
+        "Expected '✓ All sources up to date' in output when nothing needs updating.\n"
+        f"Actual output:\n{result.output}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for check_pypi_packages_for_updates
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_pypi_both_current_returns_false():
+    """Both packages at PyPI-confirmed latest → returns False (no update prompt)."""
+    import importlib.metadata
+    from unittest.mock import AsyncMock, MagicMock
+
+    from amplifier_app_cli.utils.update_executor import check_pypi_packages_for_updates
+
+    installed = {"amplifier": "1.5.0", "amplifier-core": "1.0.10"}
+    latest = {"amplifier": "1.5.0", "amplifier-core": "1.0.10"}
+
+    def fake_version(pkg: str) -> str:
+        if pkg in installed:
+            return installed[pkg]
+        raise importlib.metadata.PackageNotFoundError(pkg)
+
+    async def fake_get(url: str, **kwargs):
+        for pkg in latest:
+            if f"/{pkg}/json" in url:
+                resp = MagicMock()
+                resp.raise_for_status = MagicMock()
+                resp.json.return_value = {"info": {"version": latest[pkg]}}
+                return resp
+        raise ValueError(f"Unexpected PyPI URL: {url}")
+
+    mock_client = MagicMock()
+    mock_client.get = fake_get
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("importlib.metadata.version", side_effect=fake_version),
+        patch("httpx.AsyncClient", return_value=mock_client),
+    ):
+        result = await check_pypi_packages_for_updates()
+
+    assert result is False, (
+        f"Expected False when both packages match PyPI latest, but got {result!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_pypi_amplifier_core_update_returns_true():
+    """amplifier-core has a newer PyPI release → returns True."""
+    import importlib.metadata
+    from unittest.mock import AsyncMock, MagicMock
+
+    from amplifier_app_cli.utils.update_executor import check_pypi_packages_for_updates
+
+    installed = {"amplifier": "1.5.0", "amplifier-core": "1.0.9"}
+    latest = {"amplifier": "1.5.0", "amplifier-core": "1.0.10"}
+
+    def fake_version(pkg: str) -> str:
+        if pkg in installed:
+            return installed[pkg]
+        raise importlib.metadata.PackageNotFoundError(pkg)
+
+    async def fake_get(url: str, **kwargs):
+        for pkg in latest:
+            if f"/{pkg}/json" in url:
+                resp = MagicMock()
+                resp.raise_for_status = MagicMock()
+                resp.json.return_value = {"info": {"version": latest[pkg]}}
+                return resp
+        raise ValueError(f"Unexpected PyPI URL: {url}")
+
+    mock_client = MagicMock()
+    mock_client.get = fake_get
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("importlib.metadata.version", side_effect=fake_version),
+        patch("httpx.AsyncClient", return_value=mock_client),
+    ):
+        result = await check_pypi_packages_for_updates()
+
+    assert result is True, (
+        "Expected True when amplifier-core has a newer release on PyPI, "
+        f"but got {result!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_pypi_timeout_returns_true_and_logs_warning(caplog):
+    """PyPI timeout → returns True (assume stale) and emits a WARNING.
+
+    This is the conservative failure policy: we'd rather run a redundant
+    `uv tool install` than silently leave a user on a stale version.
+    """
+    import importlib.metadata
+    import logging
+    from unittest.mock import AsyncMock, MagicMock
+
+    import httpx
+
+    from amplifier_app_cli.utils.update_executor import check_pypi_packages_for_updates
+
+    def fake_version(pkg: str) -> str:
+        if pkg in ("amplifier", "amplifier-core"):
+            return "1.0.0"
+        raise importlib.metadata.PackageNotFoundError(pkg)
+
+    async def fake_get_timeout(url: str, **kwargs):
+        raise httpx.TimeoutException("timed out", request=MagicMock())
+
+    mock_client = MagicMock()
+    mock_client.get = fake_get_timeout
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with caplog.at_level(
+        logging.WARNING, logger="amplifier_app_cli.utils.update_executor"
+    ):
+        with (
+            patch("importlib.metadata.version", side_effect=fake_version),
+            patch("httpx.AsyncClient", return_value=mock_client),
+        ):
+            result = await check_pypi_packages_for_updates()
+
+    assert result is True, (
+        f"Expected True (assume stale) when PyPI request times out, but got {result!r}"
+    )
+    warning_msgs = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("stale" in m.lower() or "assuming" in m.lower() for m in warning_msgs), (
+        "Expected a WARNING mentioning 'stale' or 'assuming' on PyPI timeout.\n"
+        f"Actual warnings: {warning_msgs}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_pypi_no_false_positive_on_locally_newer_version():
+    """Installed 1.4.10 with PyPI at 1.4.9 must NOT trigger an update.
+
+    String comparison "1.4.10" < "1.4.9" is True (lexicographic), but
+    packaging.version.Version("1.4.10") > Version("1.4.9") — the correct result.
+    This test catches a regression back to string-based comparison.
+    """
+    import importlib.metadata
+    from unittest.mock import AsyncMock, MagicMock
+
+    from amplifier_app_cli.utils.update_executor import check_pypi_packages_for_updates
+
+    # Installed is NEWER than what PyPI reports (e.g. pre-release locally)
+    installed = {"amplifier": "1.4.10", "amplifier-core": "1.4.10"}
+    latest = {"amplifier": "1.4.9", "amplifier-core": "1.4.9"}
+
+    def fake_version(pkg: str) -> str:
+        if pkg in installed:
+            return installed[pkg]
+        raise importlib.metadata.PackageNotFoundError(pkg)
+
+    async def fake_get(url: str, **kwargs):
+        for pkg in latest:
+            if f"/{pkg}/json" in url:
+                resp = MagicMock()
+                resp.raise_for_status = MagicMock()
+                resp.json.return_value = {"info": {"version": latest[pkg]}}
+                return resp
+        raise ValueError(f"Unexpected PyPI URL: {url}")
+
+    mock_client = MagicMock()
+    mock_client.get = fake_get
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("importlib.metadata.version", side_effect=fake_version),
+        patch("httpx.AsyncClient", return_value=mock_client),
+    ):
+        result = await check_pypi_packages_for_updates()
+
+    assert result is False, (
+        "False positive: installed 1.4.10 was flagged as outdated vs PyPI 1.4.9.\n"
+        "This means string comparison is being used instead of packaging.version.Version.\n"
+        f"Got: {result!r}"
     )

--- a/tests/test_update_executor.py
+++ b/tests/test_update_executor.py
@@ -412,14 +412,18 @@ def test_update_command_exits_early_when_pypi_is_current():
 
 @pytest.mark.asyncio
 async def test_check_pypi_both_current_returns_false():
-    """Both packages at PyPI-confirmed latest → returns False (no update prompt)."""
+    """amplifier-core at PyPI-confirmed latest → returns False (no update prompt).
+
+    Only amplifier-core is checked; the amplifier umbrella is git-sourced and
+    covered by the amplifier-app-cli / amplifier-foundation git rows.
+    """
     import importlib.metadata
     from unittest.mock import AsyncMock, MagicMock
 
     from amplifier_app_cli.utils.update_executor import check_pypi_packages_for_updates
 
-    installed = {"amplifier": "1.5.0", "amplifier-core": "1.0.10"}
-    latest = {"amplifier": "1.5.0", "amplifier-core": "1.0.10"}
+    installed = {"amplifier-core": "1.0.10"}
+    latest = {"amplifier-core": "1.0.10"}
 
     def fake_version(pkg: str) -> str:
         if pkg in installed:
@@ -447,7 +451,7 @@ async def test_check_pypi_both_current_returns_false():
         result = await check_pypi_packages_for_updates()
 
     assert result is False, (
-        f"Expected False when both packages match PyPI latest, but got {result!r}"
+        f"Expected False when amplifier-core matches PyPI latest, but got {result!r}"
     )
 
 
@@ -459,8 +463,8 @@ async def test_check_pypi_amplifier_core_update_returns_true():
 
     from amplifier_app_cli.utils.update_executor import check_pypi_packages_for_updates
 
-    installed = {"amplifier": "1.5.0", "amplifier-core": "1.0.9"}
-    latest = {"amplifier": "1.5.0", "amplifier-core": "1.0.10"}
+    installed = {"amplifier-core": "1.0.9"}
+    latest = {"amplifier-core": "1.0.10"}
 
     def fake_version(pkg: str) -> str:
         if pkg in installed:
@@ -509,7 +513,7 @@ async def test_check_pypi_timeout_returns_true_and_logs_warning(caplog):
     from amplifier_app_cli.utils.update_executor import check_pypi_packages_for_updates
 
     def fake_version(pkg: str) -> str:
-        if pkg in ("amplifier", "amplifier-core"):
+        if pkg == "amplifier-core":
             return "1.0.0"
         raise importlib.metadata.PackageNotFoundError(pkg)
 
@@ -554,8 +558,8 @@ async def test_check_pypi_no_false_positive_on_locally_newer_version():
     from amplifier_app_cli.utils.update_executor import check_pypi_packages_for_updates
 
     # Installed is NEWER than what PyPI reports (e.g. pre-release locally)
-    installed = {"amplifier": "1.4.10", "amplifier-core": "1.4.10"}
-    latest = {"amplifier": "1.4.9", "amplifier-core": "1.4.9"}
+    installed = {"amplifier-core": "1.4.10"}
+    latest = {"amplifier-core": "1.4.9"}
 
     def fake_version(pkg: str) -> str:
         if pkg in installed:
@@ -586,4 +590,125 @@ async def test_check_pypi_no_false_positive_on_locally_newer_version():
         "False positive: installed 1.4.10 was flagged as outdated vs PyPI 1.4.9.\n"
         "This means string comparison is being used instead of packaging.version.Version.\n"
         f"Got: {result!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_pypi_returns_false_on_404(caplog):
+    """HTTP 404 from PyPI means 'package not on PyPI' → returns False, INFO logged.
+
+    404 is a definitive answer (not an outage), so we treat it as
+    'no update available for this package' rather than 'assume stale'.
+    This is the fix for the amplifier umbrella always-prompts bug: the
+    amplifier package is not on PyPI and returns 404, which the old code
+    incorrectly treated as an outage and assumed stale.
+    """
+    import importlib.metadata
+    import logging
+    from unittest.mock import AsyncMock, MagicMock
+
+    import httpx
+
+    from amplifier_app_cli.utils.update_executor import check_pypi_packages_for_updates
+
+    def fake_version(pkg: str) -> str:
+        if pkg == "amplifier-core":
+            return "1.0.0"
+        raise importlib.metadata.PackageNotFoundError(pkg)
+
+    async def fake_get_404(url: str, **kwargs):
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        raise httpx.HTTPStatusError(
+            "404 Not Found",
+            request=MagicMock(),
+            response=mock_response,
+        )
+
+    mock_client = MagicMock()
+    mock_client.get = fake_get_404
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with caplog.at_level(
+        logging.INFO, logger="amplifier_app_cli.utils.update_executor"
+    ):
+        with (
+            patch("importlib.metadata.version", side_effect=fake_version),
+            patch("httpx.AsyncClient", return_value=mock_client),
+        ):
+            result = await check_pypi_packages_for_updates()
+
+    assert result is False, (
+        f"Expected False when PyPI returns 404 (package not found), but got {result!r}"
+    )
+    info_msgs = [r.message for r in caplog.records if r.levelno == logging.INFO]
+    assert any(
+        "not found" in m.lower()
+        or "not on pypi" in m.lower()
+        or "skipping" in m.lower()
+        for m in info_msgs
+    ), (
+        "Expected an INFO message indicating the package was not found on PyPI.\n"
+        f"Actual INFO messages: {info_msgs}"
+    )
+    # Specifically must NOT emit a WARNING (404 is not an outage).
+    warning_msgs = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert not warning_msgs, (
+        "Expected no WARNING for a 404 response (it's a definitive answer, not an outage).\n"
+        f"Actual warnings: {warning_msgs}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_pypi_returns_true_on_500(caplog):
+    """HTTP 500 from PyPI → returns True (assume stale) and emits a WARNING.
+
+    A 5xx response means PyPI is having trouble — we can't confirm whether
+    we're up to date, so the conservative policy (assume stale) applies.
+    This is different from 404 which is a definitive 'not on PyPI' answer.
+    """
+    import importlib.metadata
+    import logging
+    from unittest.mock import AsyncMock, MagicMock
+
+    import httpx
+
+    from amplifier_app_cli.utils.update_executor import check_pypi_packages_for_updates
+
+    def fake_version(pkg: str) -> str:
+        if pkg == "amplifier-core":
+            return "1.0.0"
+        raise importlib.metadata.PackageNotFoundError(pkg)
+
+    async def fake_get_500(url: str, **kwargs):
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        raise httpx.HTTPStatusError(
+            "500 Internal Server Error",
+            request=MagicMock(),
+            response=mock_response,
+        )
+
+    mock_client = MagicMock()
+    mock_client.get = fake_get_500
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with caplog.at_level(
+        logging.WARNING, logger="amplifier_app_cli.utils.update_executor"
+    ):
+        with (
+            patch("importlib.metadata.version", side_effect=fake_version),
+            patch("httpx.AsyncClient", return_value=mock_client),
+        ):
+            result = await check_pypi_packages_for_updates()
+
+    assert result is True, (
+        f"Expected True (assume stale) when PyPI returns 500, but got {result!r}"
+    )
+    warning_msgs = [r.message for r in caplog.records if r.levelno >= logging.WARNING]
+    assert any("stale" in m.lower() or "assuming" in m.lower() for m in warning_msgs), (
+        "Expected a WARNING mentioning 'stale' or 'assuming' on PyPI 500 response.\n"
+        f"Actual warnings: {warning_msgs}"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -4,13 +4,14 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "amplifier-app-cli"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "amplifier-core" },
     { name = "amplifier-foundation" },
     { name = "click" },
     { name = "httpx", extra = ["socks"] },
+    { name = "packaging" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pygments" },
@@ -30,6 +31,7 @@ requires-dist = [
     { name = "amplifier-foundation", git = "https://github.com/microsoft/amplifier-foundation?branch=main" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.28.1" },
+    { name = "packaging", specifier = ">=24.0" },
     { name = "prompt-toolkit", specifier = ">=3.0.52" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pygments", specifier = ">=2.13.0" },


### PR DESCRIPTION
## Summary

**Problem:** `amplifier update` always claimed dependencies had updates and prompted to proceed, even immediately after a successful update. Same prompt on every run. Reproducible by anyone with an umbrella install.

**Root cause:** In commit `b86b68d` (fix(update): always route umbrella upgrade through uv; add --force cache clean), `has_umbrella_updates` was hardcoded to `True` whenever an umbrella source was detected. That commit fixed a real problem — the previous per-package SHA check missed PyPI version bumps of `amplifier-core` — but went too broad. The early-exit path became unreachable, and the prompt fired every run.

**Fix in three parts:**

1. **`utils/update_executor.py`** — Add `check_pypi_packages_for_updates()` to query PyPI's JSON API for `amplifier-core` (the only ecosystem package on PyPI per CORE_RELEASE_MANDATE). Compares installed vs latest with `packaging.version.Version` (not string equality). Differentiates failure modes:
   - 404 → "not on PyPI" → `False`, INFO log
   - 5xx, 429, transport error, parse error → "uncertain, assume stale" → `True`, WARNING log

2. **`commands/update.py`** — Replace `has_umbrella_updates = True` with `asyncio.run(check_pypi_packages_for_updates())`. Add an `amplifier-core (PyPI)` row to the Amplifier table so the source of truth is visible.

3. **`pyproject.toml`** — Declare `packaging>=24.0` as a direct runtime dependency. It was transitively available in `pip install` environments but not in isolated `uv tool install` venvs.

## Test plan

- 880 unit tests pass (+2 new tests for 404 handling and timeout resilience)
- Pre-existing red test `test_subprocess_param_routes_to_subprocess` is unchanged and unrelated
- Validated end-to-end in a Digital Twin Universe environment — caught two assumptions the unit tests with mocks could not:
  - `packaging` is not transitively available in isolated `uv tool install` venvs
  - The umbrella package is not published to PyPI (only `amplifier-core` is)

## Known non-issue

When remote SHA is `unknown` for a row (e.g., DTU snapshot SHAs that don't exist upstream), the indicator shows `●`. This is cosmetic and out of scope for this PR. A follow-up can change unknown indicators to `◦` or blank for clarity.

---

Generated with [Amplifier](https://github.com/microsoft/amplifier)