### PR TITLE
feat(bundle): make 'anchors' the default bundle for new sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ amplifier init
 # Install shell completion (optional, one-time setup)
 amplifier --install-completion
 
-# Single command (uses foundation bundle by default)
+# Single command (uses anchors bundle by default)
 amplifier run "Create a Python function to calculate fibonacci numbers"
 
 # Single command via stdin (useful for scripts/pipelines)
@@ -57,7 +57,7 @@ amplifier bundle list                                 # List available bundles
 amplifier bundle show <name>                          # Show bundle details
 amplifier bundle add <git-url> [--name alias]         # Register a bundle (name auto-derived)
 amplifier bundle remove <name>                        # Unregister a bundle
-amplifier bundle clear                                # Reset to default (foundation)
+amplifier bundle clear                                # Reset to default (anchors)
 
 # Provider management
 amplifier provider add <name> [--local|--project|--global]  # Add/configure a provider

--- a/amplifier_app_cli/commands/bundle.py
+++ b/amplifier_app_cli/commands/bundle.py
@@ -719,7 +719,7 @@ def bundle_use(name: str, scope_flag: str | None):
         console.print("  File: ~/.amplifier/settings.yaml")
 
     console.print(
-        "\n[dim]Tip: Use 'amplifier bundle clear' to revert to default (foundation bundle)[/dim]"
+        "\n[dim]Tip: Use 'amplifier bundle clear' to revert to default (anchors bundle)[/dim]"
     )
 
 
@@ -824,11 +824,11 @@ def bundle_current():
             console.print(f"[bold]Location:[/bold] {_format_location(uri)}")
 
         console.print(
-            "\n[dim]Use 'amplifier bundle clear' to revert to default (foundation bundle)[/dim]"
+            "\n[dim]Use 'amplifier bundle clear' to revert to default (anchors bundle)[/dim]"
         )
     else:
         console.print("[bold]Mode:[/bold] Bundle (default)")
-        console.print("[bold]Active bundle:[/bold] foundation (default)")
+        console.print("[bold]Active bundle:[/bold] anchors (default)")
         console.print(
             "\n[dim]Use 'amplifier bundle use <name>' to switch to a different bundle[/dim]"
         )

--- a/amplifier_app_cli/commands/bundle.py
+++ b/amplifier_app_cli/commands/bundle.py
@@ -733,7 +733,7 @@ def bundle_use(name: str, scope_flag: str | None):
 )
 @click.option("--all", "clear_all", is_flag=True, help="Clear settings from all scopes")
 def bundle_clear(scope_flag: str | None, clear_all: bool):
-    """Clear bundle settings (reverts to default foundation bundle).
+    """Clear bundle settings (reverts to default anchors bundle).
 
     Without scope flags, auto-detects and clears from wherever settings are found.
     Use --all to clear from all scopes.
@@ -759,14 +759,14 @@ def bundle_clear(scope_flag: str | None, clear_all: bool):
         else:
             console.print("[yellow]No bundle settings found to clear[/yellow]")
 
-        console.print("[green]Now using default: foundation bundle[/green]")
+        console.print("[green]Now using default: anchors bundle[/green]")
         return
 
     if scope_flag is None:
         detected_scope = _find_bundle_scope(app_settings)
         if detected_scope is None:
             console.print("[yellow]No bundle settings found in any scope[/yellow]")
-            console.print("[dim]Already using default: foundation bundle[/dim]")
+            console.print("[dim]Already using default: anchors bundle[/dim]")
             return
         scope = detected_scope
         console.print(f"[dim]Auto-detected settings in {scope} scope[/dim]")
@@ -801,7 +801,7 @@ def bundle_clear(scope_flag: str | None, clear_all: bool):
         )
         console.print("[dim]Use --all to clear from all scopes[/dim]")
     else:
-        console.print("[green]Now using default: foundation bundle[/green]")
+        console.print("[green]Now using default: anchors bundle[/green]")
 
 
 @bundle.command(name="current")

--- a/amplifier_app_cli/commands/run.py
+++ b/amplifier_app_cli/commands/run.py
@@ -135,9 +135,9 @@ def register_run_command(
             if isinstance(bundle_settings, dict):
                 bundle = bundle_settings.get("active")
 
-        # Default to foundation bundle when no explicit bundle is configured
+        # Default to anchors bundle when no explicit bundle is configured
         if not bundle:
-            bundle = "foundation"
+            bundle = "anchors"
 
         # Check if first run init is needed
         # This runs unconditionally - --provider just selects from configured providers,

--- a/amplifier_app_cli/commands/tool.py
+++ b/amplifier_app_cli/commands/tool.py
@@ -285,7 +285,7 @@ def tool_list(
         default_bundle = bundle
 
     if use_bundle:
-        bundle_name = default_bundle or "foundation"
+        bundle_name = default_bundle or "anchors"
 
         if modules:
             console.print(
@@ -371,7 +371,7 @@ def tool_info(
 
     if use_bundle:
         # Bundle path (primary)
-        bundle_name = default_bundle or "foundation"
+        bundle_name = default_bundle or "anchors"
 
         if module:
             # For bundles, --module is not supported

--- a/amplifier_app_cli/commands/tool.py
+++ b/amplifier_app_cli/commands/tool.py
@@ -80,15 +80,15 @@ def _should_use_bundle() -> tuple[bool, str | None, str | None]:
     Logic (mirrors run.py):
     1. If active bundle is set → use bundle
     2. Always use bundle system
-    3. Default to 'foundation' bundle
+    3. Default to 'anchors' bundle
     """
     # Check for active bundle
     bundle_name = _get_active_bundle_name()
     if bundle_name:
         return (True, bundle_name, None)
 
-    # Default to foundation bundle
-    return (True, "foundation", None)
+    # Default to anchors bundle
+    return (True, "anchors", None)
 
 
 # ============================================================================

--- a/amplifier_app_cli/lib/bundle_loader/discovery.py
+++ b/amplifier_app_cli/lib/bundle_loader/discovery.py
@@ -43,6 +43,13 @@ WELL_KNOWN_BUNDLES: dict[str, dict[str, str | bool]] = {
         "remote": "git+https://github.com/microsoft/amplifier-foundation@main",
         "show_in_list": True,
     },
+    # Lean principle-driven bundle (foundation/bundles/anchors). CLI default for
+    # new sessions when no bundle is explicitly configured.
+    "anchors": {
+        "package": "",  # No Python package - bundle-only
+        "remote": "git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=bundles/anchors/bundle.md",
+        "show_in_list": True,
+    },
     "recipes": {
         "package": "",  # No Python package - bundle-only
         "remote": "git+https://github.com/microsoft/amplifier-bundle-recipes@main",

--- a/amplifier_app_cli/runtime/config.py
+++ b/amplifier_app_cli/runtime/config.py
@@ -885,7 +885,7 @@ async def resolve_config_async(
         )
         return config_data, prepared_bundle
     else:
-        default_bundle = "foundation"
+        default_bundle = "anchors"
         if console:
             console.print(
                 f"[dim]No bundle specified, using default: {default_bundle}[/dim]"

--- a/tests/test_default_bundle_anchors.py
+++ b/tests/test_default_bundle_anchors.py
@@ -1,0 +1,21 @@
+"""Regression tests: no-active-bundle default must be 'anchors' (not 'foundation')."""
+from unittest.mock import patch
+
+# Import the module directly: commands/__init__ re-exports the `tool` click Group,
+# which would shadow the submodule under `from ... import tool`.
+import importlib
+tool_cmd = importlib.import_module("amplifier_app_cli.commands.tool")
+
+
+def test_should_use_bundle_defaults_to_anchors():
+    with patch.object(tool_cmd, "_get_active_bundle_name", return_value=None):
+        use_bundle, bundle_name, _ = tool_cmd._should_use_bundle()
+    assert use_bundle is True
+    assert bundle_name == "anchors"
+
+
+def test_should_use_bundle_respects_explicit_active():
+    with patch.object(tool_cmd, "_get_active_bundle_name", return_value="foundation"):
+        use_bundle, bundle_name, _ = tool_cmd._should_use_bundle()
+    assert use_bundle is True
+    assert bundle_name == "foundation"


### PR DESCRIPTION
## What

Makes `anchors` the CLI's default bundle for new sessions.

- Registers `anchors` in `WELL_KNOWN_BUNDLES` -> `git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=bundles/anchors/bundle.md`
- Flips every hardcoded last-resort default fallback "foundation" -> "anchors":
  - `commands/run.py` (interactive session default)
  - `runtime/config.py` (resolve-config default)
  - `commands/tool.py` x2 (`amplifier tool` default)
- Updates `amplifier bundle clear` messages + README to name `anchors` as the default.

## Why / behavior guarantees

The fallback only applies when **no bundle is explicitly configured**:

| Scenario | Result |
|---|---|
| New install / new session | defaults to **anchors** |
| User ran `amplifier bundle use foundation` | **unaffected** (settings.bundle.active wins over fallback) |
| In-flight / resumed session | reads its **persisted** bundle, not the fallback |
| Want foundation as default | `amplifier bundle use foundation` (unchanged) |

`foundation` and the original experiment are **not** deleted.

## PR 2 of 2 - depends on foundation PR #259

Requires microsoft/amplifier-foundation#259 (publishes `bundles/anchors/`). The remote is pinned `@main`, so this resolves correctly once #259 merges. **Merge #259 first.**

## Tests

- Existing suite: 88 passed (bundle-loader discovery, routing, registration, root-bundle-marker).
- Full end-to-end matrix validated in a Digital Twin Universe (new-install, existing-foundation, other-bundle, switch-to-foundation, resume).

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
