### PR TITLE
feat(cli): honor canonical skill name from shortcut dispatch dict

### DIFF
--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -485,12 +485,22 @@ class CommandProcessor:
                         data["trailing_prompt"] = trailing
                 return "handle_mode", data
 
-            # Check for skill shortcuts (e.g., /simplify -> load_skill)
+            # Check for skill shortcuts (e.g., /simplify -> load_skill).
+            # The dispatch dict value may include a "name" key giving the
+            # canonical skill name when the lookup key is an alias (the
+            # skill's `shortcut:` frontmatter field). Older skills bundles
+            # don't populate "name" — fall back to the lookup key.
             if shortcut_name in self.SKILL_SHORTCUTS:
+                entry = self.SKILL_SHORTCUTS[shortcut_name]
+                canonical = (
+                    entry.get("name", shortcut_name)
+                    if isinstance(entry, dict)
+                    else shortcut_name
+                )
                 return (
                     "load_skill",
                     {
-                        "skill_name": shortcut_name,
+                        "skill_name": canonical,
                         "arguments": args.strip(),
                         "command": command,
                     },
@@ -628,7 +638,8 @@ class CommandProcessor:
             if current_mode:
                 # Emit mode:cleared BEFORE state mutation so hooks see the old state
                 await self.session.coordinator.hooks.emit(
-                    "mode:cleared", {"name": current_mode, "previous_mode": current_mode}
+                    "mode:cleared",
+                    {"name": current_mode, "previous_mode": current_mode},
                 )
                 session_state["active_mode"] = None
                 # Reset warnings in mode hooks if present
@@ -2880,7 +2891,9 @@ async def interactive_chat(
                         console.print("\n[dim]Processing... (Ctrl+C to cancel)[/dim]")
 
                         # Process runtime @mentions in user input
-                        _expanded_text = await _process_runtime_mentions(session, data["text"])
+                        _expanded_text = await _process_runtime_mentions(
+                            session, data["text"]
+                        )
                         await _execute_with_interrupt(_expanded_text)
 
                     else:
@@ -2912,7 +2925,9 @@ async def interactive_chat(
                             console.print(
                                 "\n[dim]Processing... (Ctrl+C to cancel)[/dim]"
                             )
-                            trailing_prompt = await _process_runtime_mentions(session, trailing_prompt)
+                            trailing_prompt = await _process_runtime_mentions(
+                                session, trailing_prompt
+                            )
                             await _execute_with_interrupt(trailing_prompt)
 
             except EOFError:


### PR DESCRIPTION
## Summary

The skill dispatch dict from `SkillsDiscovery.get_shortcuts()` can now include a `"name"` field in each value carrying the canonical skill name. This lets a skill be invokable via both its canonical name AND an alias (the skill's `shortcut:` frontmatter field) without the CLI needing to know which key matched — it always loads the canonical.

Required for the parallel `microsoft/amplifier-bundle-skills` PR that adds shortcut alias support: without this CLI change, an alias key in `SKILL_SHORTCUTS` would dispatch a `load_skill` call with the alias as the `skill_name`, which would fail to resolve.

## Change

Single block in `CommandProcessor.process_input()`:

```python
# Check for skill shortcuts (e.g., /simplify -> load_skill).
# The dispatch dict value may include a "name" key giving the
# canonical skill name when the lookup key is an alias.
# Older skills bundles don't populate "name" — fall back to key.
if shortcut_name in self.SKILL_SHORTCUTS:
    entry = self.SKILL_SHORTCUTS[shortcut_name]
    canonical = (
        entry.get("name", shortcut_name)
        if isinstance(entry, dict)
        else shortcut_name
    )
    return (
        "load_skill",
        {
            "skill_name": canonical,
            "arguments": args.strip(),
            "command": command,
        },
    )
```

## Backward compatibility

`.get("name", shortcut_name)` falls back to the lookup key, so older skills bundles whose dispatch dict values don't include `"name"` continue to work exactly as before — canonical names still work, aliases no-op until the skills bundle is updated (since old skills bundles can't produce alias keys).

## Validation

```
uv run python -m pytest tests/ -k "skill" -q
96 passed, 868 deselected in 0.14s
```

All skill-related CLI tests pass.

## Companion PRs

- `microsoft/amplifier-bundle-skills` — adds the `shortcut:` field and updates `get_shortcuts()` to include canonical `name`
- `microsoft/amplifier-bundle-modes` — parallel regex relaxation for modes' `shortcut:` field
- `microsoft-amplifier/amplifier-bundle-made-support` — dogfoods with `shortcut: COSam` on cranky-old-sam