### PR TITLE
fix(session): refresh provider credentials at sub-session resume

### DIFF
--- a/amplifier_app_cli/session_spawner.py
+++ b/amplifier_app_cli/session_spawner.py
@@ -532,7 +532,9 @@ async def spawn_sub_session(
     child_coord = getattr(child_session, "coordinator", None)
     if parent_coord is not None and child_coord is not None:
         try:
-            overlay_skills = parent_coord.get_capability(RUNTIME_SKILL_OVERLAY_CAPABILITY)
+            overlay_skills = parent_coord.get_capability(
+                RUNTIME_SKILL_OVERLAY_CAPABILITY
+            )
         except (AttributeError, KeyError):
             overlay_skills = None
         if overlay_skills:
@@ -688,7 +690,9 @@ async def spawn_sub_session(
         if _resolver is not None:
             from amplifier_foundation.mentions import expand_mentions_in_instruction
 
-            _deduplicator = child_session.coordinator.get_capability("mention_deduplicator")
+            _deduplicator = child_session.coordinator.get_capability(
+                "mention_deduplicator"
+            )
             _wd = child_session.coordinator.get_capability("session.working_dir")
             _rel_to = Path(_wd) if _wd else Path.cwd()
             system_instruction = await expand_mentions_in_instruction(
@@ -726,7 +730,9 @@ async def spawn_sub_session(
         if _instr_resolver is not None:
             from amplifier_foundation.mentions import expand_mentions_in_instruction
 
-            _instr_dedup = child_session.coordinator.get_capability("mention_deduplicator")
+            _instr_dedup = child_session.coordinator.get_capability(
+                "mention_deduplicator"
+            )
             _instr_wd = child_session.coordinator.get_capability("session.working_dir")
             _instr_rel = Path(_instr_wd) if _instr_wd else Path.cwd()
             instruction = await expand_mentions_in_instruction(
@@ -865,6 +871,33 @@ async def resume_sub_session(
         raise RuntimeError(
             f"Corrupted session metadata for '{sub_session_id}'. Cannot reconstruct session without config."
         )
+
+    # --- Credential refresh ---------------------------------------------------
+    # On-disk metadata has API keys redacted to "[REDACTED]" (security fix in
+    # SessionStore._save_metadata).  Re-derive live provider credentials from
+    # user settings + environment variables — the same pipeline that runs at
+    # root-session startup — and splice them back into the loaded config before
+    # creating the session.
+    # --------------------------------------------------------------------------
+    if merged_config.get("providers"):
+        from amplifier_app_cli.lib.settings import AppSettings
+        from amplifier_app_cli.runtime.config import (
+            _apply_provider_overrides,
+            _map_id_to_instance_id,
+            expand_env_vars,
+        )
+
+        _live_overrides = AppSettings().get_provider_overrides()
+        if _live_overrides:
+            _refreshed = _apply_provider_overrides(
+                merged_config["providers"], _live_overrides
+            )
+            _refreshed = _map_id_to_instance_id(_refreshed)
+            merged_config = expand_env_vars({**merged_config, "providers": _refreshed})
+            logger.debug(
+                "Refreshed credentials for %d provider(s) at resume time",
+                len(_refreshed),
+            )
 
     parent_id = metadata.get("parent_id")
     agent_name = metadata.get("agent_name", "unknown")
@@ -1109,7 +1142,9 @@ async def resume_sub_session(
         if _resume_resolver is not None:
             from amplifier_foundation.mentions import expand_mentions_in_instruction
 
-            _resume_dedup = child_session.coordinator.get_capability("mention_deduplicator")
+            _resume_dedup = child_session.coordinator.get_capability(
+                "mention_deduplicator"
+            )
             _resume_wd = child_session.coordinator.get_capability("session.working_dir")
             _resume_rel = Path(_resume_wd) if _resume_wd else Path.cwd()
             instruction = await expand_mentions_in_instruction(

--- a/tests/test_resume_credential_refresh.py
+++ b/tests/test_resume_credential_refresh.py
@@ -1,0 +1,155 @@
+"""Test credential refresh during sub-session resume.
+
+When session metadata is persisted, API keys are redacted to "[REDACTED]"
+(security fix).  At resume time, live credentials must be re-derived from
+user settings so provider calls succeed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from amplifier_app_cli.runtime.config import (
+    _apply_provider_overrides,
+    _map_id_to_instance_id,
+    expand_env_vars,
+)
+
+
+def _make_redacted_config() -> dict:
+    """Config as it would be loaded from disk after redaction."""
+    return {
+        "providers": [
+            {
+                "module": "provider-anthropic",
+                "config": {
+                    "api_key": "[REDACTED]",
+                    "model": "claude-sonnet-4-20250514",
+                },
+            },
+            {
+                "module": "provider-openai",
+                "config": {"api_key": "[REDACTED]", "model": "gpt-4o"},
+            },
+        ],
+        "tools": [{"module": "tool-bash"}],
+    }
+
+
+def _make_live_overrides() -> list[dict]:
+    """User settings overrides with live credentials."""
+    return [
+        {
+            "module": "provider-anthropic",
+            "config": {"api_key": "sk-ant-live-key-123"},
+        },
+        {
+            "module": "provider-openai",
+            "config": {"api_key": "sk-openai-live-key-456"},
+        },
+    ]
+
+
+def test_credential_refresh_restores_api_keys():
+    """Redacted api_key values are replaced with live credentials."""
+    redacted = _make_redacted_config()
+    live_overrides = _make_live_overrides()
+
+    refreshed = _apply_provider_overrides(redacted["providers"], live_overrides)
+    refreshed = _map_id_to_instance_id(refreshed)
+    result = expand_env_vars({**redacted, "providers": refreshed})
+
+    anthropic = next(
+        p for p in result["providers"] if p["module"] == "provider-anthropic"
+    )
+    openai = next(p for p in result["providers"] if p["module"] == "provider-openai")
+
+    assert anthropic["config"]["api_key"] == "sk-ant-live-key-123"
+    assert openai["config"]["api_key"] == "sk-openai-live-key-456"
+
+
+def test_credential_refresh_preserves_non_credential_config():
+    """Agent-specific provider config (model, routing) survives the refresh."""
+    redacted = _make_redacted_config()
+    live_overrides = _make_live_overrides()
+
+    refreshed = _apply_provider_overrides(redacted["providers"], live_overrides)
+    refreshed = _map_id_to_instance_id(refreshed)
+    result = expand_env_vars({**redacted, "providers": refreshed})
+
+    anthropic = next(
+        p for p in result["providers"] if p["module"] == "provider-anthropic"
+    )
+    openai = next(p for p in result["providers"] if p["module"] == "provider-openai")
+
+    # Model selections from the original spawn config must survive
+    assert anthropic["config"]["model"] == "claude-sonnet-4-20250514"
+    assert openai["config"]["model"] == "gpt-4o"
+
+    # Non-provider config must be untouched
+    assert result["tools"] == [{"module": "tool-bash"}]
+
+
+def test_credential_refresh_handles_env_var_overrides():
+    """Settings with ${VAR} references are expanded to real values."""
+    redacted = _make_redacted_config()
+    env_overrides = [
+        {
+            "module": "provider-anthropic",
+            "config": {"api_key": "${TEST_ANTHROPIC_KEY}"},
+        },
+    ]
+
+    with patch.dict("os.environ", {"TEST_ANTHROPIC_KEY": "sk-from-env-789"}):
+        refreshed = _apply_provider_overrides(redacted["providers"], env_overrides)
+        refreshed = _map_id_to_instance_id(refreshed)
+        result = expand_env_vars({**redacted, "providers": refreshed})
+
+    anthropic = next(
+        p for p in result["providers"] if p["module"] == "provider-anthropic"
+    )
+    assert anthropic["config"]["api_key"] == "sk-from-env-789"
+
+
+def test_credential_refresh_with_id_mapping():
+    """Providers with 'id' field get 'instance_id' mapped for kernel compat."""
+    redacted = {
+        "providers": [
+            {
+                "module": "provider-anthropic",
+                "id": "anthropic-sonnet",
+                "config": {"api_key": "[REDACTED]"},
+            },
+        ],
+    }
+    live_overrides = [
+        {
+            "module": "provider-anthropic",
+            "id": "anthropic-sonnet",
+            "config": {"api_key": "sk-live-key"},
+        },
+    ]
+
+    refreshed = _apply_provider_overrides(redacted["providers"], live_overrides)
+    refreshed = _map_id_to_instance_id(refreshed)
+    result = expand_env_vars({**redacted, "providers": refreshed})
+
+    provider = result["providers"][0]
+    assert provider["config"]["api_key"] == "sk-live-key"
+    assert provider["instance_id"] == "anthropic-sonnet"
+
+
+def test_credential_refresh_no_overrides_is_noop():
+    """When no user overrides exist, config passes through unchanged."""
+    redacted = _make_redacted_config()
+    empty_overrides: list[dict] = []
+
+    refreshed = _apply_provider_overrides(redacted["providers"], empty_overrides)
+    refreshed = _map_id_to_instance_id(refreshed)
+    result = expand_env_vars({**redacted, "providers": refreshed})
+
+    # Keys remain redacted — no overrides to restore from
+    anthropic = next(
+        p for p in result["providers"] if p["module"] == "provider-anthropic"
+    )
+    assert anthropic["config"]["api_key"] == "[REDACTED]"


### PR DESCRIPTION
## Summary

Companion to #192 (redact secrets in metadata). After that PR redacts API keys to `"[REDACTED]"` before writing session metadata to disk, `resume_sub_session()` must re-derive live credentials from user settings before creating the `AmplifierSession`.

## Problem

`resume_sub_session()` at `session_spawner.py:856-895` loads `config` from `metadata.json` and passes it directly to `AmplifierSession()` — no credential refresh between load and use. After #192, `api_key` values on disk become `"[REDACTED]"`, so any resumed sub-session fails authentication on the first API call.

## Fix

After loading `merged_config` from disk, re-derive live provider credentials from user settings using existing `config.py` building blocks:

1. `AppSettings().get_provider_overrides()` — reads provider configs from settings.yaml
2. `_apply_provider_overrides()` — deep-merges live credentials by module ID (preserves agent-specific model overrides)
3. `_map_id_to_instance_id()` — maps `id` → `instance_id` for kernel compatibility
4. `expand_env_vars()` — expands `${VAR}` references to actual values

All four functions already exist and are exported in `config.py.__all__`.

## Testing

5 new tests covering:
- API key restoration from user settings overrides
- Preservation of non-credential config (model selections, tool config)
- Environment variable expansion (`${VAR}`)
- `id` → `instance_id` mapping
- No-op when no overrides exist