### PR TITLE
fix: register session.working_dir before child session initialize()

### DIFF
--- a/amplifier_app_cli/session_spawner.py
+++ b/amplifier_app_cli/session_spawner.py
@@ -514,6 +514,19 @@ async def spawn_sub_session(
             f"Shared {len(paths_to_share)} sys.path entries from parent to child session"
         )
 
+    # Working directory - register BEFORE initialize() so hooks reading it in
+    # on_session_ready (which fires during initialize()) see the capability.
+    # Without this ordering, context-intelligence detects working_dir=None and
+    # disables fan-out for the child session, silently dropping hook data.
+    # Fall back to cwd so the value is never empty even when the parent
+    # session was created without an explicit working_dir capability.
+    _child_working_dir = parent_session.coordinator.get_capability(
+        "session.working_dir"
+    ) or str(Path.cwd().resolve())
+    child_session.coordinator.register_capability(
+        "session.working_dir", _child_working_dir
+    )
+
     # Initialize child session (mounts modules per merged config)
     # Now the resolver is available for loading modules with source: directives
     await child_session.initialize()
@@ -587,17 +600,6 @@ async def spawn_sub_session(
         # Fallback to fresh deduplicator if parent doesn't have one
         child_session.coordinator.register_capability(
             "mention_deduplicator", ContentDeduplicator()
-        )
-
-    # Working directory - inherit from parent for consistent path resolution
-    # This ensures child sessions use the same project directory as parent
-    # (critical for server/web deployments where process cwd differs from user's project)
-    parent_working_dir = parent_session.coordinator.get_capability(
-        "session.working_dir"
-    )
-    if parent_working_dir:
-        child_session.coordinator.register_capability(
-            "session.working_dir", parent_working_dir
         )
 
     # Routing capability — inherit so child's hooks-routing can compose runtime overrides.
@@ -974,6 +976,24 @@ async def resume_sub_session(
         resolver = create_foundation_resolver()
     await child_session.coordinator.mount("module-source-resolver", resolver)
 
+    # Working directory - register BEFORE initialize() so hooks reading it in
+    # on_session_ready (which fires during initialize()) see the capability.
+    # Prefer the value saved in metadata at original spawn time, then fall back
+    # to the parent's working_dir if a parent session was supplied, and finally
+    # to cwd — so the capability is never absent/empty.
+    _child_resume_working_dir = (
+        metadata.get("working_dir")
+        or (
+            parent_session.coordinator.get_capability("session.working_dir")
+            if parent_session is not None
+            else None
+        )
+        or str(Path.cwd().resolve())
+    )
+    child_session.coordinator.register_capability(
+        "session.working_dir", _child_resume_working_dir
+    )
+
     # Initialize session (mounts modules per config)
     # Now the resolver is available for loading modules with source: directives
     await child_session.initialize()
@@ -1007,14 +1027,6 @@ async def resume_sub_session(
     child_session.coordinator.register_capability(
         "self_delegation_depth", self_delegation_depth
     )
-
-    # Working directory - restore from metadata for consistent path resolution
-    # (critical for server/web deployments where process cwd differs from user's project)
-    saved_working_dir = metadata.get("working_dir")
-    if saved_working_dir:
-        child_session.coordinator.register_capability(
-            "session.working_dir", saved_working_dir
-        )
 
     # Register session spawning capabilities on resumed child session
     # This enables nested agent delegation (child can spawn grandchildren)

--- a/amplifier_app_cli/session_spawner.py
+++ b/amplifier_app_cli/session_spawner.py
@@ -514,10 +514,11 @@ async def spawn_sub_session(
             f"Shared {len(paths_to_share)} sys.path entries from parent to child session"
         )
 
-    # Working directory - register BEFORE initialize(). Any capability a hook
-    # consumes in on_session_ready must be registered before initialize()/mount,
-    # because on_session_ready fires during initialize(); a capability registered
-    # afterwards is invisible to it (the hook sees it as absent).
+    # Working directory - register BEFORE initialize(). Any capability a module
+    # consumes while mounting or in on_session_ready must be registered before
+    # initialize(), because module mounting and on_session_ready both run during
+    # initialize(); a capability registered afterwards is invisible to them (the
+    # module sees it as absent). This affects ANY module, not just hooks.
     # Fall back to cwd so the value is never empty even when the parent
     # session was created without an explicit working_dir capability.
     _child_working_dir = parent_session.coordinator.get_capability(
@@ -976,8 +977,9 @@ async def resume_sub_session(
         resolver = create_foundation_resolver()
     await child_session.coordinator.mount("module-source-resolver", resolver)
 
-    # Working directory - register BEFORE initialize() so hooks reading it in
-    # on_session_ready (which fires during initialize()) see the capability.
+    # Working directory - register BEFORE initialize() so any module reading it
+    # while mounting or in on_session_ready (both run during initialize()) sees
+    # the capability. This affects ANY module, not just hooks.
     # Prefer the value saved in metadata at original spawn time, then fall back
     # to the parent's working_dir if a parent session was supplied, and finally
     # to cwd — so the capability is never absent/empty.

--- a/amplifier_app_cli/session_spawner.py
+++ b/amplifier_app_cli/session_spawner.py
@@ -514,10 +514,10 @@ async def spawn_sub_session(
             f"Shared {len(paths_to_share)} sys.path entries from parent to child session"
         )
 
-    # Working directory - register BEFORE initialize() so hooks reading it in
-    # on_session_ready (which fires during initialize()) see the capability.
-    # Without this ordering, context-intelligence detects working_dir=None and
-    # disables fan-out for the child session, silently dropping hook data.
+    # Working directory - register BEFORE initialize(). Any capability a hook
+    # consumes in on_session_ready must be registered before initialize()/mount,
+    # because on_session_ready fires during initialize(); a capability registered
+    # afterwards is invisible to it (the hook sees it as absent).
     # Fall back to cwd so the value is never empty even when the parent
     # session was created without an explicit working_dir capability.
     _child_working_dir = parent_session.coordinator.get_capability(

--- a/tests/test_session_spawner.py
+++ b/tests/test_session_spawner.py
@@ -523,10 +523,15 @@ class TestCapabilityRegistrationIntegration:
         )
         assert registered_capabilities["session.working_dir"] == "/test/project/path"
 
-    async def test_resume_without_working_dir_skips_registration(
+    async def test_resume_without_working_dir_uses_cwd_fallback(
         self, tmp_path, monkeypatch
     ):
-        """Test that resume_sub_session handles missing working_dir gracefully."""
+        """Test that resume_sub_session always registers session.working_dir.
+
+        Even when metadata has no working_dir key, the capability is registered
+        with a cwd fallback so that on_session_ready hooks (e.g. context-intelligence)
+        never see working_dir=None and silently disable fan-out.
+        """
         from unittest.mock import AsyncMock, MagicMock, patch
 
         monkeypatch.setenv("HOME", str(tmp_path))
@@ -542,7 +547,7 @@ class TestCapabilityRegistrationIntegration:
             "config": {
                 "session": {"orchestrator": "loop-basic", "context": "context-simple"}
             },
-            # working_dir intentionally omitted
+            # working_dir intentionally omitted — fix must use cwd fallback
             "self_delegation_depth": 0,
         }
         store.save(session_id, transcript, metadata)
@@ -576,12 +581,18 @@ class TestCapabilityRegistrationIntegration:
                         except Exception:
                             pass
 
-        # Verify session.working_dir was NOT registered (no value to restore)
-        assert "session.working_dir" not in registered_capabilities, (
-            "session.working_dir should not be registered when metadata has no working_dir"
+        # Verify session.working_dir IS registered (cwd fallback) even with no metadata value
+        assert "session.working_dir" in registered_capabilities, (
+            "session.working_dir must always be registered on resume — even when metadata "
+            "has no working_dir key. The fix uses cwd as fallback so that hooks like "
+            "context-intelligence do not silently disable fan-out."
+        )
+        assert registered_capabilities["session.working_dir"], (
+            "session.working_dir fallback value must be non-empty. "
+            f"Got: {registered_capabilities['session.working_dir']!r}"
         )
 
-        # But session.spawn/resume should still be registered
+        # session.spawn/resume should still be registered
         assert "session.spawn" in registered_capabilities
         assert "session.resume" in registered_capabilities
 

--- a/tests/test_session_spawner.py
+++ b/tests/test_session_spawner.py
@@ -529,9 +529,9 @@ class TestCapabilityRegistrationIntegration:
         """Test that resume_sub_session always registers session.working_dir.
 
         Even when metadata has no working_dir key, the capability is registered
-        with a cwd fallback so that on_session_ready hooks never see
-        working_dir=None — any capability a hook consumes in on_session_ready
-        must be registered before initialize().
+        with a cwd fallback so that any module reading it during initialize()
+        never sees working_dir=None — any capability a module consumes during
+        initialize() must be registered before initialize(), not just hooks.
         """
         from unittest.mock import AsyncMock, MagicMock, patch
 

--- a/tests/test_session_spawner.py
+++ b/tests/test_session_spawner.py
@@ -529,8 +529,9 @@ class TestCapabilityRegistrationIntegration:
         """Test that resume_sub_session always registers session.working_dir.
 
         Even when metadata has no working_dir key, the capability is registered
-        with a cwd fallback so that on_session_ready hooks (e.g. context-intelligence)
-        never see working_dir=None and silently disable fan-out.
+        with a cwd fallback so that on_session_ready hooks never see
+        working_dir=None — any capability a hook consumes in on_session_ready
+        must be registered before initialize().
         """
         from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -584,8 +585,8 @@ class TestCapabilityRegistrationIntegration:
         # Verify session.working_dir IS registered (cwd fallback) even with no metadata value
         assert "session.working_dir" in registered_capabilities, (
             "session.working_dir must always be registered on resume — even when metadata "
-            "has no working_dir key. The fix uses cwd as fallback so that hooks like "
-            "context-intelligence do not silently disable fan-out."
+            "has no working_dir key. The fix uses cwd as fallback so that "
+            "on_session_ready hooks never see working_dir=None."
         )
         assert registered_capabilities["session.working_dir"], (
             "session.working_dir fallback value must be non-empty. "

--- a/tests/test_working_dir_pre_init.py
+++ b/tests/test_working_dir_pre_init.py
@@ -1,14 +1,16 @@
 """Regression test: session.working_dir registered BEFORE child_session.initialize().
 
 ROOT CAUSE:
-  Hooks that read capabilities during on_session_ready (which fires DURING
-  initialize()) received working_dir=None because the registration happened
-  AFTER initialize() in both the new-session and resume paths.
+  Modules that read capabilities while mounting or during on_session_ready
+  (both run DURING initialize()) received working_dir=None because the
+  registration happened AFTER initialize() in both the new-session and resume
+  paths.
 
-  General rule: any capability a hook consumes in on_session_ready must be
-  registered before initialize()/mount; a capability registered afterwards is
-  invisible to on_session_ready, so the hook sees it as absent and may silently
-  disable behavior that depends on it.
+  General rule: any capability a module consumes while mounting or in
+  on_session_ready must be registered before initialize(); a capability
+  registered afterwards is invisible to them, so the module sees it as absent
+  and may silently disable behavior that depends on it. This affects ANY module,
+  not just hooks.
 
 FIX:
   Move register_capability("session.working_dir", ...) to BEFORE
@@ -123,9 +125,10 @@ class TestSpawnWorkingDirBeforeInit:
     async def test_working_dir_registered_before_initialize(self) -> None:
         """register_capability('session.working_dir') must precede initialize().
 
-        This ensures hooks that read session.working_dir inside on_session_ready
-        (which fires during initialize()) see a non-None value. Any capability a
-        hook consumes in on_session_ready must be registered before initialize().
+        This ensures any module that reads session.working_dir while mounting or
+        inside on_session_ready (both run during initialize()) sees a non-None
+        value. Any capability a module consumes during initialize() must be
+        registered before initialize() — this affects ANY module, not just hooks.
         """
         from amplifier_app_cli.session_spawner import spawn_sub_session
 
@@ -184,8 +187,9 @@ class TestSpawnWorkingDirBeforeInit:
 
         assert wd_idx < init_idx, (
             "session.working_dir must be registered BEFORE initialize() so that "
-            "on_session_ready hooks see the working_dir value (any capability a "
-            "hook consumes in on_session_ready must be registered before initialize()). "
+            "any module reading it during initialize() sees the working_dir value "
+            "(any capability a module consumes during initialize() must be "
+            "registered before initialize() — not just hooks). "
             f"Actual order: {call_log} "
             f"(register:session.working_dir at index {wd_idx}, "
             f"initialize at index {init_idx})"
@@ -342,7 +346,7 @@ class TestResumeWorkingDirBeforeInit:
 
         assert wd_idx < init_idx, (
             "session.working_dir must be registered BEFORE initialize() on resume so "
-            "that on_session_ready hooks see the working_dir value. "
+            "that any module reading it during initialize() sees the working_dir value. "
             f"Actual order: {call_log} "
             f"(register:session.working_dir at index {wd_idx}, "
             f"initialize at index {init_idx})"

--- a/tests/test_working_dir_pre_init.py
+++ b/tests/test_working_dir_pre_init.py
@@ -5,11 +5,10 @@ ROOT CAUSE:
   initialize()) received working_dir=None because the registration happened
   AFTER initialize() in both the new-session and resume paths.
 
-  Symptom observed (context-intelligence hook):
-    "session.working_dir capability is unavailable; fan-out disabled for this
-     session (local JSONL only)"
-  This caused the hook to silently drop all write fan-out even when the user
-  had valid destinations configured.
+  General rule: any capability a hook consumes in on_session_ready must be
+  registered before initialize()/mount; a capability registered afterwards is
+  invisible to on_session_ready, so the hook sees it as absent and may silently
+  disable behavior that depends on it.
 
 FIX:
   Move register_capability("session.working_dir", ...) to BEFORE
@@ -125,8 +124,8 @@ class TestSpawnWorkingDirBeforeInit:
         """register_capability('session.working_dir') must precede initialize().
 
         This ensures hooks that read session.working_dir inside on_session_ready
-        (which fires during initialize()) see a non-None value and do not
-        silently disable capabilities like context-intelligence fan-out.
+        (which fires during initialize()) see a non-None value. Any capability a
+        hook consumes in on_session_ready must be registered before initialize().
         """
         from amplifier_app_cli.session_spawner import spawn_sub_session
 
@@ -185,8 +184,8 @@ class TestSpawnWorkingDirBeforeInit:
 
         assert wd_idx < init_idx, (
             "session.working_dir must be registered BEFORE initialize() so that "
-            "on_session_ready hooks (e.g. context-intelligence) see the working_dir "
-            "value and do not silently disable fan-out. "
+            "on_session_ready hooks see the working_dir value (any capability a "
+            "hook consumes in on_session_ready must be registered before initialize()). "
             f"Actual order: {call_log} "
             f"(register:session.working_dir at index {wd_idx}, "
             f"initialize at index {init_idx})"

--- a/tests/test_working_dir_pre_init.py
+++ b/tests/test_working_dir_pre_init.py
@@ -1,0 +1,427 @@
+"""Regression test: session.working_dir registered BEFORE child_session.initialize().
+
+ROOT CAUSE:
+  Hooks that read capabilities during on_session_ready (which fires DURING
+  initialize()) received working_dir=None because the registration happened
+  AFTER initialize() in both the new-session and resume paths.
+
+  Symptom observed (context-intelligence hook):
+    "session.working_dir capability is unavailable; fan-out disabled for this
+     session (local JSONL only)"
+  This caused the hook to silently drop all write fan-out even when the user
+  had valid destinations configured.
+
+FIX:
+  Move register_capability("session.working_dir", ...) to BEFORE
+  child_session.initialize() in both paths (session_spawner.py).
+
+REGRESSION CONTRACT:
+  register_capability("session.working_dir", ...) must appear in the call log
+  BEFORE initialize() for both the new-session (spawn_sub_session) and resume
+  (resume_sub_session) paths.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_call_log() -> list[str]:
+    """Return a shared list used to record key event names in order."""
+    return []
+
+
+def _make_parent_session(working_dir: str = "/parent/wd") -> MagicMock:
+    """Build a minimal MagicMock parent session for spawn tests."""
+    parent = MagicMock()
+
+    parent.config = {
+        "agents": {"test_agent": {"description": "Test agent"}},
+        "session": {"orchestrator": "loop-basic"},
+    }
+
+    parent.coordinator = MagicMock()
+    parent.coordinator.config = {
+        "agents": {"test_agent": {"description": "Test agent"}}
+    }
+
+    cap_store: dict = {"session.working_dir": working_dir}
+
+    def _get_capability(name: str):
+        return cap_store.get(name)
+
+    parent.coordinator.get_capability = MagicMock(side_effect=_get_capability)
+    parent.session_id = "parent-session-id"
+    parent.coordinator.display_system = MagicMock()
+    parent.coordinator.approval_system = MagicMock()
+    parent.coordinator.cancellation = MagicMock()
+    parent.coordinator.cancellation.register_child = MagicMock()
+    parent.coordinator.cancellation.unregister_child = MagicMock()
+    parent.coordinator.get = MagicMock(return_value=None)
+    parent.loader = None
+
+    return parent
+
+
+def _make_child_session_mock(call_log: list[str]) -> MagicMock:
+    """Build a MagicMock child session that records register_capability / initialize order.
+
+    Records events into call_log:
+      - "register:session.working_dir" when that capability is registered
+      - "initialize" when initialize() is called
+    """
+    child = MagicMock()
+    child.session_id = "child-session-id"
+
+    cap_store: dict = {}
+
+    def _register_capability(name: str, value) -> None:
+        cap_store[name] = value
+        if name == "session.working_dir":
+            call_log.append("register:session.working_dir")
+
+    def _get_capability(name: str):
+        return cap_store.get(name)
+
+    child.coordinator = MagicMock()
+    child.coordinator.register_capability = MagicMock(side_effect=_register_capability)
+    child.coordinator.get_capability = MagicMock(side_effect=_get_capability)
+    child.coordinator.get = MagicMock(return_value=None)
+    child.coordinator.cancellation = MagicMock()
+    child.coordinator.mount = AsyncMock()
+    child.coordinator.display_system = MagicMock()
+    child.coordinator.hooks = MagicMock()
+    child.coordinator.hooks.emit = AsyncMock()
+    child.coordinator.hooks.register = MagicMock(return_value=MagicMock())
+    child.coordinator.approval_system = MagicMock()
+
+    async def _initialize_recording():
+        call_log.append("initialize")
+
+    child.initialize = AsyncMock(side_effect=_initialize_recording)
+    child.execute = AsyncMock(return_value="agent output")
+    child.cleanup = AsyncMock()
+
+    return child
+
+
+# ---------------------------------------------------------------------------
+# New-session path: spawn_sub_session
+# ---------------------------------------------------------------------------
+
+
+class TestSpawnWorkingDirBeforeInit:
+    """session.working_dir must be registered before initialize() in spawn_sub_session."""
+
+    @pytest.mark.asyncio
+    async def test_working_dir_registered_before_initialize(self) -> None:
+        """register_capability('session.working_dir') must precede initialize().
+
+        This ensures hooks that read session.working_dir inside on_session_ready
+        (which fires during initialize()) see a non-None value and do not
+        silently disable capabilities like context-intelligence fan-out.
+        """
+        from amplifier_app_cli.session_spawner import spawn_sub_session
+
+        call_log: list[str] = _build_call_log()
+        parent = _make_parent_session(working_dir="/test/working/dir")
+        child = _make_child_session_mock(call_log)
+
+        def _make_session(config, **kwargs):
+            return child
+
+        with (
+            patch(
+                "amplifier_app_cli.session_spawner.AmplifierSession",
+                side_effect=_make_session,
+            ),
+            patch(
+                "amplifier_app_cli.session_spawner.generate_sub_session_id",
+                return_value="child-session-id",
+            ),
+            patch(
+                "amplifier_app_cli.session_spawner.bridge_child_cost",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "amplifier_app_cli.session_spawner._extract_bundle_context",
+                return_value=None,
+            ),
+            patch("amplifier_app_cli.session_store.SessionStore"),
+            patch(
+                "amplifier_app_cli.lib.mention_loading.app_resolver.AppMentionResolver"
+            ),
+            patch(
+                "amplifier_app_cli.paths.create_foundation_resolver",
+                return_value=MagicMock(),
+            ),
+            patch("amplifier_foundation.mentions.ContentDeduplicator"),
+        ):
+            await spawn_sub_session(
+                agent_name="test_agent",
+                instruction="Do something",
+                parent_session=parent,
+                agent_configs={"test_agent": {"description": "Test agent"}},
+            )
+
+        # Assert ordering: working_dir registration must come BEFORE initialize
+        assert "register:session.working_dir" in call_log, (
+            "session.working_dir was never registered on the child session. "
+            f"call_log: {call_log}"
+        )
+        assert "initialize" in call_log, (
+            f"child_session.initialize() was never called. call_log: {call_log}"
+        )
+
+        wd_idx = call_log.index("register:session.working_dir")
+        init_idx = call_log.index("initialize")
+
+        assert wd_idx < init_idx, (
+            "session.working_dir must be registered BEFORE initialize() so that "
+            "on_session_ready hooks (e.g. context-intelligence) see the working_dir "
+            "value and do not silently disable fan-out. "
+            f"Actual order: {call_log} "
+            f"(register:session.working_dir at index {wd_idx}, "
+            f"initialize at index {init_idx})"
+        )
+
+    @pytest.mark.asyncio
+    async def test_working_dir_uses_cwd_fallback_when_parent_has_none(self) -> None:
+        """When parent has no working_dir capability, cwd is used — never empty."""
+        from amplifier_app_cli.session_spawner import spawn_sub_session
+
+        call_log: list[str] = _build_call_log()
+        parent = _make_parent_session(
+            working_dir=""
+        )  # empty → falsy → triggers cwd fallback
+        # Rebuild so get_capability returns None for session.working_dir
+        parent.coordinator.get_capability = MagicMock(return_value=None)
+
+        child = _make_child_session_mock(call_log)
+        registered_values: list = []
+
+        original_register = child.coordinator.register_capability.side_effect
+
+        def _track_wd(name: str, value) -> None:
+            if name == "session.working_dir":
+                registered_values.append(value)
+            original_register(name, value)
+
+        child.coordinator.register_capability = MagicMock(side_effect=_track_wd)
+
+        def _make_session(config, **kwargs):
+            return child
+
+        with (
+            patch(
+                "amplifier_app_cli.session_spawner.AmplifierSession",
+                side_effect=_make_session,
+            ),
+            patch(
+                "amplifier_app_cli.session_spawner.generate_sub_session_id",
+                return_value="child-session-id",
+            ),
+            patch(
+                "amplifier_app_cli.session_spawner.bridge_child_cost",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "amplifier_app_cli.session_spawner._extract_bundle_context",
+                return_value=None,
+            ),
+            patch("amplifier_app_cli.session_store.SessionStore"),
+            patch(
+                "amplifier_app_cli.lib.mention_loading.app_resolver.AppMentionResolver"
+            ),
+            patch(
+                "amplifier_app_cli.paths.create_foundation_resolver",
+                return_value=MagicMock(),
+            ),
+            patch("amplifier_foundation.mentions.ContentDeduplicator"),
+        ):
+            await spawn_sub_session(
+                agent_name="test_agent",
+                instruction="Do something",
+                parent_session=parent,
+                agent_configs={"test_agent": {"description": "Test agent"}},
+            )
+
+        assert registered_values, (
+            "session.working_dir should always be registered — even when parent "
+            "has no working_dir capability. Got no registrations."
+        )
+        assert registered_values[0], (
+            "session.working_dir fallback value must be non-empty (cwd). "
+            f"Got: {registered_values[0]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Resume path: resume_sub_session
+# ---------------------------------------------------------------------------
+
+
+class TestResumeWorkingDirBeforeInit:
+    """session.working_dir must be registered before initialize() in resume_sub_session."""
+
+    @pytest.mark.asyncio
+    async def test_working_dir_registered_before_initialize_on_resume(self) -> None:
+        """register_capability('session.working_dir') must precede initialize() on resume.
+
+        Resume reconstructs the child session from stored metadata. The same
+        ordering requirement applies: on_session_ready fires during initialize(),
+        so working_dir must already be registered at that point.
+        """
+        from amplifier_app_cli.session_spawner import resume_sub_session
+
+        call_log: list[str] = _build_call_log()
+        child = _make_child_session_mock(call_log)
+
+        def _make_session(config, **kwargs):
+            return child
+
+        stored_metadata = {
+            "config": {
+                "agents": {"test_agent": {"description": "Test agent"}},
+                "session": {"orchestrator": "loop-basic"},
+            },
+            "agent_name": "test_agent",
+            "parent_id": "parent-session-id",
+            "trace_id": "trace-id",
+            "working_dir": "/stored/working/dir",
+            "self_delegation_depth": 0,
+        }
+
+        mock_store = MagicMock()
+        mock_store.exists.return_value = True
+        mock_store.load.return_value = ([], stored_metadata)
+        mock_store.save = MagicMock()
+
+        with (
+            patch(
+                "amplifier_app_cli.session_spawner.AmplifierSession",
+                side_effect=_make_session,
+            ),
+            patch(
+                "amplifier_app_cli.session_store.SessionStore", return_value=mock_store
+            ),
+            patch(
+                "amplifier_app_cli.lib.mention_loading.app_resolver.AppMentionResolver"
+            ),
+            patch(
+                "amplifier_app_cli.paths.create_foundation_resolver",
+                return_value=MagicMock(),
+            ),
+            patch("amplifier_foundation.mentions.ContentDeduplicator"),
+            patch("amplifier_app_cli.ui.CLIApprovalSystem"),
+            patch("amplifier_app_cli.ui.CLIDisplaySystem"),
+        ):
+            await resume_sub_session(
+                sub_session_id="child-session-id",
+                instruction="Follow-up instruction",
+                parent_session=None,
+            )
+
+        assert "register:session.working_dir" in call_log, (
+            "session.working_dir was never registered on the resumed child session. "
+            f"call_log: {call_log}"
+        )
+        assert "initialize" in call_log, (
+            "child_session.initialize() was never called during resume. "
+            f"call_log: {call_log}"
+        )
+
+        wd_idx = call_log.index("register:session.working_dir")
+        init_idx = call_log.index("initialize")
+
+        assert wd_idx < init_idx, (
+            "session.working_dir must be registered BEFORE initialize() on resume so "
+            "that on_session_ready hooks see the working_dir value. "
+            f"Actual order: {call_log} "
+            f"(register:session.working_dir at index {wd_idx}, "
+            f"initialize at index {init_idx})"
+        )
+
+    @pytest.mark.asyncio
+    async def test_resume_uses_parent_fallback_when_metadata_working_dir_absent(
+        self,
+    ) -> None:
+        """When metadata has no working_dir, parent session's value is used."""
+        from amplifier_app_cli.session_spawner import resume_sub_session
+
+        call_log: list[str] = _build_call_log()
+        child = _make_child_session_mock(call_log)
+        registered_values: list = []
+
+        original_register = child.coordinator.register_capability.side_effect
+
+        def _track_wd(name: str, value) -> None:
+            if name == "session.working_dir":
+                registered_values.append(value)
+            original_register(name, value)
+
+        child.coordinator.register_capability = MagicMock(side_effect=_track_wd)
+
+        def _make_session(config, **kwargs):
+            return child
+
+        stored_metadata = {
+            "config": {
+                "agents": {"test_agent": {"description": "Test agent"}},
+                "session": {"orchestrator": "loop-basic"},
+            },
+            "agent_name": "test_agent",
+            "parent_id": "parent-session-id",
+            "trace_id": "trace-id",
+            # No "working_dir" key — should fall back to parent then cwd
+            "self_delegation_depth": 0,
+        }
+
+        mock_store = MagicMock()
+        mock_store.exists.return_value = True
+        mock_store.load.return_value = ([], stored_metadata)
+        mock_store.save = MagicMock()
+
+        parent = _make_parent_session(working_dir="/parent/fallback/dir")
+
+        with (
+            patch(
+                "amplifier_app_cli.session_spawner.AmplifierSession",
+                side_effect=_make_session,
+            ),
+            patch(
+                "amplifier_app_cli.session_store.SessionStore", return_value=mock_store
+            ),
+            patch(
+                "amplifier_app_cli.lib.mention_loading.app_resolver.AppMentionResolver"
+            ),
+            patch(
+                "amplifier_app_cli.paths.create_foundation_resolver",
+                return_value=MagicMock(),
+            ),
+            patch("amplifier_foundation.mentions.ContentDeduplicator"),
+            patch("amplifier_app_cli.ui.CLIApprovalSystem"),
+            patch("amplifier_app_cli.ui.CLIDisplaySystem"),
+        ):
+            await resume_sub_session(
+                sub_session_id="child-session-id",
+                instruction="Follow-up",
+                parent_session=parent,
+            )
+
+        assert registered_values, (
+            "session.working_dir should always be registered on resume. "
+            "Got no registrations."
+        )
+        assert registered_values[0] == "/parent/fallback/dir", (
+            "When metadata has no working_dir, the parent session's "
+            "session.working_dir capability should be used as the fallback. "
+            f"Got: {registered_values[0]!r}"
+        )


### PR DESCRIPTION
## Problem

In-process sub-agent sessions silently dropped context-intelligence event uploads.

`session_spawner.py` registered the `session.working_dir` capability on the child coordinator **AFTER** `await child_session.initialize()`, but a hook's `on_session_ready` fires **DURING** `initialize()` (per amplifier-core contract: it runs when the coordinator is fully composed). So hooks that read `session.working_dir` at session-ready time saw `None`.

Concretely, the context-intelligence hook logged:
> "session.working_dir capability is unavailable; fan-out disabled (local JSONL only)"

and silently uploaded **ZERO** events from every in-process sub-agent session (e.g. the graph-analyst agent). The root/top-level session was unaffected (it goes through foundation's `create_session`, which registers working_dir before initialize).

Foundation does it correctly (`amplifier_foundation/bundle/_prepared.py` registers `session.working_dir` before `session.initialize()`); app-cli's reimplemented in-process child spawn inverted that order.

## Root Cause

Two in-process session spawn paths in `session_spawner.py`:
- `spawn_sub_session` (new-session path): working_dir registered ~70 lines **after** initialize() at line ~595
- `resume_sub_session` (resume path): working_dir registered ~30 lines **after** initialize() at line ~1013

Both violated the invariant that all capabilities must be registered **before** initialize() so that hooks' `on_session_ready` callbacks see them.

## Fix

Move the `session.working_dir` registration to **BEFORE** `child_session.initialize()` in both in-process paths — alongside the other pre-init capability mounts. Resolve the value robustly so it is never empty:
- Parent's working_dir (resume also tries `metadata["working_dir"]`)
- With a `str(Path.cwd().resolve())` fallback

Removed the now-redundant post-initialize registration blocks.

## Tests

- Added `tests/test_working_dir_pre_init.py` (4 new tests) asserting `working_dir` is registered **BEFORE** `initialize()` for both new-session and resume paths, plus the cwd/parent fallback chain.
- Updated one existing test that encoded the old (wrong) skip-registration behavior.
- Full suite: 979 passed, 3 pre-existing unrelated failures (present on unmodified main).

## End-to-End Validation

Ran a real `amplifier` CLI session (isolated Digital Twin environment) that delegates in-process to the context-intelligence graph-analyst agent, with a destinations-only config (single `private-home-server` destination pointing at a mock CI server), context-intelligence layered as an `--app` behavior.

**BEFORE** (unpatched main):
- Sub-agent logged: "working_dir capability is unavailable / routed to none"
- Mock server received: 31 ROOT POSTs and 0 SUB-AGENT POSTs
- **Sub-agent uploads silently dropped**

**AFTER** (this fix):
- Warning gone
- Mock server received: 30 ROOT + 13 SUB-AGENT POSTs
- Sub-agent events uploaded to `private-home-server` with the destination's Bearer key, distinct graph-analyst `session_id`

## Files Changed

- `amplifier_app_cli/session_spawner.py` — moved working_dir registration to pre-init in both spawn paths
- `tests/test_working_dir_pre_init.py` — new regression tests (4 tests)
- `tests/test_session_spawner.py` — updated one test to assert corrected behavior