### PR TITLE
fix(cli): forward /command arguments into load_skill so fork skills receive them

### DIFF
--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -2341,11 +2341,21 @@ class CommandProcessor:
             available = ", ".join(s[0] for s in skills) if skills else "none"
             return False, f"Unknown skill: {skill_name}. Available: {available}"
 
-        # Construct synthetic prompt for session.execute()
+        # Construct synthetic prompt for session.execute().
+        #
+        # When the user supplies argument text (e.g. `/council <target>`), the
+        # model MUST forward it as the load_skill `arguments` parameter. This is
+        # the only channel by which the text reaches a fork skill's $ARGUMENTS:
+        # a forked sub-session cannot see this parent conversation, so passing it
+        # as "additional context" here is not enough on its own.
         if arguments:
             return (
                 True,
-                f'Use the load_skill tool to load the skill "{skill_name}". Additional context from the user: {arguments}',
+                f'Use the load_skill tool to load the skill "{skill_name}", '
+                f"passing the user's input as the `arguments` parameter "
+                f'(load_skill(skill_name="{skill_name}", arguments=...)) so the skill '
+                f"receives it — this is required for fork skills, which cannot otherwise "
+                f"see it. The user's input is: {arguments}",
             )
         else:
             return True, f'Use the load_skill tool to load the skill "{skill_name}".'


### PR DESCRIPTION
## Summary

Fixes a critical bug where slash-command arguments (e.g. `/council <target>`) never reached fork skills. This caused council and other fork-based skills to always fail with usage output, unable to process their target.

## The Bug

When a user invokes a fork skill via a slash command with arguments (e.g. `/council review this idea`), the CLI dispatcher forwards the skill name and user instruction to the model, which calls `load_skill(name, arguments, ...)`. The problem:

- The app-cli's synthetic prompt injected into the model (`_load_skill` at main.py:2348) did not instruct the model to forward the `arguments` parameter to the `load_skill` call.
- The model consequently called `load_skill(name='council', ...)` with no `arguments=...` key.
- The tool-skills module received no `arguments` parameter, defaulted to `None`, and passed an empty string to skill preprocessing.
- Council and other fork skills that depend on `$ARGUMENTS` would receive empty string, triggering their usage output guard.

## The Fix

The synthetic prompt in `_load_skill` (main.py:2348) now explicitly instructs the model to forward the `arguments` parameter to the `load_skill` call:

```
Include the arguments parameter when calling load_skill: arguments='<arguments>'
```

This pairs with a corresponding fix in **amplifier-bundle-skills PR #29**, which ensures fork skills thread the `$ARGUMENTS` variable through to their sub-agent bodies.

## Verification

Verified end-to-end in a Digital Twin Universe environment:

- `/council review this idea: ...` forwarded `arguments='review this idea: ...'` to load_skill
- Council's forked sub-session received `$ARGUMENTS` fully populated
- Council completed the review of the exact target string
- `/council` with no args still correctly prints usage (empty args → guard fires as intended)
- Inline skills (e.g. `/cranky-old-sam <arg>`) also receive arguments correctly

## Related

- **amplifier-bundle-skills PR #29**: Companion fix to thread `$ARGUMENTS` to fork skill bodies
- This is the CLI half of the council fix (showstopper where fork skills received no arguments at all)

Generated with [Amplifier](https://github.com/microsoft/amplifier)
