### PR TITLE
fix(tests): update subprocess config assertion to include agents key

### DIFF
--- a/tests/test_session_spawner_subprocess.py
+++ b/tests/test_session_spawner_subprocess.py
@@ -91,7 +91,7 @@ class TestSubprocessRouting:
         # Verify subprocess runner was called
         fake_module.run_session_in_subprocess.assert_called_once()
         call_kwargs = fake_module.run_session_in_subprocess.call_args
-        assert call_kwargs.kwargs["config"] == {"session": {}}
+        assert call_kwargs.kwargs["config"] == {"agents": {}, "session": {}}
         assert call_kwargs.kwargs["prompt"] == "Do something"
         assert call_kwargs.kwargs["parent_id"] == "parent-session-id"
         assert call_kwargs.kwargs["session_id"] == "fixed-test-id"


### PR DESCRIPTION
## Summary

Fixes a pre-existing test failure on `main` unrelated to any feature work.

## Problem

`tests/test_session_spawner_subprocess.py::TestSubprocessRouting::test_subprocess_param_routes_to_subprocess` was asserting `{"session": {}}` but the production code now includes `{"agents": {}, "session": {}}` — the `agents` key is always present in the config dict. The test was documented as pre-existing in the PR #186 commit message.

## Fix

Updated the assertion at line 94 to match the current actual config shape:

```python
# Before
assert call_kwargs.kwargs["config"] == {"session": {}}
# After
assert call_kwargs.kwargs["config"] == {"agents": {}, "session": {}}
```

## Verification

982/982 tests passing after this fix (zero failures).