### PR TITLE
fix(update): apply update when git deps stale but PyPI current

### DIFF
--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -1129,6 +1129,13 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
         else []
     )
 
+    # check_pypi_packages_for_updates() only queries PyPI (amplifier-core).
+    # Git-sourced deps (amplifier-app-cli, amplifier-foundation, …) are tracked
+    # by umbrella_deps but were never wired back into the apply decision.
+    # If any git dep is stale, the update path must trigger regardless of PyPI.
+    if any(d.get("has_update") for d in umbrella_deps):
+        has_umbrella_updates = True
+
     # Display results based on verbosity
     if verbose:
         _show_verbose_report(

--- a/tests/test_update_executor.py
+++ b/tests/test_update_executor.py
@@ -712,3 +712,146 @@ async def test_check_pypi_returns_true_on_500(caplog):
         "Expected a WARNING mentioning 'stale' or 'assuming' on PyPI 500 response.\n"
         f"Actual warnings: {warning_msgs}"
     )
+
+
+def test_update_command_applies_when_git_deps_stale_but_pypi_current():
+    """Regression: stale git deps trigger the update even when PyPI is current.
+
+    Bug scenario (fixed by this PR):
+    - amplifier-app-cli has local SHA 3d4f953, remote SHA 51a5138 → has_update=True
+    - amplifier-foundation has local SHA a27d582, remote SHA edb8054 → has_update=True
+    - amplifier-core on PyPI: 1.6.0 installed == 1.6.0 latest → no PyPI update
+
+    Before the fix, check_pypi_packages_for_updates() returned False, so
+    has_umbrella_updates stayed False, nothing_to_update became True, and
+    `amplifier update` printed "All sources up to date" and exited — even though
+    the table correctly showed the SHA mismatches.
+
+    After the fix, any d.get("has_update") in umbrella_deps sets
+    has_umbrella_updates=True, and execute_updates IS called.
+    """
+    from click.testing import CliRunner
+
+    from amplifier_app_cli.commands.update import update
+    from amplifier_app_cli.utils.source_status import UpdateReport
+    from amplifier_app_cli.utils.update_executor import ExecutionResult
+
+    fake_info = UmbrellaInfo(
+        url="https://github.com/microsoft/amplifier",
+        ref="main",
+        commit_id=None,
+    )
+    captured: dict = {}
+
+    async def fake_execute_updates(
+        report, umbrella_info=None, progress_callback=None, force=False
+    ):
+        captured["umbrella_info"] = umbrella_info
+        return ExecutionResult(success=True, updated=["amplifier"], messages=[])
+
+    # PyPI reports amplifier-core is current — this is the key precondition.
+    async def fake_pypi_current():
+        return False
+
+    empty_report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+
+    async def fake_check_all_sources(**kwargs):
+        return empty_report
+
+    async def fake_check_all_bundle_status():
+        return {}
+
+    # Two git-sourced deps are stale — this is what the table already shows correctly.
+    async def fake_get_umbrella_dep_details(info):
+        return [
+            {
+                "name": "amplifier-app-cli",
+                "local_sha": "3d4f953",
+                "remote_sha": "51a5138",
+                "source_url": "https://github.com/microsoft/amplifier-app-cli",
+                "has_update": True,
+                "is_local": False,
+                "path": None,
+                "has_changes": False,
+            },
+            {
+                "name": "amplifier-foundation",
+                "local_sha": "a27d582",
+                "remote_sha": "edb8054",
+                "source_url": "https://github.com/microsoft/amplifier-foundation",
+                "has_update": True,
+                "is_local": False,
+                "path": None,
+                "has_changes": False,
+            },
+            {
+                "name": "amplifier-core (PyPI)",
+                "local_sha": "1.6.0",
+                "remote_sha": "1.6.0",
+                "source_url": "https://pypi.org/project/amplifier-core/",
+                "has_update": False,
+                "is_local": False,
+                "path": None,
+                "has_changes": False,
+                "display_type": "version",
+            },
+        ]
+
+    with (
+        patch(
+            "amplifier_app_cli.utils.umbrella_discovery.discover_umbrella_source",
+            return_value=fake_info,
+        ),
+        patch(
+            "amplifier_app_cli.utils.update_executor.check_pypi_packages_for_updates",
+            side_effect=fake_pypi_current,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.check_all_sources",
+            side_effect=fake_check_all_sources,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update._check_all_bundle_status",
+            side_effect=fake_check_all_bundle_status,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update._get_umbrella_dependency_details",
+            side_effect=fake_get_umbrella_dep_details,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.execute_updates",
+            side_effect=fake_execute_updates,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update._refresh_skills_cache",
+            return_value=None,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.save_update_last_check",
+            return_value=None,
+        ),
+    ):
+        runner = CliRunner()
+        result = runner.invoke(update, ["--yes"])
+
+    if result.exception and not isinstance(result.exception, SystemExit):
+        import traceback
+
+        raise AssertionError(
+            f"update command raised an exception:\n"
+            f"{''.join(traceback.format_exception(type(result.exception), result.exception, result.exception.__traceback__))}\n"
+            f"Output:\n{result.output}"
+        )
+
+    assert captured.get("umbrella_info") is not None, (
+        "execute_updates was NOT called even though git deps are stale.\n"
+        "check_pypi_packages_for_updates() returned False (PyPI current), but\n"
+        "umbrella_deps contained has_update=True entries for amplifier-app-cli\n"
+        "and amplifier-foundation — the update path must still trigger.\n"
+        f"captured={captured!r}\n"
+        f"Command output:\n{result.output}"
+    )
+    assert "all sources up to date" not in result.output.lower(), (
+        "Command reported 'All sources up to date' despite stale git deps.\n"
+        f"Command output:\n{result.output}"
+    )


### PR DESCRIPTION
## Bug

`amplifier update` reports "All sources up to date" and exits even when the table shows `amplifier-app-cli` and `amplifier-foundation` with git SHA mismatches.

**Real example triggering the bug:**
- `amplifier-app-cli`: local `3d4f953`, remote `51a5138` → table shows update available
- `amplifier-foundation`: local `a27d582`, remote `edb8054` → table shows update available
- `amplifier-core` (PyPI): 1.6.0 == 1.6.0 → table shows current

Result: table renders the diffs correctly, but then prints "All sources up to date" and exits.

## Root cause

Two parallel data paths in `commands/update.py` drove different decisions:

**Path 1 — table** (`umbrella_deps`, line 1126): `_get_umbrella_dependency_details()` walks all git-sourced deps, computes `has_update = local_sha != remote_sha` per package. Drives the displayed table.

**Path 2 — apply gate** (`has_umbrella_updates`, line 1085): `check_pypi_packages_for_updates()` queries PyPI for `amplifier-core` only. Returns `False` when PyPI is current. This alone drove `nothing_to_update`.

The `check_pypi_packages_for_updates()` docstring (lines 264-269) even notes the git rows exist: *"The umbrella `amplifier` package is git-sourced; its version is already covered by the `amplifier-app-cli` / `amplifier-foundation` git rows."* The git rows were never wired back into `has_umbrella_updates`.

## Fix shape chosen: A (conservative)

Two shapes were evaluated:

- **Shape A**: keep `check_pypi_packages_for_updates()`, OR-in git staleness from `umbrella_deps`
- **Shape B**: delete `check_pypi_packages_for_updates()`, derive entirely from `umbrella_deps`

**Shape A chosen** because the functions have different error policies for PyPI:
- `check_pypi_packages_for_updates()`: **fail-stale** (returns `True` on network/parse errors — avoids v1.0.7 silent-staleness pattern, documented in its docstring)
- `_get_umbrella_dependency_details()` amplifier-core row: **fail-clean** (exceptions set `has_update=False`; outer `except Exception: return []` makes whole function fail-clean)

Shape B would silently downgrade from fail-stale to fail-clean — potentially reintroducing the exact silent-staleness pattern the authors explicitly protected against.

## Change

`amplifier_app_cli/commands/update.py` — 7 lines after `umbrella_deps` is computed (before display calls and `nothing_to_update` gate):

```python
# check_pypi_packages_for_updates() only queries PyPI (amplifier-core).
# Git-sourced deps (amplifier-app-cli, amplifier-foundation, ...) are tracked
# by umbrella_deps but were never wired back into the apply decision.
# If any git dep is stale, the update path must trigger regardless of PyPI.
if any(d.get("has_update") for d in umbrella_deps):
    has_umbrella_updates = True
```

Placement ensures `_show_concise_report()` and all downstream uses of `has_umbrella_updates` (lines 1165, 1196, 1224) see the corrected flag.

## Correctness trace

**Bug scenario** (git deps stale, PyPI current):
1. `check_pypi_packages_for_updates()` → `False` → `has_umbrella_updates = False`
2. `umbrella_deps` contains `has_update=True` entries
3. NEW: `any(...) → True → has_umbrella_updates = True`
4. `nothing_to_update = False` → update applies correctly

**All-clean scenario**:
1. `check_pypi_packages_for_updates()` → `False`
2. `umbrella_deps` all `has_update=False`
3. NEW: `any(...) → False` → `has_umbrella_updates` unchanged
4. `nothing_to_update = True` → "All sources up to date" prints correctly

## Tests

New: `test_update_command_applies_when_git_deps_stale_but_pypi_current` — mocks the exact bug scenario (two stale git deps, PyPI current), verifies `execute_updates` IS called and "All sources up to date" is NOT printed.

Existing tests pass:
- `test_update_command_exits_early_when_pypi_is_current` — nothing_to_update=True when all clean
- `test_update_command_passes_umbrella_info_despite_no_git_updates` — PyPI-only update still works