### PR TITLE
fix(cli): restore table rendering for bundle/module/source list commands

### DIFF
--- a/amplifier_app_cli/commands/bundle.py
+++ b/amplifier_app_cli/commands/bundle.py
@@ -91,18 +91,15 @@ def bundle_list(show_all: bool, compact: bool, detailed: bool, fmt: str):
     app_settings = AppSettings()
     discovery = AppBundleDiscovery()
     active_bundle = app_settings.get_active_bundle()
-    view = resolve_view(
-        ("bundle", "list"), compact_flag=compact, detailed_flag=detailed
-    )
     renderer = ItemRenderer(console)
 
     if show_all:
         _show_all_bundles(
-            discovery, active_bundle, view=view, fmt=fmt, renderer=renderer
+            discovery, active_bundle, compact=compact, fmt=fmt, renderer=renderer
         )
     else:
         _show_user_bundles(
-            discovery, active_bundle, view=view, fmt=fmt, renderer=renderer
+            discovery, active_bundle, compact=compact, fmt=fmt, renderer=renderer
         )
 
 
@@ -117,7 +114,7 @@ def _bundle_item(
     status = "active" if name == active_bundle else "available"
     item: dict[str, Any] = {
         "name": name,
-        "enabled": name == active_bundle,
+        "enabled": True,  # bundles are available/loadable — active-ness shown via status
         "source_uri": uri,
         "behaviors": [location] if location else [],
         "config_summary": {"status": status, "location": location},
@@ -131,7 +128,7 @@ def _show_user_bundles(
     discovery: AppBundleDiscovery,
     active_bundle: str | None,
     *,
-    view: str,
+    compact: bool,
     fmt: str,
     renderer: ItemRenderer,
 ) -> None:
@@ -164,12 +161,37 @@ def _show_user_bundles(
         renderer.render_json(items)
         return
 
-    renderer.render(items, view=view, category="bundle", section_title="bundles")
+    if compact:
+        renderer.render(
+            items, view="compact", category="bundle", section_title="bundles"
+        )
+    else:
+        # Restored Rich Table (default and --detailed both use this path)
+        table = Table(
+            title="Available Bundles", show_header=True, header_style="bold cyan"
+        )
+        table.add_column("Name", style="green")
+        table.add_column("Location", style="yellow")
+        table.add_column("Status")
+
+        for item in items:
+            name = item["name"]
+            location = item["config_summary"]["location"]
+            item_type = item["config_summary"].get("type", "")
+            if item_type == "app":
+                status = "[cyan]app[/cyan]"
+            elif item["config_summary"]["status"] == "active":
+                status = "[bold green]active[/bold green]"
+            else:
+                status = ""
+            table.add_row(name, location, status)
+
+        console.print(table)
 
     if active_bundle:
-        console.print(f"[dim]Mode: Bundle ({active_bundle})[/dim]")
+        console.print(f"\n[dim]Mode: Bundle ({active_bundle})[/dim]")
     else:
-        console.print("[dim]Mode: No bundle active (default)[/dim]")
+        console.print("\n[dim]Mode: No bundle active (default)[/dim]")
     console.print(
         "[dim]Use --all to see all bundles including dependencies and nested bundles.[/dim]"
     )
@@ -179,7 +201,7 @@ def _show_all_bundles(
     discovery: AppBundleDiscovery,
     active_bundle: str | None,
     *,
-    view: str,
+    compact: bool,
     fmt: str,
     renderer: ItemRenderer,
 ) -> None:
@@ -204,10 +226,37 @@ def _show_all_bundles(
             )
         if fmt == "json":
             all_items.extend(items)
-        else:
+        elif compact:
             renderer.render(
-                items, view=view, category="bundle", section_title="built-in bundles"
+                items,
+                view="compact",
+                category="bundle",
+                section_title="built-in bundles",
             )
+        else:
+            table = Table(
+                title="Built-in Bundles (always available)",
+                show_header=True,
+                header_style="bold cyan",
+            )
+            table.add_column("Name", style="green")
+            table.add_column("Location", style="yellow")
+            table.add_column("In Default List", style="dim")
+            table.add_column("Status")
+            for item in items:
+                status = (
+                    "[bold green]active[/bold green]"
+                    if item["config_summary"]["status"] == "active"
+                    else ""
+                )
+                table.add_row(
+                    item["name"],
+                    item["config_summary"]["location"],
+                    item["config_summary"].get("in_default_list", ""),
+                    status,
+                )
+            console.print(table)
+            console.print()
 
     # User-added bundles
     if categories["user_added"]:
@@ -223,10 +272,33 @@ def _show_all_bundles(
             )
         if fmt == "json":
             all_items.extend(items)
-        else:
+        elif compact:
             renderer.render(
-                items, view=view, category="bundle", section_title="user-added bundles"
+                items,
+                view="compact",
+                category="bundle",
+                section_title="user-added bundles",
             )
+        else:
+            table = Table(
+                title="User-Added Bundles", show_header=True, header_style="bold cyan"
+            )
+            table.add_column("Name", style="green")
+            table.add_column("Location", style="yellow")
+            table.add_column("Status")
+            for item in items:
+                status = (
+                    "[bold green]active[/bold green]"
+                    if item["config_summary"]["status"] == "active"
+                    else ""
+                )
+                table.add_row(
+                    item["name"],
+                    item["config_summary"]["location"],
+                    status,
+                )
+            console.print(table)
+            console.print()
 
     # Discovered root bundles (dependencies)
     if categories["dependencies"]:
@@ -243,13 +315,30 @@ def _show_all_bundles(
             )
         if fmt == "json":
             all_items.extend(items)
-        else:
+        elif compact:
             renderer.render(
                 items,
-                view=view,
+                view="compact",
                 category="bundle",
                 section_title="discovered root bundles",
             )
+        else:
+            table = Table(
+                title="Discovered Root Bundles (loaded via includes/namespaces)",
+                show_header=True,
+                header_style="bold yellow",
+            )
+            table.add_column("Name", style="green")
+            table.add_column("Location", style="yellow")
+            table.add_column("Loaded By", style="dim")
+            for item in items:
+                table.add_row(
+                    item["name"],
+                    item["config_summary"]["location"],
+                    item["config_summary"].get("loaded_by", ""),
+                )
+            console.print(table)
+            console.print()
 
     # Nested bundles (behaviors, providers)
     if categories["nested_bundles"]:
@@ -268,10 +357,27 @@ def _show_all_bundles(
             )
         if fmt == "json":
             all_items.extend(items)
-        else:
+        elif compact:
             renderer.render(
-                items, view=view, category="bundle", section_title="nested bundles"
+                items, view="compact", category="bundle", section_title="nested bundles"
             )
+        else:
+            table = Table(
+                title="Nested Bundles (behaviors, providers - part of a root bundle)",
+                show_header=True,
+                header_style="bold magenta",
+            )
+            table.add_column("Name", style="dim green")
+            table.add_column("Root Bundle", style="dim cyan")
+            table.add_column("Location", style="dim yellow")
+            for item in items:
+                table.add_row(
+                    item["name"],
+                    item["config_summary"].get("root", ""),
+                    item["config_summary"]["location"],
+                )
+            console.print(table)
+            console.print()
 
     if fmt == "json":
         renderer.render_json(all_items)
@@ -383,7 +489,7 @@ def bundle_show(name: str, compact: bool, detailed: bool, fmt: str):
     # Build a bundle item for JSON and compact views
     bundle_item: dict[str, Any] = {
         "name": bundle_obj.name,
-        "enabled": bundle_obj.name == active_bundle,
+        "enabled": True,  # bundles are available/loadable — active-ness shown via active: yes/no
         "source_uri": bundle_obj.uri if hasattr(bundle_obj, "uri") else None,
         "include_paths": [
             [

--- a/amplifier_app_cli/commands/module.py
+++ b/amplifier_app_cli/commands/module.py
@@ -53,12 +53,10 @@ def list_modules(type: str, compact: bool, detailed: bool, fmt: str):
     loader = ModuleLoader()
     modules_info = asyncio.run(loader.discover())
     resolver = create_foundation_resolver()
-    view = resolve_view(
-        ("module", "list"), compact_flag=compact, detailed_flag=detailed
-    )
     renderer = ItemRenderer(console)
 
-    items: list[dict[str, Any]] = []
+    # Collect installed and cached modules separately (for rich table path)
+    installed_items: list[dict[str, Any]] = []
     for module_info in modules_info:
         if type != "all" and type != module_info.type:
             continue
@@ -70,7 +68,7 @@ def list_modules(type: str, compact: bool, detailed: bool, fmt: str):
             source_str = "unknown"
             origin = "unknown"
 
-        items.append(
+        installed_items.append(
             {
                 "name": module_info.id,
                 "enabled": True,
@@ -80,17 +78,19 @@ def list_modules(type: str, compact: bool, detailed: bool, fmt: str):
                 "config_summary": {
                     "type": module_info.type,
                     "description": module_info.description,
+                    "source": source_str,
+                    "origin": origin,
                 },
             }
         )
 
-    # Cached modules
     local_override_names = _get_local_override_names()
     cached_modules = [
         m for m in _get_cached_modules(type) if m["id"] not in local_override_names
     ]
+    cached_items: list[dict[str, Any]] = []
     for mod in cached_modules:
-        items.append(
+        cached_items.append(
             {
                 "name": mod["id"],
                 "enabled": True,
@@ -106,16 +106,82 @@ def list_modules(type: str, compact: bool, detailed: bool, fmt: str):
             }
         )
 
-    if not items:
+    all_items = installed_items + cached_items
+    if not all_items:
         console.print("[dim]No installed modules found[/dim]")
         return
 
     if fmt == "json":
-        renderer.render_json(items)
+        renderer.render_json(all_items)
         return
 
-    renderer.render(items, view=view, category="module", section_title="modules")
-    if cached_modules:
+    if compact:
+        renderer.render(
+            all_items, view="compact", category="module", section_title="modules"
+        )
+        if cached_items:
+            console.print(
+                "[dim]Note: Cached modules are downloaded on-demand when used.[/dim]"
+            )
+            console.print(
+                "[dim]Use 'amplifier module update' to update cached modules.[/dim]"
+            )
+        return
+
+    # Restored Rich Tables (default and --detailed)
+    if installed_items:
+        table = Table(
+            title="Installed Modules (via entry points)",
+            show_header=True,
+            header_style="bold cyan",
+        )
+        table.add_column("Name", style="green")
+        table.add_column("Type", style="yellow")
+        table.add_column("Source", style="magenta")
+        table.add_column("Origin", style="cyan")
+        table.add_column("Description")
+
+        for item in installed_items:
+            cs = item["config_summary"]
+            source_str = cs.get("source", "unknown")
+            if len(source_str) > 40:
+                source_str = source_str[:37] + "..."
+            origin = cs.get("origin", "unknown")
+            table.add_row(
+                item["name"],
+                cs.get("type", ""),
+                source_str,
+                origin,
+                cs.get("description", ""),
+            )
+        console.print(table)
+    else:
+        console.print("[dim]No installed modules found[/dim]")
+
+    if cached_items:
+        console.print()
+        table = Table(
+            title="Cached Modules (downloaded from git)",
+            show_header=True,
+            header_style="bold magenta",
+        )
+        table.add_column("Name", style="green")
+        table.add_column("Type", style="yellow")
+        table.add_column("Ref", style="cyan")
+        table.add_column("SHA", style="dim")
+        table.add_column("Mutable", style="magenta")
+
+        for item in cached_items:
+            cs = item["config_summary"]
+            table.add_row(
+                item["name"],
+                cs.get("type", ""),
+                cs.get("ref", ""),
+                cs.get("sha", ""),
+                cs.get("mutable", ""),
+            )
+        console.print(table)
+        console.print()
         console.print(
             "[dim]Note: Cached modules are downloaded on-demand when used.[/dim]"
         )

--- a/amplifier_app_cli/commands/source.py
+++ b/amplifier_app_cli/commands/source.py
@@ -17,12 +17,13 @@ from pathlib import Path
 from typing import Any, cast
 
 import click
+from rich.table import Table
 
 from ..console import console
 from ..lib.settings import AppSettings
 from ..paths import ScopeNotAvailableError
 from ..ui.item_renderer import ItemRenderer
-from ..ui.view_policy import resolve_view, view_flags
+from ..ui.view_policy import view_flags
 from ..utils.error_format import escape_markup
 from ..paths import ScopeType
 from ..paths import create_foundation_resolver
@@ -455,42 +456,94 @@ def source_list(compact: bool, detailed: bool, fmt: str):
         console.print("  [cyan]amplifier source add <identifier> <uri>[/cyan]")
         return
 
-    view = resolve_view(
-        ("source", "list"), compact_flag=compact, detailed_flag=detailed
-    )
     renderer = ItemRenderer(console)
 
-    items: list[dict[str, Any]] = []
-
-    for module_id, source_uri in sorted(module_sources.items()):
-        items.append(
-            {
-                "name": module_id,
-                "enabled": True,
-                "source_uri": source_uri,
-                "behaviors": ["module"],
-                "config_summary": {"type": "module"},
-            }
-        )
-
-    for bundle_name, source_uri in sorted(bundle_sources.items()):
-        items.append(
-            {
-                "name": bundle_name,
-                "enabled": True,
-                "source_uri": source_uri,
-                "behaviors": ["bundle"],
-                "config_summary": {"type": "bundle"},
-            }
-        )
-
     if fmt == "json":
+        items: list[dict[str, Any]] = []
+        for module_id, source_uri in sorted(module_sources.items()):
+            items.append(
+                {
+                    "name": module_id,
+                    "enabled": True,
+                    "source_uri": source_uri,
+                    "behaviors": ["module"],
+                    "config_summary": {"type": "module"},
+                }
+            )
+        for bundle_name, source_uri in sorted(bundle_sources.items()):
+            items.append(
+                {
+                    "name": bundle_name,
+                    "enabled": True,
+                    "source_uri": source_uri,
+                    "behaviors": ["bundle"],
+                    "config_summary": {"type": "bundle"},
+                }
+            )
         renderer.render_json(items)
         return
 
-    renderer.render(
-        items, view=view, category="source", section_title="source overrides"
-    )
+    if compact:
+        items = []
+        for module_id, source_uri in sorted(module_sources.items()):
+            items.append(
+                {
+                    "name": module_id,
+                    "enabled": True,
+                    "source_uri": source_uri,
+                    "behaviors": ["module"],
+                    "config_summary": {"type": "module"},
+                }
+            )
+        for bundle_name, source_uri in sorted(bundle_sources.items()):
+            items.append(
+                {
+                    "name": bundle_name,
+                    "enabled": True,
+                    "source_uri": source_uri,
+                    "behaviors": ["bundle"],
+                    "config_summary": {"type": "bundle"},
+                }
+            )
+        renderer.render(
+            items, view="compact", category="source", section_title="source overrides"
+        )
+        return
+
+    # Restored Rich Tables (default and --detailed)
+    if module_sources:
+        table = Table(
+            title="Module Source Overrides", show_header=True, header_style="bold cyan"
+        )
+        table.add_column("Module", style="green")
+        table.add_column("Source", style="magenta")
+
+        for module_id, source_uri in sorted(module_sources.items()):
+            display_uri = (
+                source_uri if len(source_uri) <= 60 else source_uri[:57] + "..."
+            )
+            table.add_row(module_id, display_uri)
+
+        console.print(table)
+
+    if bundle_sources:
+        if module_sources:
+            console.print()
+        table = Table(
+            title="Bundle Source Overrides",
+            show_header=True,
+            header_style="bold cyan",
+        )
+        table.add_column("Bundle", style="green")
+        table.add_column("Source", style="magenta")
+
+        for bundle_name, source_uri in sorted(bundle_sources.items()):
+            display_uri = (
+                source_uri if len(source_uri) <= 60 else source_uri[:57] + "..."
+            )
+            table.add_row(bundle_name, display_uri)
+
+        console.print(table)
 
 
 @source.command("show")

--- a/amplifier_app_cli/ui/view_policy.py
+++ b/amplifier_app_cli/ui/view_policy.py
@@ -34,14 +34,17 @@ DEFAULT_VIEW: dict[tuple[str, ...], str] = {
     ("module", "list"): "compact",
     ("module", "show"): "detailed",
     ("provider", "list"): "regular",
-    ("tool", "list"): "compact",
+    ("tool", "list"): "regular",
     ("tool", "info"): "detailed",
     ("source", "list"): "compact",
     ("session", "list"): "compact",
     ("session", "show"): "detailed",
     ("routing", "list"): "regular",
     ("routing", "show"): "detailed",
-    ("agents", "list"): "compact",
+    (
+        "agents",
+        "list",
+    ): "compact",  # regular and compact produce identical output for agents
     ("agents", "show"): "detailed",
     ("module", "override", "list"): "compact",
 }


### PR DESCRIPTION
## Summary

Restore the rich, table-based CLI rendering for inventory list commands (`bundle list`, `module list`, `source list`) and the richer section view for `tool list`.

## Root Cause

PR #180 (commit 4ce54f9, "views-and-provenance") introduced a shared ItemRenderer for the in-session `/config` dashboard and over-broadly migrated the CLI list/show commands to it. The CLI's own inventory categories (bundle/module/source) have no dedicated renderer section, so they fell back to a thin generic one-line list — losing the columnar tables. Additionally, `_bundle_item` set `enabled = (name == active_bundle)`, which mislabeled every available bundle as `← disabled`.

## Changes

- **bundle/module/source**: restored their own `rich.Table` rendering as the default view. `--compact` and `--format json` still route through the shared ItemRenderer.
- **tool list**: flipped default view from `compact` to `regular` in view_policy.py so the existing rich section renders.
- **Fixed semantics bug**: `_bundle_item` now sets `enabled=True`; active-ness conveyed by Status column + Mode footer.
- **No in-session impact**: main.py, item_renderer.py, dashboard_renderer.py unchanged.

## Verification

- Test suite: 915 passed, 1 pre-existing unrelated failure
- Tested in DTU with all commands verified
- No impact to in-session `/config show --detailed` path

Generated with [Amplifier](https://github.com/microsoft/amplifier)