### PR TITLE
fix: pass session_cwd and is_resumed on self-healing retry

### DIFF
--- a/amplifier_app_cli/session_runner.py
+++ b/amplifier_app_cli/session_runner.py
@@ -412,6 +412,8 @@ async def _create_bundle_session(
                     session_id=session_id,
                     approval_system=approval_system,
                     display_system=display_system,
+                    session_cwd=Path.cwd(),  # CLI uses CWD for local @-mentions
+                    is_resumed=config.is_resume,  # Pass resume flag to kernel
                 )
                 # Warn if retry still has issues
                 if _should_attempt_self_healing(session, prepared_bundle):


### PR DESCRIPTION
## Problem

When app-cli's self-healing path fires (a configured module fails to load on the first `create_session` attempt due to stale install state), the retry recreates the session **without** `session_cwd` and `is_resumed` arguments.

### Consequences

**working_dir fallback:** foundation computes:
```python
effective_working_dir = session_cwd or self.bundle.base_path or Path.cwd()
```
Dropping `session_cwd` makes the retry session fall back to `bundle.base_path`/`Path.cwd()` instead of the real CLI working directory. Downstream, hooks that read the `session.working_dir` capability (e.g. context-intelligence event fan-out) route to the wrong directory.

**is_resumed flag lost:** the retry session loses the resume flag, so a resumed session emits a spurious `session:start` lifecycle event.

## Solution

This PR simply makes the self-healing retry pass the same two arguments the normal path already passes—restoring parity so the recovered session behaves identically to a first-try session.

## Testing / scope

This is a correctness/parity fix. It was validated in an isolated Digital Twin environment by forcing the self-healing retry path (latest app-cli main + context-intelligence bundle main + foundation main). 

**Note:** on CURRENT foundation main, `session.working_dir` is always truthy due to the `... or Path.cwd()` final fallback, so this patch does not change whether the capability is populated on main — it changes **WHICH directory** (the real CLI cwd vs a fallback) the retry session uses, and restores the lost `is_resumed` flag. The patch brings the retry path to parity with the normal path; it is low-risk and behavior-preserving for the happy path.