### PR TITLE
fix(cli): restore table rendering for session list

### DIFF
--- a/amplifier_app_cli/commands/session.py
+++ b/amplifier_app_cli/commands/session.py
@@ -1496,12 +1496,35 @@ def _display_project_sessions(
             }
         )
 
-    renderer = ItemRenderer(console)
     if fmt == "json":
-        renderer.render_json(items)
+        ItemRenderer(console).render_json(items)
         return
 
-    renderer.render(items, view=view, category="session", section_title=title)
+    if view == "compact":
+        ItemRenderer(console).render(
+            items, view=view, category="session", section_title=title
+        )
+        return
+
+    # Default (regular/detailed): a Rich table — mirrors the --all-projects table
+    # minus the Project column. Session listings are tabular records, not the
+    # on/off config items the shared ItemRenderer was built for, so the table
+    # actually shows the modified-time and message-count columns that the
+    # compact view computes but never displays.
+    table = Table(title=title, show_header=True, header_style="bold cyan")
+    table.add_column("Name", style="cyan", max_width=40)
+    table.add_column("Session ID", style="green")
+    table.add_column("Modified", style="yellow")
+    table.add_column("Msgs", justify="right")
+    for item in items:
+        cfg = item["config_summary"]
+        table.add_row(
+            item["name"],
+            cfg["session_id"],
+            cfg["modified"],
+            cfg["messages"],
+        )
+    console.print(table)
 
 
 __all__ = ["register_session_commands"]

--- a/amplifier_app_cli/ui/view_policy.py
+++ b/amplifier_app_cli/ui/view_policy.py
@@ -37,7 +37,7 @@ DEFAULT_VIEW: dict[tuple[str, ...], str] = {
     ("tool", "list"): "regular",
     ("tool", "info"): "detailed",
     ("source", "list"): "compact",
-    ("session", "list"): "compact",
+    ("session", "list"): "regular",
     ("session", "show"): "detailed",
     ("routing", "list"): "regular",
     ("routing", "show"): "detailed",


### PR DESCRIPTION
## Summary

Restore a Rich table as the default rendering for `amplifier session list` (the current-project / `--project` view).

## What changed

This is a follow-up to PR #201. PR #180 had migrated the per-project session listing through the shared in-session `ItemRenderer`, which only prints `[on] <name>` — a flat one-liner that dropped the Modified-time and message-count columns. The `--all-projects` variant kept its Rich table, leaving the command internally inconsistent.

`_display_project_sessions` now renders a Rich table (Name / Session ID / Modified / Msgs) for the default view — mirroring the existing `--all-projects` table, minus the Project column. `--compact` and `--format json` still route through ItemRenderer. `view_policy.py` default for `('session','list')` flipped `compact -> regular`.

## Verification

- Modified files: `amplifier_app_cli/commands/session.py`, `amplifier_app_cli/ui/view_policy.py`
- Verified the function has only two callers (both in `session list`) and is not coupled to the resume/fork/pager paths
- In-session `/config` rendering untouched (`main.py` / `ui/item_renderer.py` / `ui/dashboard_renderer.py` unchanged)
- Tests: 94 passed (same single pre-existing unrelated failure only)
- Verified working in a DTU

Generated with [Amplifier](https://github.com/microsoft/amplifier)