### PR TITLE
feat: steering input UX + DRY input-reuse

### DIFF
--- a/amplifier_app_cli/approval_provider.py
+++ b/amplifier_app_cli/approval_provider.py
@@ -1,5 +1,7 @@
 """CLI approval provider for interactive user approval."""
 
+from __future__ import annotations
+
 import asyncio
 import logging
 
@@ -8,6 +10,8 @@ from amplifier_core import ApprovalResponse
 from rich.console import Console
 from rich.panel import Panel
 from rich.prompt import Confirm
+
+from .stdin_arbiter import StdinArbiter
 
 logger = logging.getLogger(__name__)
 
@@ -19,14 +23,16 @@ class CLIApprovalProvider:
     Implements ApprovalProvider protocol for CLI environments.
     """
 
-    def __init__(self, console: Console):
+    def __init__(self, console: Console, arbiter: StdinArbiter | None = None):
         """
         Initialize CLI approval provider.
 
         Args:
             console: Rich console for output
+            arbiter: Optional stdin arbiter for coordinating with steering reader
         """
         self.console = console
+        self._arbiter = arbiter
 
     async def request_approval(self, request: ApprovalRequest) -> ApprovalResponse:
         """
@@ -41,6 +47,18 @@ class CLIApprovalProvider:
         Raises:
             TimeoutError: If request.timeout expires
         """
+        # Claim stdin before rendering the panel so the steering reader
+        # cannot consume keystrokes meant for the approval prompt.
+        if self._arbiter is not None:
+            self._arbiter.begin_approval()
+        try:
+            return await self._do_request_approval(request)
+        finally:
+            if self._arbiter is not None:
+                self._arbiter.end_approval()
+
+    async def _do_request_approval(self, request: ApprovalRequest) -> ApprovalResponse:
+        """Inner implementation of request_approval (wrapped by arbiter claim)."""
         # Build rich panel with request details
         risk_color = self._get_risk_color(request.risk_level)
 

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -2827,7 +2827,15 @@ async def interactive_chat(
             # Rich's Console.file property reads sys.stdout dynamically at write
             # time (self._file is None by default), so the patched proxy is
             # picked up automatically — no changes to console.py are needed.
-            with patch_stdout():
+            #
+            # raw=True is REQUIRED: prompt_toolkit's StdoutProxy defaults to
+            # raw=False, which routes writes through Vt100_Output.write() ->
+            # data.replace("\x1b", "?"), stripping every ESC byte. Rich emits
+            # ANSI (colors, cursor control); without raw=True those escapes are
+            # mangled into literal "?[2m" text and rules/markdown smear across
+            # the pinned prompt. raw=True uses write_raw() and passes ANSI
+            # through intact (run_in_terminal still owns prompt erase/restore).
+            with patch_stdout(raw=True):
                 _reader_task = asyncio.create_task(_manager.run())
 
                 try:

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -2839,15 +2839,15 @@ async def interactive_chat(
         # terminal. GUARDED for back-compat: an unmodified (or older)
         # hooks-streaming-ui module won't have registered the
         # "ui.streaming_hooks" capability (get_capability returns None) or
-        # won't define _composing_fn on its StreamingUIHooks instance
+        # won't expose set_composing_source on its StreamingUIHooks instance
         # (hasattr guard) -- either way app-cli runs unaffected.
         _streaming_hooks_instance = session.coordinator.get_capability(
             "ui.streaming_hooks"
         )
         if _streaming_hooks_instance is not None and hasattr(
-            _streaming_hooks_instance, "_composing_fn"
+            _streaming_hooks_instance, "set_composing_source"
         ):
-            _streaming_hooks_instance._composing_fn = _manager.is_composing
+            _streaming_hooks_instance.set_composing_source(_manager.is_composing)
 
         try:
             # patch_stdout() must wrap the ENTIRE turn so that any Rich writes
@@ -2970,9 +2970,9 @@ async def interactive_chat(
             # stale bound method from this (finished) manager can never be
             # queried by a future turn's streaming-ui hooks instance.
             if _streaming_hooks_instance is not None and hasattr(
-                _streaming_hooks_instance, "_composing_fn"
+                _streaming_hooks_instance, "set_composing_source"
             ):
-                _streaming_hooks_instance._composing_fn = None
+                _streaming_hooks_instance.set_composing_source(None)
 
     # Execute initial prompt if provided
     if initial_prompt:

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -2815,11 +2815,17 @@ async def interactive_chat(
         )
 
         # Register a hook so the badge counter decrements each time the
-        # orchestrator drains one queued steer.  Use a unique name derived
-        # from the manager's id so multiple turns don't accumulate callbacks.
+        # orchestrator drains one queued steer.  Capture the unregister handle
+        # and release it in the finally below: a fresh SteeringInputManager is
+        # created every turn, so without an explicit unregister the callbacks
+        # (each bound to a now-finished manager) accumulate on the shared hooks
+        # registry across turns.  The unique per-turn name does NOT prevent
+        # that -- it defeats name-based dedup -- the unregister does.  Mirrors
+        # the register/unregister-in-finally pattern in session_spawner.py.
         _hooks = session.coordinator.get("hooks")
+        _unregister_badge_hook = None
         if _hooks and hasattr(_hooks, "register"):
-            _hooks.register(
+            _unregister_badge_hook = _hooks.register(
                 "orchestrator:steering_injected",
                 _manager.on_steering_injected,
                 priority=500,
@@ -2955,6 +2961,11 @@ async def interactive_chat(
         finally:
             signal.signal(signal.SIGINT, original_handler)
             # Don't reset cancellation here - session.py handles status
+            # Unregister this turn's badge hook so callbacks bound to this
+            # finished per-turn manager don't accumulate on the shared hooks
+            # registry across turns.
+            if _unregister_badge_hook is not None:
+                _unregister_badge_hook()
             # THROTTLE/COALESCE spike: clear the compose-state callback so a
             # stale bound method from this (finished) manager can never be
             # queried by a future turn's streaming-ui hooks instance.

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import logging
 import os
-import select
 import signal
 import sys
 from collections.abc import Callable
@@ -2362,7 +2361,6 @@ class CommandProcessor:
             return True, f'Use the load_skill tool to load the skill "{skill_name}".'
 
 
-
 def get_module_search_paths() -> list[Path]:
     """
     Determine module search paths for ModuleLoader.
@@ -2504,66 +2502,6 @@ async def _process_runtime_mentions(session: AmplifierSession, prompt: str) -> s
         deduplicator=deduplicator,
         relative_to=Path.cwd(),
     )
-
-
-def _stdin_ready(timeout: float) -> bool:
-    """Return True if stdin has data within *timeout* seconds (POSIX only).
-
-    Uses select() with a bounded timeout so the caller never holds a blocking
-    read indefinitely.  Swallows OS errors (e.g. stdin is not a real fd in
-    tests or non-TTY contexts) and returns False instead.
-    """
-    try:
-        r, _, _ = select.select([sys.stdin], [], [], timeout)
-        return bool(r)
-    except (OSError, ValueError):
-        return False
-
-
-async def _steering_reader(steer_cap, arbiter, stop_event: asyncio.Event, console) -> None:
-    """Read stdin lines during a running turn and forward to session.steer.
-
-    Runs only while *stop_event* is unset.  Uses _stdin_ready (select-based,
-    bounded to 0.1 s) so teardown leaves no outstanding blocking read.
-    Suspends entirely while an approval prompt owns stdin via *arbiter*.
-
-    Fail-loud contract:
-    - steer_cap is None  -> prints visible "unavailable" message, never drops silently.
-    - SteeringQueueFull  -> prints visible rejection, turn continues.
-    - Empty/whitespace lines are ignored (not forwarded).
-    """
-    loop = asyncio.get_event_loop()
-    while not stop_event.is_set():
-        # Approval owns stdin while active — do not read.
-        if arbiter is not None and arbiter.approval_active:
-            await asyncio.sleep(0.05)
-            continue
-        # Bounded readiness check off the event-loop thread; returns within 0.1 s
-        # so stop_event is honoured promptly (no leaked blocking read at teardown).
-        ready = await loop.run_in_executor(None, _stdin_ready, 0.1)
-        if not ready:
-            continue
-        # Re-check: approval may have claimed stdin between select and read.
-        if arbiter is not None and arbiter.approval_active:
-            continue
-        line = sys.stdin.readline()  # data is ready → returns a full TTY line
-        if line == "":  # EOF
-            break
-        text = line.strip()
-        if not text:
-            continue  # ignore blank / whitespace-only lines
-        if steer_cap is None:
-            # Fail loud — never silently drop a typed line.
-            console.print(
-                "[yellow]Steering unavailable: this orchestrator does not "
-                "support session.steer.[/yellow]"
-            )
-            continue
-        try:
-            steer_cap(text)
-            console.print("[dim]queued \u2014 applies after current step[/dim]")
-        except Exception as e:  # ValueError, SteeringQueueFull, etc.
-            console.print(f"[red]Steering rejected: {e}[/red]")
 
 
 def _create_prompt_session(get_active_mode: Callable | None = None) -> PromptSession:
@@ -2856,103 +2794,135 @@ async def interactive_chat(
 
         original_handler = signal.signal(signal.SIGINT, sigint_handler)
 
-        # Mid-turn steering: start concurrent stdin reader for the duration of this turn.
-        steer_cap = session.coordinator.get_capability("session.steer")
-        _arbiter = session.coordinator.get_capability("cli.stdin_arbiter")
+        # Mid-turn steering: create the anchored-input manager.
+        # patch_stdout() (below) ensures all Rich console.print calls that
+        # originate from session.execute() or hooks appear ABOVE the pinned
+        # steering prompt rather than corrupting it.
+        from .steering_input import SteeringInputManager
+
         _stop_event = asyncio.Event()
-        _reader_task = asyncio.create_task(
-            _steering_reader(steer_cap, _arbiter, _stop_event, console)
+        _manager = SteeringInputManager(
+            steer_cap=session.coordinator.get_capability("session.steer"),
+            arbiter=session.coordinator.get_capability("cli.stdin_arbiter"),
+            stop_event=_stop_event,
+            console=console,
         )
 
+        # Register a hook so the badge counter decrements each time the
+        # orchestrator drains one queued steer.  Use a unique name derived
+        # from the manager's id so multiple turns don't accumulate callbacks.
+        _hooks = session.coordinator.get("hooks")
+        if _hooks and hasattr(_hooks, "register"):
+            _hooks.register(
+                "orchestrator:steering_injected",
+                _manager.on_steering_injected,
+                priority=500,
+                name=f"_steering_badge_{id(_manager)}",
+            )
+
         try:
-            execute_task = asyncio.create_task(session.execute(prompt_text))
+            # patch_stdout() must wrap the ENTIRE turn so that any Rich writes
+            # (from session.execute(), hooks, etc.) flow through the proxy and
+            # appear above the pinned steering prompt rather than overwriting it.
+            # Rich's Console.file property reads sys.stdout dynamically at write
+            # time (self._file is None by default), so the patched proxy is
+            # picked up automatically — no changes to console.py are needed.
+            with patch_stdout():
+                _reader_task = asyncio.create_task(_manager.run())
 
-            # Poll task while checking for cancellation
-            while not execute_task.done():
-                # Check for immediate cancellation - cancel the task
-                if session.coordinator.cancellation.is_immediate:
-                    execute_task.cancel()
-                    break
-                await asyncio.sleep(0.05)
+                try:
+                    execute_task = asyncio.create_task(session.execute(prompt_text))
 
-            try:
-                response = await execute_task
+                    # Poll task while checking for cancellation
+                    while not execute_task.done():
+                        # Check for immediate cancellation - cancel the task
+                        if session.coordinator.cancellation.is_immediate:
+                            execute_task.cancel()
+                            break
+                        await asyncio.sleep(0.05)
 
-                # Get hooks early for observability around render + prompt:complete + store
-                hooks = session.coordinator.get("hooks")
+                    try:
+                        response = await execute_task
 
-                # --- cleanup:render_begin ---
-                if hooks:
-                    await hooks.emit(
-                        CLEANUP_RENDER_BEGIN, {"session_id": actual_session_id}
-                    )
-                from .ui import render_message
-                # The streaming-UI hook no longer paints the final response;
-                # app-cli is the sole owner of the final render in all cases
-                # (fixes #256 double-render).
-                render_message(
-                    {"role": "assistant", "content": response},
-                    console,
-                    show_label=True,
-                )
+                        # Get hooks early for observability around render + prompt:complete + store
+                        hooks = session.coordinator.get("hooks")
 
-                # --- cleanup:render_end ---
-                if hooks:
-                    await hooks.emit(
-                        CLEANUP_RENDER_END, {"session_id": actual_session_id}
-                    )
+                        # --- cleanup:render_begin ---
+                        if hooks:
+                            await hooks.emit(
+                                CLEANUP_RENDER_BEGIN, {"session_id": actual_session_id}
+                            )
+                        from .ui import render_message
 
-                # Emit prompt:complete event
-                if hooks:
-                    from amplifier_core.events import PROMPT_COMPLETE
+                        # The streaming-UI hook no longer paints the final response;
+                        # app-cli is the sole owner of the final render in all cases
+                        # (fixes #256 double-render).
+                        render_message(
+                            {"role": "assistant", "content": response},
+                            console,
+                            show_label=True,
+                        )
 
-                    await hooks.emit(
-                        PROMPT_COMPLETE,
-                        {
-                            "prompt": prompt_text,
-                            "response": response,
-                            "session_id": actual_session_id,
-                        },
-                    )
+                        # --- cleanup:render_end ---
+                        if hooks:
+                            await hooks.emit(
+                                CLEANUP_RENDER_END, {"session_id": actual_session_id}
+                            )
 
-                # --- cleanup:store_begin ---
-                if hooks:
-                    await hooks.emit(
-                        CLEANUP_STORE_BEGIN, {"session_id": actual_session_id}
-                    )
+                        # Emit prompt:complete event
+                        if hooks:
+                            from amplifier_core.events import PROMPT_COMPLETE
 
-                # Save session after execution (even if cancelled - preserves state)
-                await _save_session()
+                            await hooks.emit(
+                                PROMPT_COMPLETE,
+                                {
+                                    "prompt": prompt_text,
+                                    "response": response,
+                                    "session_id": actual_session_id,
+                                },
+                            )
 
-                # --- cleanup:store_end ---
-                if hooks:
-                    await hooks.emit(
-                        CLEANUP_STORE_END, {"session_id": actual_session_id}
-                    )
+                        # --- cleanup:store_begin ---
+                        if hooks:
+                            await hooks.emit(
+                                CLEANUP_STORE_BEGIN, {"session_id": actual_session_id}
+                            )
 
-                # Return based on cancellation status
-                if session.coordinator.cancellation.is_cancelled:
-                    console.print("\n[yellow]Cancelled[/yellow]")
-                    return False
-                return True
+                        # Save session after execution (even if cancelled - preserves state)
+                        await _save_session()
 
-            except asyncio.CancelledError:
-                # Immediate cancellation - task was force-cancelled
-                console.print("\n[yellow]Cancelled[/yellow]")
-                # Still save session to preserve any partial progress
-                await _save_session()
-                return False
+                        # --- cleanup:store_end ---
+                        if hooks:
+                            await hooks.emit(
+                                CLEANUP_STORE_END, {"session_id": actual_session_id}
+                            )
+
+                        # Return based on cancellation status
+                        if session.coordinator.cancellation.is_cancelled:
+                            console.print("\n[yellow]Cancelled[/yellow]")
+                            return False
+                        return True
+
+                    except asyncio.CancelledError:
+                        # Immediate cancellation - task was force-cancelled
+                        console.print("\n[yellow]Cancelled[/yellow]")
+                        # Still save session to preserve any partial progress
+                        await _save_session()
+                        return False
+
+                finally:
+                    # Teardown the steering reader inside the patch_stdout()
+                    # context: signal it to stop, then wait for it to finish so
+                    # it cannot consume the next REPL prompt's input.
+                    _stop_event.set()
+                    _reader_task.cancel()
+                    try:
+                        await _reader_task
+                    except asyncio.CancelledError:
+                        pass
 
         finally:
             signal.signal(signal.SIGINT, original_handler)
-            # Teardown the steering reader: signal it to stop, then wait for it
-            # to finish so it cannot consume the next REPL prompt's input.
-            _stop_event.set()
-            _reader_task.cancel()
-            try:
-                await _reader_task
-            except asyncio.CancelledError:
-                pass
             # Don't reset cancellation here - session.py handles status
 
     # Execute initial prompt if provided

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -2473,7 +2473,7 @@ def cli(ctx, install_completion):
         )
 
 
-async def _process_runtime_mentions(session: AmplifierSession, prompt: str) -> str:
+async def process_runtime_mentions(session: AmplifierSession, prompt: str) -> str:
     """Process @mentions in user input at runtime.
 
     Returns the prompt with <context_file> XML blocks prepended for any resolved
@@ -2806,6 +2806,12 @@ async def interactive_chat(
             arbiter=session.coordinator.get_capability("cli.stdin_arbiter"),
             stop_event=_stop_event,
             console=console,
+            # Reuse path (docs/designs/steering-input-reuse.md, Fork A,
+            # locked): steered input goes through the SAME
+            # CommandProcessor.process_input + process_runtime_mentions the
+            # REPL uses (see _enqueue), not a second raw-injection path.
+            command_processor=command_processor,
+            session=session,
         )
 
         # Register a hook so the badge counter decrements each time the
@@ -2941,7 +2947,7 @@ async def interactive_chat(
         console.print("\n[dim]Processing... (Ctrl+C to cancel)[/dim]")
 
         # Process runtime @mentions in initial prompt
-        initial_prompt = await _process_runtime_mentions(session, initial_prompt)
+        initial_prompt = await process_runtime_mentions(session, initial_prompt)
         await _execute_with_interrupt(initial_prompt)
 
     # === REPL LOOP ===
@@ -2963,7 +2969,7 @@ async def interactive_chat(
                         console.print("\n[dim]Processing... (Ctrl+C to cancel)[/dim]")
 
                         # Process runtime @mentions in user input
-                        _expanded_text = await _process_runtime_mentions(
+                        _expanded_text = await process_runtime_mentions(
                             session, data["text"]
                         )
                         await _execute_with_interrupt(_expanded_text)
@@ -2980,7 +2986,7 @@ async def interactive_chat(
                                 console.print(
                                     "\n[dim]Processing... (Ctrl+C to cancel)[/dim]"
                                 )
-                                text = await _process_runtime_mentions(session, text)
+                                text = await process_runtime_mentions(session, text)
                                 await _execute_with_interrupt(text)
                             else:
                                 console.print(f"[cyan]{text}[/cyan]")
@@ -2997,7 +3003,7 @@ async def interactive_chat(
                             console.print(
                                 "\n[dim]Processing... (Ctrl+C to cancel)[/dim]"
                             )
-                            trailing_prompt = await _process_runtime_mentions(
+                            trailing_prompt = await process_runtime_mentions(
                                 session, trailing_prompt
                             )
                             await _execute_with_interrupt(trailing_prompt)
@@ -3138,7 +3144,7 @@ async def execute_single(
                 )
 
         # Process runtime @mentions in user input
-        prompt = await _process_runtime_mentions(session, prompt)
+        prompt = await process_runtime_mentions(session, prompt)
 
         if verbose:
             console.print(f"[dim]Executing: {prompt}[/dim]")

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import select
 import signal
 import sys
 from collections.abc import Callable
@@ -2505,6 +2506,66 @@ async def _process_runtime_mentions(session: AmplifierSession, prompt: str) -> s
     )
 
 
+def _stdin_ready(timeout: float) -> bool:
+    """Return True if stdin has data within *timeout* seconds (POSIX only).
+
+    Uses select() with a bounded timeout so the caller never holds a blocking
+    read indefinitely.  Swallows OS errors (e.g. stdin is not a real fd in
+    tests or non-TTY contexts) and returns False instead.
+    """
+    try:
+        r, _, _ = select.select([sys.stdin], [], [], timeout)
+        return bool(r)
+    except (OSError, ValueError):
+        return False
+
+
+async def _steering_reader(steer_cap, arbiter, stop_event: asyncio.Event, console) -> None:
+    """Read stdin lines during a running turn and forward to session.steer.
+
+    Runs only while *stop_event* is unset.  Uses _stdin_ready (select-based,
+    bounded to 0.1 s) so teardown leaves no outstanding blocking read.
+    Suspends entirely while an approval prompt owns stdin via *arbiter*.
+
+    Fail-loud contract:
+    - steer_cap is None  -> prints visible "unavailable" message, never drops silently.
+    - SteeringQueueFull  -> prints visible rejection, turn continues.
+    - Empty/whitespace lines are ignored (not forwarded).
+    """
+    loop = asyncio.get_event_loop()
+    while not stop_event.is_set():
+        # Approval owns stdin while active — do not read.
+        if arbiter is not None and arbiter.approval_active:
+            await asyncio.sleep(0.05)
+            continue
+        # Bounded readiness check off the event-loop thread; returns within 0.1 s
+        # so stop_event is honoured promptly (no leaked blocking read at teardown).
+        ready = await loop.run_in_executor(None, _stdin_ready, 0.1)
+        if not ready:
+            continue
+        # Re-check: approval may have claimed stdin between select and read.
+        if arbiter is not None and arbiter.approval_active:
+            continue
+        line = sys.stdin.readline()  # data is ready → returns a full TTY line
+        if line == "":  # EOF
+            break
+        text = line.strip()
+        if not text:
+            continue  # ignore blank / whitespace-only lines
+        if steer_cap is None:
+            # Fail loud — never silently drop a typed line.
+            console.print(
+                "[yellow]Steering unavailable: this orchestrator does not "
+                "support session.steer.[/yellow]"
+            )
+            continue
+        try:
+            steer_cap(text)
+            console.print("[dim]queued \u2014 applies after current step[/dim]")
+        except Exception as e:  # ValueError, SteeringQueueFull, etc.
+            console.print(f"[red]Steering rejected: {e}[/red]")
+
+
 def _create_prompt_session(get_active_mode: Callable | None = None) -> PromptSession:
     """Create configured PromptSession for REPL.
 
@@ -2795,6 +2856,14 @@ async def interactive_chat(
 
         original_handler = signal.signal(signal.SIGINT, sigint_handler)
 
+        # Mid-turn steering: start concurrent stdin reader for the duration of this turn.
+        steer_cap = session.coordinator.get_capability("session.steer")
+        _arbiter = session.coordinator.get_capability("cli.stdin_arbiter")
+        _stop_event = asyncio.Event()
+        _reader_task = asyncio.create_task(
+            _steering_reader(steer_cap, _arbiter, _stop_event, console)
+        )
+
         try:
             execute_task = asyncio.create_task(session.execute(prompt_text))
 
@@ -2876,6 +2945,14 @@ async def interactive_chat(
 
         finally:
             signal.signal(signal.SIGINT, original_handler)
+            # Teardown the steering reader: signal it to stop, then wait for it
+            # to finish so it cannot consume the next REPL prompt's input.
+            _stop_event.set()
+            _reader_task.cancel()
+            try:
+                await _reader_task
+            except asyncio.CancelledError:
+                pass
             # Don't reset cancellation here - session.py handles status
 
     # Execute initial prompt if provided

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -2826,6 +2826,23 @@ async def interactive_chat(
                 name=f"_steering_badge_{id(_manager)}",
             )
 
+        # THROTTLE/COALESCE spike (revertable, display-only): publish this
+        # turn's compose-state so hooks-streaming-ui can coalesce its
+        # streaming Live repaints while the user is composing a mid-turn
+        # steer, instead of fighting the pinned steering prompt for the
+        # terminal. GUARDED for back-compat: an unmodified (or older)
+        # hooks-streaming-ui module won't have registered the
+        # "ui.streaming_hooks" capability (get_capability returns None) or
+        # won't define _composing_fn on its StreamingUIHooks instance
+        # (hasattr guard) -- either way app-cli runs unaffected.
+        _streaming_hooks_instance = session.coordinator.get_capability(
+            "ui.streaming_hooks"
+        )
+        if _streaming_hooks_instance is not None and hasattr(
+            _streaming_hooks_instance, "_composing_fn"
+        ):
+            _streaming_hooks_instance._composing_fn = _manager.is_composing
+
         try:
             # patch_stdout() must wrap the ENTIRE turn so that any Rich writes
             # (from session.execute(), hooks, etc.) flow through the proxy and
@@ -2938,6 +2955,13 @@ async def interactive_chat(
         finally:
             signal.signal(signal.SIGINT, original_handler)
             # Don't reset cancellation here - session.py handles status
+            # THROTTLE/COALESCE spike: clear the compose-state callback so a
+            # stale bound method from this (finished) manager can never be
+            # queried by a future turn's streaming-ui hooks instance.
+            if _streaming_hooks_instance is not None and hasattr(
+                _streaming_hooks_instance, "_composing_fn"
+            ):
+                _streaming_hooks_instance._composing_fn = None
 
     # Execute initial prompt if provided
     if initial_prompt:

--- a/amplifier_app_cli/session_runner.py
+++ b/amplifier_app_cli/session_runner.py
@@ -275,10 +275,14 @@ async def create_initialized_session(
 
     # Step 10: Register approval provider (app-layer policy)
     from .approval_provider import CLIApprovalProvider
+    from .stdin_arbiter import StdinArbiter
+
+    arbiter = StdinArbiter()
+    session.coordinator.register_capability("cli.stdin_arbiter", arbiter)
 
     register_provider = session.coordinator.get_capability("approval.register_provider")
     if register_provider:
-        approval_provider = CLIApprovalProvider(console)
+        approval_provider = CLIApprovalProvider(console, arbiter=arbiter)
         register_provider(approval_provider)
         logger.debug("Registered CLIApprovalProvider for interactive approvals")
 

--- a/amplifier_app_cli/stdin_arbiter.py
+++ b/amplifier_app_cli/stdin_arbiter.py
@@ -1,0 +1,21 @@
+"""Coordinates exclusive stdin access between approval prompts and the
+mid-turn steering reader. Approval is the priority owner: while an approval is
+in flight, the steering reader suspends entirely.
+"""
+
+from __future__ import annotations
+
+
+class StdinArbiter:
+    def __init__(self) -> None:
+        self._approval_active = False
+
+    @property
+    def approval_active(self) -> bool:
+        return self._approval_active
+
+    def begin_approval(self) -> None:
+        self._approval_active = True
+
+    def end_approval(self) -> None:
+        self._approval_active = False

--- a/amplifier_app_cli/steering_input.py
+++ b/amplifier_app_cli/steering_input.py
@@ -116,12 +116,24 @@ class SteeringInputManager:
         stop_event: asyncio.Event,
         console: Any,
         *,
+        command_processor: Any | None = None,
+        session: Any = None,
         _input_provider: (Callable[[], Coroutine[Any, Any, str | None]] | None) = None,
+        _mentions_expander: (
+            Callable[[Any, str], Coroutine[Any, Any, str]] | None
+        ) = None,
     ) -> None:
         self._steer_cap = steer_cap
         self._arbiter = arbiter
         self._stop_event = stop_event
         self._console = console
+        # Reuse path (docs/designs/steering-input-reuse.md, Fork A, locked):
+        # the SAME CommandProcessor + session used by the REPL, so steered
+        # input goes through the SAME classification + @-mention expansion.
+        # Both optional (None preserves the old raw-passthrough behavior) so
+        # existing constructors/tests are unaffected.
+        self._command_processor = command_processor
+        self._session = session
         # Monotonic pair — increment-only counters that are the single source
         # of truth for the badge.  Badge = max(0, _enqueued_total - _injected_total).
         # Order-insensitive: cannot go negative; self-heals once events catch up.
@@ -132,6 +144,10 @@ class SteeringInputManager:
         self._pt_session: Any = None
         # Injectable for tests (avoids real TTY requirement).
         self._input_provider = _input_provider
+        # Injectable for tests (avoids importing the real main.py module).
+        # When None, the real amplifier_app_cli.main.process_runtime_mentions
+        # is lazily imported in _enqueue -- same function the REPL calls.
+        self._mentions_expander = _mentions_expander
 
     # ------------------------------------------------------------------
     # Public state
@@ -234,6 +250,40 @@ class SteeringInputManager:
                 "working.[/yellow]"
             )
             return
+
+        # Reuse path (docs/designs/steering-input-reuse.md, Fork A, locked):
+        # run steered text through the SAME CommandProcessor.process_input the
+        # REPL uses, then the SAME process_runtime_mentions @-mention
+        # expansion, before delivering it.  command_processor is optional
+        # (None preserves the old raw-passthrough behavior for any caller that
+        # does not wire it).
+        if self._command_processor is not None:
+            action, data = self._command_processor.process_input(text)
+
+            if action != "prompt":
+                # Locked command policy: REJECT-ALL mid-turn. No /mode
+                # whitelist, no handle_command call on the steering path \u2014
+                # an honest, actionable rejection instead of silent drop or
+                # raw injection.
+                self._console.print(
+                    f"[yellow]\u29d7 commands aren't applied mid-turn \u2014 finish "
+                    f"or cancel the turn first, then run it: {text}[/yellow]"
+                )
+                return
+
+            expander = self._mentions_expander
+            if expander is None:
+                from .main import process_runtime_mentions as expander
+
+            try:
+                text = await expander(self._session, data["text"])
+            except Exception as exc:
+                # Must never strand the drain loop: catch, fail loud, do not
+                # steer a half-expanded message.
+                self._console.print(
+                    f"[red]\u29d7 couldn't expand mentions: {exc}[/red]"
+                )
+                return
 
         try:
             self._steer_cap(text)

--- a/amplifier_app_cli/steering_input.py
+++ b/amplifier_app_cli/steering_input.py
@@ -95,10 +95,17 @@ class SteeringInputManager:
     # Hook callback (registered on "orchestrator:steering_injected")
     # ------------------------------------------------------------------
 
-    async def on_steering_injected(self, event_data: dict) -> None:
+    async def on_steering_injected(self, event: str, data: dict[str, Any]) -> None:
         """Decrement badge counter when the orchestrator drains one steer.
 
+        Signature matches the Amplifier hook dispatcher calling convention:
+        ``handler(event_type: str, payload: dict)`` — two positional arguments
+        (see ``IncrementalSaveHook.on_tool_post`` in ``incremental_save.py`` for
+        the canonical reference).
+
         One ``orchestrator:steering_injected`` event == one drained message.
+        Payload keys emitted by the orchestrator: ``orchestrator``, ``content``,
+        ``iteration``, ``queued_remaining``, ``metadata``.
         Counter is guarded against going below zero.
         """
         if self._pending_count > 0:
@@ -108,6 +115,26 @@ class SteeringInputManager:
                 self._pt_session.app.invalidate()
             except Exception:
                 pass  # App not running or already cleaned up; non-fatal
+
+    # ------------------------------------------------------------------
+    # Prompt message (callable passed to prompt_toolkit as ``message=``)
+    # ------------------------------------------------------------------
+
+    def _prompt_message(self) -> Any:
+        """Return the current prompt message with live queued-count annotation.
+
+        Passed as ``message=self._prompt_message`` (a callable) so
+        prompt_toolkit re-evaluates it on each ``app.invalidate()`` call,
+        keeping the queued count visible without bottom-toolbar CPR support.
+
+        When N messages are queued: ``"  steer (N queued ⧗): "``
+        When no messages are pending: ``"  steer: "``
+        """
+        from prompt_toolkit.formatted_text import HTML
+
+        if self._pending_count > 0:
+            return HTML(f"  steer ({self._pending_count} queued \u29d7): ")
+        return HTML("  steer: ")
 
     # ------------------------------------------------------------------
     # Bottom toolbar (callable passed to prompt_toolkit)
@@ -152,6 +179,12 @@ class SteeringInputManager:
             self._pending_count += 1
             # Show in scrollback above the prompt so the user sees the ack.
             self._console.print(f"[dim]\u29d7 queued: {text}[/dim]")
+            # Refresh the prompt so the callable message re-renders with the new count.
+            if self._pt_session is not None:
+                try:
+                    self._pt_session.app.invalidate()
+                except Exception:
+                    pass
         except Exception as exc:  # ValueError, SteeringQueueFull, etc.
             self._console.print(f"[red]Steering rejected: {exc}[/red]")
 
@@ -168,10 +201,11 @@ class SteeringInputManager:
         """
         if self._input_provider is None:
             from prompt_toolkit import PromptSession
-            from prompt_toolkit.formatted_text import HTML
 
             self._pt_session = PromptSession()
-            _message: Any = HTML("<ansiblue>  steer: </ansiblue>")
+            # Pass a callable so prompt_toolkit re-evaluates the message on each
+            # app.invalidate() call, keeping the queued count live in the prompt.
+            _message: Any = self._prompt_message
         else:
             _message = None  # not used in the test / injected path
 

--- a/amplifier_app_cli/steering_input.py
+++ b/amplifier_app_cli/steering_input.py
@@ -1,0 +1,279 @@
+"""Anchored steering input during agent turns.
+
+``SteeringInputManager`` runs a ``prompt_toolkit`` prompt pinned at the bottom
+of the terminal while the agent works a turn.  Typed input is forwarded to
+``session.steer()``; a live "N queued" badge in the bottom toolbar stays
+visible until all steers have been drained by the orchestrator.
+
+Design notes
+~~~~~~~~~~~~
+* ``patch_stdout()`` is activated by ``_execute_with_interrupt`` around the
+  *whole* turn (not just the prompt).  Rich's ``Console.file`` property reads
+  ``sys.stdout`` dynamically (``self._file`` is ``None`` by default in the
+  singleton created at module import), so the patched proxy is picked up at
+  write time automatically — no changes to ``console.py`` are required.
+
+* ``PromptSession.app`` is the persistent ``Application`` object created once
+  in ``PromptSession.__init__`` and reused across ``prompt_async()`` calls.
+  ``Application.invalidate()`` is thread-safe (uses ``loop.call_soon_threadsafe``
+  internally), so it is safe to call from any coroutine on the same event loop.
+
+* ``_input_provider`` allows tests to inject a mock input source without
+  spinning up a real TTY.  Production code leaves it ``None``.
+
+Correctness interactions handled
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. **patch_stdout** – caller activates it for the whole turn; Rich writes flow
+   through the patched ``sys.stdout`` and appear above the pinned prompt.
+2. **StdinArbiter** – when ``arbiter.approval_active`` is ``True`` the running
+   ``prompt_async()`` task is cancelled (releasing the terminal), the manager
+   waits for approval to finish, then restarts the prompt.
+3. **Ctrl-C / SIGINT** – ``KeyboardInterrupt`` raised from ``prompt_async()``
+   is caught and the loop continues; the ``sigint_handler`` installed by
+   ``_execute_with_interrupt`` has already updated the cancellation token.
+4. **Teardown** – ``stop_event.set()`` + ``task.cancel()`` + ``await`` in the
+   ``finally`` block of ``_execute_with_interrupt``; the inner polling loop
+   honours ``stop_event`` within the next 50 ms tick.
+5. **Empty / whitespace** – silently ignored in ``_enqueue()``.
+   **Fail-loud** – visible message when ``steer_cap`` is ``None``.
+   **Overflow** – visible rejection on ``SteeringQueueFull``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Coroutine
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class SteeringInputManager:
+    """Anchored steering prompt + queued-badge for a single agent turn.
+
+    Lifecycle::
+
+        manager = SteeringInputManager(steer_cap, arbiter, stop_event, console)
+        task = asyncio.create_task(manager.run())
+        # ... turn runs ...
+        stop_event.set()
+        task.cancel()
+        await task   # or swallow CancelledError
+    """
+
+    def __init__(
+        self,
+        steer_cap: Any | None,
+        arbiter: Any | None,
+        stop_event: asyncio.Event,
+        console: Any,
+        *,
+        _input_provider: (Callable[[], Coroutine[Any, Any, str | None]] | None) = None,
+    ) -> None:
+        self._steer_cap = steer_cap
+        self._arbiter = arbiter
+        self._stop_event = stop_event
+        self._console = console
+        self._pending_count: int = 0
+        # PromptSession is created lazily in run(); stored here so
+        # on_steering_injected() can call self._pt_session.app.invalidate().
+        self._pt_session: Any = None
+        # Injectable for tests (avoids real TTY requirement).
+        self._input_provider = _input_provider
+
+    # ------------------------------------------------------------------
+    # Public state
+    # ------------------------------------------------------------------
+
+    @property
+    def pending_count(self) -> int:
+        """Number of messages currently queued but not yet injected."""
+        return self._pending_count
+
+    # ------------------------------------------------------------------
+    # Hook callback (registered on "orchestrator:steering_injected")
+    # ------------------------------------------------------------------
+
+    async def on_steering_injected(self, event_data: dict) -> None:
+        """Decrement badge counter when the orchestrator drains one steer.
+
+        One ``orchestrator:steering_injected`` event == one drained message.
+        Counter is guarded against going below zero.
+        """
+        if self._pending_count > 0:
+            self._pending_count -= 1
+        if self._pt_session is not None:
+            try:
+                self._pt_session.app.invalidate()
+            except Exception:
+                pass  # App not running or already cleaned up; non-fatal
+
+    # ------------------------------------------------------------------
+    # Bottom toolbar (callable passed to prompt_toolkit)
+    # ------------------------------------------------------------------
+
+    def _toolbar(self) -> str:
+        """Return badge text for the bottom toolbar.
+
+        Returns an empty string when there are no queued messages so
+        prompt_toolkit renders no toolbar strip.
+        """
+        if self._pending_count > 0:
+            s = "s" if self._pending_count != 1 else ""
+            return (
+                f"\u29d7 {self._pending_count} message{s} queued"
+                " \u00b7 applies after the current step"
+            )
+        return ""
+
+    # ------------------------------------------------------------------
+    # Enqueue
+    # ------------------------------------------------------------------
+
+    async def _enqueue(self, text: str) -> None:
+        """Validate *text*, call steer_cap, increment counter, print ack.
+
+        Empty / whitespace-only *text* is silently ignored (not forwarded).
+        All other failures are surfaced as visible console messages (fail-loud).
+        """
+        if not text.strip():
+            return  # Silently ignore blank / whitespace-only lines
+
+        if self._steer_cap is None:
+            self._console.print(
+                "[yellow]Steering unavailable: this orchestrator does not "
+                "support session.steer.[/yellow]"
+            )
+            return
+
+        try:
+            self._steer_cap(text)
+            self._pending_count += 1
+            # Show in scrollback above the prompt so the user sees the ack.
+            self._console.print(f"[dim]\u29d7 queued: {text}[/dim]")
+        except Exception as exc:  # ValueError, SteeringQueueFull, etc.
+            self._console.print(f"[red]Steering rejected: {exc}[/red]")
+
+    # ------------------------------------------------------------------
+    # Main loop
+    # ------------------------------------------------------------------
+
+    async def run(self) -> None:
+        """Run the anchored steering prompt for the duration of a turn.
+
+        Exits when ``stop_event`` is set (normal turn end), on EOF (Ctrl-D),
+        or when the task is cancelled by the ``finally`` block in
+        ``_execute_with_interrupt``.
+        """
+        if self._input_provider is None:
+            from prompt_toolkit import PromptSession
+            from prompt_toolkit.formatted_text import HTML
+
+            self._pt_session = PromptSession()
+            _message: Any = HTML("<ansiblue>  steer: </ansiblue>")
+        else:
+            _message = None  # not used in the test / injected path
+
+        try:
+            while not self._stop_event.is_set():
+                # Suspend during approval — yield stdin to Confirm.ask.
+                if self._arbiter is not None and self._arbiter.approval_active:
+                    await asyncio.sleep(0.05)
+                    continue
+
+                # Launch input as a cancellable task so we can abort it when
+                # approval starts mid-prompt or stop_event fires.
+                if self._input_provider is not None:
+                    prompt_task: asyncio.Task[str | None] = asyncio.create_task(
+                        self._input_provider()
+                    )
+                else:
+                    assert self._pt_session is not None
+                    prompt_task = asyncio.create_task(
+                        self._pt_session.prompt_async(
+                            message=_message,
+                            bottom_toolbar=self._toolbar,
+                        )
+                    )
+
+                # Poll until the task finishes or an abort condition arises.
+                aborted_for_approval = False
+                while not prompt_task.done():
+                    if self._stop_event.is_set():
+                        # Turn ended — cancel and exit cleanly.
+                        prompt_task.cancel()
+                        try:
+                            await prompt_task
+                        except (
+                            asyncio.CancelledError,
+                            KeyboardInterrupt,
+                            EOFError,
+                        ):
+                            pass
+                        return
+
+                    if self._arbiter is not None and self._arbiter.approval_active:
+                        # Abort prompt so approval gets exclusive stdin access.
+                        prompt_task.cancel()
+                        try:
+                            await prompt_task
+                        except (
+                            asyncio.CancelledError,
+                            KeyboardInterrupt,
+                            EOFError,
+                        ):
+                            pass
+                        # Wait for approval to finish before restarting.
+                        while (
+                            self._arbiter is not None
+                            and self._arbiter.approval_active
+                            and not self._stop_event.is_set()
+                        ):
+                            await asyncio.sleep(0.05)
+                        aborted_for_approval = True
+                        break
+
+                    await asyncio.sleep(0.05)
+
+                if aborted_for_approval:
+                    continue  # Restart outer while — re-check stop_event
+
+                if self._stop_event.is_set():
+                    if not prompt_task.done():
+                        prompt_task.cancel()
+                        try:
+                            await prompt_task
+                        except (
+                            asyncio.CancelledError,
+                            KeyboardInterrupt,
+                            EOFError,
+                        ):
+                            pass
+                    return
+
+                # Retrieve result (task is already done at this point).
+                try:
+                    text = await prompt_task
+                except asyncio.CancelledError:
+                    continue
+                except KeyboardInterrupt:
+                    # Ctrl-C: sigint_handler in _execute_with_interrupt has
+                    # already updated the cancellation token.  Just continue —
+                    # the poll loop will detect it and cancel execute_task.
+                    continue
+                except EOFError:
+                    # Ctrl-D: user is done with steering input.
+                    break
+                except Exception as exc:
+                    logger.debug("Steering prompt error: %s", exc)
+                    continue
+
+                if self._stop_event.is_set():
+                    break
+
+                if text is not None:
+                    await self._enqueue(text.strip() if text else "")
+
+        finally:
+            self._pt_session = None

--- a/amplifier_app_cli/steering_input.py
+++ b/amplifier_app_cli/steering_input.py
@@ -28,9 +28,41 @@ Correctness interactions handled
 2. **StdinArbiter** – when ``arbiter.approval_active`` is ``True`` the running
    ``prompt_async()`` task is cancelled (releasing the terminal), the manager
    waits for approval to finish, then restarts the prompt.
-3. **Ctrl-C / SIGINT** – ``KeyboardInterrupt`` raised from ``prompt_async()``
-   is caught and the loop continues; the ``sigint_handler`` installed by
-   ``_execute_with_interrupt`` has already updated the cancellation token.
+3. **Ctrl-C / SIGINT** – Two independent events arrive when Ctrl-C is pressed:
+   the OS SIGINT signal and the ``\\x03`` TTY byte read by prompt_toolkit.
+
+   Without special handling, prompt_toolkit's default ``c-c`` / ``<sigint>``
+   key binding calls ``app.exit(exception=KeyboardInterrupt())``.  That
+   ``KeyboardInterrupt`` propagates through the ``prompt_async()`` coroutine
+   and into asyncio's ``Task.__step_run_and_handle_result()``, which catches
+   ``KeyboardInterrupt``/``SystemExit`` and *re-raises* after storing the
+   exception (CPython 3.11+).  The re-raise then escapes through
+   ``Handle._run()`` (also re-raises ``KeyboardInterrupt``) and
+   ``EventLoop._run_once()`` straight into ``asyncio.run()`` — crashing the
+   process before any ``except KeyboardInterrupt`` clause in user code can
+   catch it.  The ``except KeyboardInterrupt: continue`` that appears in
+   ``run()`` around ``await prompt_task`` is therefore unreachable when the
+   default binding is in use.
+
+   Additionally, prompt_toolkit's ``Application.run_async()`` calls
+   ``loop.add_signal_handler(SIGINT, ...)`` which **overrides** the
+   ``signal.signal(SIGINT, sigint_handler)`` installed by
+   ``_execute_with_interrupt``, so that handler (which updates the
+   cancellation token) is never invoked.
+
+   The fix uses two ``PromptSession`` parameters together:
+
+   * ``interrupt_exception=_CtrlCInterrupt`` — replaces ``KeyboardInterrupt``
+     with a plain ``Exception`` subclass.  asyncio's task machinery stores it
+     as a normal task exception (no re-raise), so ``await prompt_task`` raises
+     it in the normal place and the ``except _CtrlCInterrupt: continue`` clause
+     in ``run()`` catches it cleanly.
+
+   * ``handle_sigint=False`` passed to ``prompt_async()`` — prevents
+     ``Application.run_async()`` from calling ``loop.add_signal_handler()``,
+     leaving ``sigint_handler`` active so the cancellation token is updated
+     correctly for graceful → immediate cancellation.
+
 4. **Teardown** – ``stop_event.set()`` + ``task.cancel()`` + ``await`` in the
    ``finally`` block of ``_execute_with_interrupt``; the inner polling loop
    honours ``stop_event`` within the next 50 ms tick.
@@ -47,6 +79,21 @@ from collections.abc import Callable, Coroutine
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+class _CtrlCInterrupt(Exception):
+    """Sentinel raised by the steering PromptSession when Ctrl-C is pressed.
+
+    Using a plain ``Exception`` subclass instead of ``KeyboardInterrupt``
+    prevents asyncio's ``Task.__step_run_and_handle_result()`` from re-raising
+    the exception after storing it (CPython 3.11+ re-raises only
+    ``KeyboardInterrupt`` and ``SystemExit``).  The re-raise would otherwise
+    escape through ``Handle._run()`` and crash ``asyncio.run()``.
+
+    The actual SIGINT signal is handled separately by the ``sigint_handler``
+    installed in ``_execute_with_interrupt`` (kept active because we pass
+    ``handle_sigint=False`` to ``prompt_async()``).
+    """
 
 
 class SteeringInputManager:
@@ -159,9 +206,11 @@ class SteeringInputManager:
         Empty / whitespace-only *text* is silently ignored (not forwarded).
         All other failures are surfaced as visible console messages (fail-loud).
 
-        Ack gating (§5.3 of steering-drain.md):
-          * ``stop_event`` **not** set (turn live): ``⧗ queued: {text}``
-          * ``stop_event`` **set** (turn ending/ended): ``⧗ queued for next turn: {text}``
+        Turn-end gating:
+          * ``stop_event`` **not** set (turn live): forward + ``⧗ queued: {text}``
+          * ``stop_event`` **set** (turn ending/ended): do NOT forward — the
+            orchestrator's execute()-entry clear() would discard it — and print
+            an honest "turn ended — not sent" ack instead of a false promise.
         """
         if not text.strip():
             return  # Silently ignore blank / whitespace-only lines
@@ -173,16 +222,23 @@ class SteeringInputManager:
             )
             return
 
+        # Turn already ending/ended: a steer enqueued now is wiped by the
+        # orchestrator's execute()-entry clear() before the next turn runs, so it
+        # would NOT be delivered. Be honest (no false "queued for next turn"
+        # promise) and do not enqueue it. Cross-turn delivery is the parked
+        # FollowUpQueue's job, not the mid-turn SteeringQueue's.
+        if self._stop_event.is_set():
+            self._console.print(
+                f"[yellow]\u29d7 turn ended \u2014 not sent: {text}\n"
+                "  steering applies mid-turn; resend it while the agent is "
+                "working.[/yellow]"
+            )
+            return
+
         try:
             self._steer_cap(text)
             self._enqueued_total += 1
-            # Gate the ack on whether the turn is still live (§5.3 steering-drain.md).
-            # stop_event set  → steer will apply to the NEXT turn (turn ending/ended)
-            # stop_event clear → steer will be consumed by the current turn (live)
-            if self._stop_event.is_set():
-                self._console.print(f"[dim]\u29d7 queued for next turn: {text}[/dim]")
-            else:
-                self._console.print(f"[dim]\u29d7 queued: {text}[/dim]")
+            self._console.print(f"[dim]\u29d7 queued: {text}[/dim]")
             # Refresh the prompt so the callable message re-renders with the new count.
             if self._pt_session is not None:
                 try:
@@ -206,7 +262,13 @@ class SteeringInputManager:
         if self._input_provider is None:
             from prompt_toolkit import PromptSession
 
-            self._pt_session = PromptSession()
+            # interrupt_exception=_CtrlCInterrupt: replace the default
+            # KeyboardInterrupt with a plain Exception subclass so that asyncio's
+            # Task.__step_run_and_handle_result() does NOT re-raise after storing
+            # the exception.  The re-raise only applies to KeyboardInterrupt /
+            # SystemExit (CPython 3.11+) and would otherwise propagate through
+            # Handle._run() → _run_once() → asyncio.run(), crashing the process.
+            self._pt_session = PromptSession(interrupt_exception=_CtrlCInterrupt)
             # Pass a callable so prompt_toolkit re-evaluates the message on each
             # app.invalidate() call, keeping the queued count live in the prompt.
             _message: Any = self._prompt_message
@@ -231,6 +293,12 @@ class SteeringInputManager:
                     prompt_task = asyncio.create_task(
                         self._pt_session.prompt_async(
                             message=_message,
+                            # handle_sigint=False: do NOT let prompt_toolkit call
+                            # loop.add_signal_handler(SIGINT, ...), which would
+                            # override the sigint_handler installed by
+                            # _execute_with_interrupt and prevent the cancellation
+                            # token from being updated when Ctrl-C is pressed.
+                            handle_sigint=False,
                         )
                     )
 
@@ -294,10 +362,21 @@ class SteeringInputManager:
                     text = await prompt_task
                 except asyncio.CancelledError:
                     continue
+                except _CtrlCInterrupt:
+                    # Ctrl-C while the steering prompt was active.
+                    # PromptSession raised _CtrlCInterrupt (not KeyboardInterrupt)
+                    # so asyncio's task machinery stores it normally and does NOT
+                    # re-raise, allowing this except clause to be reached.
+                    # The OS SIGINT was handled by sigint_handler in
+                    # _execute_with_interrupt (kept active via handle_sigint=False),
+                    # which updated the cancellation token.  The poll loop in
+                    # _execute_with_interrupt will detect the cancellation on its
+                    # next 50 ms tick and cancel execute_task.
+                    continue
                 except KeyboardInterrupt:
-                    # Ctrl-C: sigint_handler in _execute_with_interrupt has
-                    # already updated the cancellation token.  Just continue —
-                    # the poll loop will detect it and cancel execute_task.
+                    # Safety net: should not be raised with the current
+                    # PromptSession(interrupt_exception=_CtrlCInterrupt) setup,
+                    # but kept in case a future code path reaches this point.
                     continue
                 except EOFError:
                     # Ctrl-D: user is done with steering input.

--- a/amplifier_app_cli/steering_input.py
+++ b/amplifier_app_cli/steering_input.py
@@ -2,7 +2,7 @@
 
 ``SteeringInputManager`` runs a ``prompt_toolkit`` prompt pinned at the bottom
 of the terminal while the agent works a turn.  Typed input is forwarded to
-``session.steer()``; a live "N queued" badge in the bottom toolbar stays
+``session.steer()``; a live "N queued" badge in the prompt line stays
 visible until all steers have been drained by the orchestrator.
 
 Design notes
@@ -137,24 +137,6 @@ class SteeringInputManager:
         return HTML("  steer: ")
 
     # ------------------------------------------------------------------
-    # Bottom toolbar (callable passed to prompt_toolkit)
-    # ------------------------------------------------------------------
-
-    def _toolbar(self) -> str:
-        """Return badge text for the bottom toolbar.
-
-        Returns an empty string when there are no queued messages so
-        prompt_toolkit renders no toolbar strip.
-        """
-        if self._pending_count > 0:
-            s = "s" if self._pending_count != 1 else ""
-            return (
-                f"\u29d7 {self._pending_count} message{s} queued"
-                " \u00b7 applies after the current step"
-            )
-        return ""
-
-    # ------------------------------------------------------------------
     # Enqueue
     # ------------------------------------------------------------------
 
@@ -227,7 +209,6 @@ class SteeringInputManager:
                     prompt_task = asyncio.create_task(
                         self._pt_session.prompt_async(
                             message=_message,
-                            bottom_toolbar=self._toolbar,
                         )
                     )
 

--- a/amplifier_app_cli/steering_input.py
+++ b/amplifier_app_cli/steering_input.py
@@ -75,7 +75,11 @@ class SteeringInputManager:
         self._arbiter = arbiter
         self._stop_event = stop_event
         self._console = console
-        self._pending_count: int = 0
+        # Monotonic pair — increment-only counters that are the single source
+        # of truth for the badge.  Badge = max(0, _enqueued_total - _injected_total).
+        # Order-insensitive: cannot go negative; self-heals once events catch up.
+        self._enqueued_total: int = 0
+        self._injected_total: int = 0
         # PromptSession is created lazily in run(); stored here so
         # on_steering_injected() can call self._pt_session.app.invalidate().
         self._pt_session: Any = None
@@ -88,15 +92,21 @@ class SteeringInputManager:
 
     @property
     def pending_count(self) -> int:
-        """Number of messages currently queued but not yet injected."""
-        return self._pending_count
+        """Number of messages currently queued but not yet injected.
+
+        Derived from the monotonic pair: ``max(0, _enqueued_total -
+        _injected_total)``.  The ``max(0, …)`` clamp prevents the badge from
+        going negative if an inject event arrives from a cross-turn carry
+        (§3.4 of steering-drain.md).
+        """
+        return max(0, self._enqueued_total - self._injected_total)
 
     # ------------------------------------------------------------------
     # Hook callback (registered on "orchestrator:steering_injected")
     # ------------------------------------------------------------------
 
     async def on_steering_injected(self, event: str, data: dict[str, Any]) -> None:
-        """Decrement badge counter when the orchestrator drains one steer.
+        """Increment injected_total when the orchestrator drains one steer.
 
         Signature matches the Amplifier hook dispatcher calling convention:
         ``handler(event_type: str, payload: dict)`` — two positional arguments
@@ -106,10 +116,12 @@ class SteeringInputManager:
         One ``orchestrator:steering_injected`` event == one drained message.
         Payload keys emitted by the orchestrator: ``orchestrator``, ``content``,
         ``iteration``, ``queued_remaining``, ``metadata``.
-        Counter is guarded against going below zero.
+
+        Badge derives from ``max(0, _enqueued_total - _injected_total)`` so an
+        extra/foreign inject event cannot drive it below zero — the ``max``
+        clamp in ``pending_count`` handles that.
         """
-        if self._pending_count > 0:
-            self._pending_count -= 1
+        self._injected_total += 1
         if self._pt_session is not None:
             try:
                 self._pt_session.app.invalidate()
@@ -132,8 +144,9 @@ class SteeringInputManager:
         """
         from prompt_toolkit.formatted_text import HTML
 
-        if self._pending_count > 0:
-            return HTML(f"  steer ({self._pending_count} queued \u29d7): ")
+        n = self.pending_count  # derived from monotonic pair
+        if n > 0:
+            return HTML(f"  steer ({n} queued \u29d7): ")
         return HTML("  steer: ")
 
     # ------------------------------------------------------------------
@@ -141,10 +154,14 @@ class SteeringInputManager:
     # ------------------------------------------------------------------
 
     async def _enqueue(self, text: str) -> None:
-        """Validate *text*, call steer_cap, increment counter, print ack.
+        """Validate *text*, call steer_cap, increment enqueued_total, print ack.
 
         Empty / whitespace-only *text* is silently ignored (not forwarded).
         All other failures are surfaced as visible console messages (fail-loud).
+
+        Ack gating (§5.3 of steering-drain.md):
+          * ``stop_event`` **not** set (turn live): ``⧗ queued: {text}``
+          * ``stop_event`` **set** (turn ending/ended): ``⧗ queued for next turn: {text}``
         """
         if not text.strip():
             return  # Silently ignore blank / whitespace-only lines
@@ -158,9 +175,14 @@ class SteeringInputManager:
 
         try:
             self._steer_cap(text)
-            self._pending_count += 1
-            # Show in scrollback above the prompt so the user sees the ack.
-            self._console.print(f"[dim]\u29d7 queued: {text}[/dim]")
+            self._enqueued_total += 1
+            # Gate the ack on whether the turn is still live (§5.3 steering-drain.md).
+            # stop_event set  → steer will apply to the NEXT turn (turn ending/ended)
+            # stop_event clear → steer will be consumed by the current turn (live)
+            if self._stop_event.is_set():
+                self._console.print(f"[dim]\u29d7 queued for next turn: {text}[/dim]")
+            else:
+                self._console.print(f"[dim]\u29d7 queued: {text}[/dim]")
             # Refresh the prompt so the callable message re-renders with the new count.
             if self._pt_session is not None:
                 try:

--- a/amplifier_app_cli/steering_input.py
+++ b/amplifier_app_cli/steering_input.py
@@ -186,15 +186,15 @@ class SteeringInputManager:
         prompt_toolkit re-evaluates it on each ``app.invalidate()`` call,
         keeping the queued count visible without bottom-toolbar CPR support.
 
-        When N messages are queued: ``"  steer (N queued ⧗): "``
-        When no messages are pending: ``"  steer: "``
+        When N messages are queued: ``"  (N queued ⧗) "``
+        When no messages are pending: empty string (the "steer" label is hidden).
         """
         from prompt_toolkit.formatted_text import HTML
 
         n = self.pending_count  # derived from monotonic pair
         if n > 0:
-            return HTML(f"  steer ({n} queued \u29d7): ")
-        return HTML("  steer: ")
+            return HTML(f"  ({n} queued \u29d7) ")
+        return HTML("")
 
     # ------------------------------------------------------------------
     # Enqueue

--- a/amplifier_app_cli/steering_input.py
+++ b/amplifier_app_cli/steering_input.py
@@ -164,6 +164,30 @@ class SteeringInputManager:
         """
         return max(0, self._enqueued_total - self._injected_total)
 
+    @property
+    def is_composing(self) -> bool:
+        """True while the user is actively mid-typing a steer.
+
+        THROTTLE/COALESCE spike (revertable, display-only): consumed by
+        hooks-streaming-ui via ``_execute_with_interrupt`` publishing this
+        property as a callback (``hooks_instance._composing_fn``), so the
+        streaming Live preview can reduce its repaint cadence instead of
+        fighting the pinned steering prompt for the terminal.
+
+        True iff a ``PromptSession`` is currently open (``_pt_session`` is
+        not None) AND its in-progress buffer text is non-empty.  Defensive:
+        ``_pt_session`` is None (not prompting) or any exception while
+        inspecting prompt_toolkit internals (e.g. a torn-down Application)
+        resolves to False rather than raising.
+        """
+        session = self._pt_session
+        if session is None:
+            return False
+        try:
+            return bool(session.app.current_buffer.text)
+        except Exception:
+            return False
+
     # ------------------------------------------------------------------
     # Hook callback (registered on "orchestrator:steering_injected")
     # ------------------------------------------------------------------

--- a/docs/designs/steering-input-reuse.md
+++ b/docs/designs/steering-input-reuse.md
@@ -1,0 +1,97 @@
+# Steering Input Reuse — honor slash commands & @-mentions (DRY)
+
+## Problem
+Steered input (typed mid-turn) is injected RAW: `SteeringInputManager._enqueue` →
+`steer_cap(text)` (`session.steer`). It bypasses the normal REPL input processing, so a
+steered `/mode plan` or `@file.py look at this` reaches the agent as literal text. We want
+steered input treated like any other input by **reusing the same processing code** — one
+home, so future improvements to the main input pipeline flow to steering automatically and
+we never maintain two input paths.
+
+## Discovery (file:line)
+Normal REPL pipeline (`main.py:2947+`), three cleanly-separable stages:
+1. `action, data = command_processor.process_input(text)` — slash dispatch.
+   `CommandProcessor.process_input` (`main.py:445`) — **public, pure, sync**. Non-slash →
+   `("prompt", {text})`; slash → `(action, data)` over 16 COMMANDS + MODE/SKILL shortcuts.
+2. If `action == "prompt"`: `expanded = await _process_runtime_mentions(session, data["text"])`
+   — @-mention expansion (`main.py:2476`, **module-private**, async, read-only).
+3. `await _execute_with_interrupt(expanded)` — new turn (`session.execute`). Else
+   `handle_command(action, data)` (REPL-level) + `trailing_prompt`.
+
+Steering path: `_enqueue(text)` (`steering_input.py:203`) → `self._steer_cap(text)` →
+`session.steer` (mid-turn inject, NOT a new turn). It skips stages 1 and 2 entirely.
+
+**Key:** the shared part is the FRONT (classify + expand); the DELIVERY tail differs
+(`session.execute` for the REPL vs `session.steer` for steering).
+
+## Plan — one front-end, two delivery tails
+1. Make the front-end reusable from the steering path (no logic duplication):
+   - Export `process_runtime_mentions` (drop the leading `_`).
+   - Pass the existing `CommandProcessor` instance into `SteeringInputManager.__init__`
+     (it currently lives only in `interactive_chat`'s scope).
+2. In `_enqueue`, run the SAME classification + expansion before delivering:
+   - `action, data = command_processor.process_input(text)`
+   - `action == "prompt"` → `expanded = await process_runtime_mentions(session, data["text"])`
+     → `steer_cap(expanded)`  ← the @-mention + clean-message win.
+   - else (a slash command) → mid-turn command policy (below).
+3. Mid-turn command policy (the genuine design decision):
+   - **Default = fail loud.** Commands that mutate the running turn or session
+     (`/clear`, `/fork`, `/save`, `/config`, `/quit`) are NOT applied mid-turn; print an
+     honest "`/clear` isn't applied mid-turn — finish or cancel the turn first." No silent
+     drop, no raw injection.
+   - Optionally apply a small whitelist of mid-turn-safe, non-context-mutating commands
+     (e.g. `/mode`) via the same `handle_command` path.
+4. DRY guarantee: classification + expansion live in the shared functions; both the REPL and
+   steering call them. Improvements to `process_input` / mention expansion reach steering for
+   free — the user's core requirement.
+
+## Design forks for the council
+- **Reuse depth:** (A) steering calls the existing `process_input` + `process_runtime_mentions`
+  directly — logic single-homed, ~5 lines of orchestration duplicated, no change to the proven
+  REPL. (B) Extract a shared `prepare_input_line(text)` wrapper both the REPL and steering call
+  — orchestration also single-homed (guards against a future REPL step being missed by
+  steering), but touches the proven REPL loop.
+- **Command policy:** reject-all-commands-mid-turn (MVP, simplest) vs apply-a-safe-whitelist
+  (e.g. `/mode`) + fail-loud for the rest.
+
+## Out of scope / parked
+Steering-prompt history; FollowUpQueue (defer commands to turn-end); fixed-input TUI.
+
+## Risk × impact
+- Message + @-mention reuse: low risk, high value, clearly correct — the actual gap hit.
+- Mid-turn command execution: higher risk (mutating state mid-turn) — hence fail-loud default
+  and this review.
+
+## Decisions (locked, post-council)
+Council verdict: 6 CONCERN, 0 FAIL. Converged: lock **Fork A** (don't touch the proven REPL —
+B's only gain guards a hypothetical future step, paid by re-opening a tested surface before
+ship); the @-mention + clean-message reuse is the real win; the mid-turn *command* policy is
+the genuinely hard part (split-brain-turn risk via `handle_command` mid-turn).
+
+User decisions:
+- **Fork A.** Steering calls the existing `process_input` + `process_runtime_mentions`; ~5 lines
+  of orchestration in `_enqueue`. No REPL surgery.
+- **Command policy = REJECT-ALL mid-turn** (skip `/mode` and all command *application* during
+  steering for now). Honest, actionable rejection on the existing steering-ack console path:
+  "commands aren't applied mid-turn — finish or cancel the turn first, then run it." No silent
+  drop, no raw injection. No `handle_command` call on the steering path at all.
+- **Ship: hold.** Fold everything into ONE PR per repo (loop-streaming + app-cli), not
+  ship-then-fast-follow.
+
+Parked (with reasons): `/mode`-whitelist / safe-mid-turn-command apply (needs a written
+"mid-turn-safe" invariant + ordering guarantee between `steer` and `handle_command` + DTU
+proof); FollowUpQueue (defer rejected/queued commands to turn-end — the livability upgrade
+user-advocate flagged); steering-prompt history; fixed-input TUI.
+
+Edge-handling required (from tester-breaker / crusty):
+- `_enqueue` must wrap expansion **defensively** — an exception from `process_runtime_mentions`
+  (bad/huge/missing `@path`, permission error) must NEVER strand the drain loop. Catch, fail
+  loud to the console, and do not steer a half-expanded message.
+- Empty / whitespace / delimiter-only inputs (`""`, `" "`, `"/"`, `"//x"`, `"@"`, `"@ "`) must
+  classify + handle without crashing.
+- **Ordering preserved:** `_enqueue` awaits expansion inline before the next prompt read
+  (sequential) → delivery order == type order. Confirm the `run()` loop is sequential.
+- Rejection renders on the existing steering-ack console path (defined channel; never injected
+  into the agent's context).
+- Windows path handling is **inherited** from the reused `process_runtime_mentions` (reuse, not
+  rewrite) — no new path logic on the steering side.

--- a/docs/designs/steering.md
+++ b/docs/designs/steering.md
@@ -616,4 +616,80 @@ revive rule (§3.6) guarantees action even if typed during the final generation.
 - **Bricks & studs:** the orchestrator has zero knowledge of the app; the app has zero
   knowledge of the orchestrator's internals. The only contract is the `session.steer`
   capability (+ the `cli.stdin_arbiter` capability internal to the app).
-```
+
+---
+
+## 9. UX: anchored input + queued badge
+
+**Status:** Implemented in `amplifier_app_cli/steering_input.py`  
+**Branch:** `feat/steering`
+
+### What was built
+
+The raw-TTY `select`-based stdin reader (`_stdin_ready` + `_steering_reader` in
+`main.py`) was replaced with a `prompt_toolkit`-based `SteeringInputManager` in the
+new module `amplifier_app_cli/steering_input.py`.
+
+**Anchored input line** — During a turn, `SteeringInputManager.run()` runs as a
+concurrent `asyncio` task. It calls `PromptSession.prompt_async()` with a
+`message=HTML("<ansiblue>  steer: </ansiblue>")` and a `bottom_toolbar` callable.
+The prompt line is pinned at the bottom of the terminal; all agent output (Rich
+`console.print` from hooks and `CLIDisplaySystem`) is wrapped in `patch_stdout()` and
+appears above it.
+
+**patch_stdout scope** — `patch_stdout()` is now activated in
+`_execute_with_interrupt` for the *entire* turn (not just the REPL wait between
+turns). Rich's `Console.file` property reads `sys.stdout` dynamically at write time
+(`self._file` is `None` by default for the singleton created at module import), so
+patched output is picked up automatically — no changes to `console.py` were required.
+
+**Queued-message badge** — `SteeringInputManager` maintains a `_pending_count`
+integer:
+- Incremented by 1 inside `_enqueue()` after each successful `steer_cap()` call.
+- Decremented by 1 in `on_steering_injected()`, which is registered as a hook on
+  `"orchestrator:steering_injected"` (one event == one drained message) in
+  `_execute_with_interrupt`.
+- The `_toolbar()` callable returns `"⧗ N message(s) queued · applies after the
+  current step"` when `N > 0`, and an empty string (no strip rendered) when `N == 0`.
+- After each decrement, `PromptSession.app.invalidate()` is called to refresh the
+  toolbar immediately. (`PromptSession.app` is the persistent `Application` object
+  created once in `__init__` and reused across `prompt_async()` calls;
+  `Application.invalidate()` is thread-safe via `loop.call_soon_threadsafe`.)
+
+**Scrollback ack** — On successful enqueue, a `[dim]⧗ queued: <text>[/dim]` line
+is printed to the scrollback via `console.print()` (which flows through
+`patch_stdout()` and appears above the pinned prompt).
+
+### How each correctness interaction is handled
+
+| # | Interaction | Mechanism |
+|---|-------------|-----------|
+| 1 | `patch_stdout` active for the whole turn | `with patch_stdout():` wraps the reader task creation AND `execute_task` in `_execute_with_interrupt`. Rich's `Console.file` is a dynamic property (`self._file or sys.stdout`), so the proxy is picked up at write time without any console.py changes. |
+| 2 | StdinArbiter / approval contention | When `arbiter.approval_active` becomes `True` while `prompt_async()` is awaiting input, a watcher inside the `run()` polling loop cancels the `prompt_task` (releasing the terminal from prompt_toolkit's raw mode), then polls until `approval_active` is `False`, then restarts the outer loop. `Confirm.ask` (running in a thread executor) gets exclusive stdin access. |
+| 3 | Ctrl-C must still cancel the turn | The `sigint_handler` installed by `_execute_with_interrupt` fires synchronously via `signal.signal` when SIGINT arrives and updates the cancellation token regardless of whether the steering prompt is active. `KeyboardInterrupt` raised from `prompt_async()` by prompt_toolkit's key binding is caught in the `run()` loop and handled with `continue` — the signal handler has already set the graceful/immediate state. |
+| 4 | Teardown | The `finally` block inside `with patch_stdout():` sets `_stop_event`, cancels and awaits `_reader_task`. This runs on normal completion, graceful/immediate cancel (Ctrl-C), and on error. The outermost `finally` restores the SIGINT handler. The prompt is guaranteed down before control returns to the REPL. |
+| 5 | Empty/whitespace ignored; fail-loud; overflow | `_enqueue()` returns early for empty text. If `steer_cap` is `None`, a yellow `[yellow]Steering unavailable[/yellow]` message is printed. If `steer_cap` raises (e.g. `SteeringQueueFull`), a red `[red]Steering rejected: …[/red]` message is printed. No silent drops. |
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `amplifier_app_cli/steering_input.py` | **New.** `SteeringInputManager` class with `run()`, `_enqueue()`, `on_steering_injected()`, `_toolbar()`, and `_input_provider` injection for tests. |
+| `amplifier_app_cli/main.py` | Removed `import select`, `_stdin_ready()`, `_steering_reader()`. Updated `_execute_with_interrupt`: creates `SteeringInputManager`, registers the decrement hook, wraps the turn with `with patch_stdout():`. |
+| `tests/test_steering.py` | Replaced select-based reader tests with 24 unit tests covering counter semantics, empty/whitespace, fail-loud, overflow, arbiter suspension, teardown, and toolbar text. |
+
+### What was NOT verified by unit test (flagged honestly)
+
+- **Visual behavior (pinned input, live badge)** — cannot be confirmed without a real
+  terminal. The positioning of the prompt at the bottom and the real-time toolbar
+  refresh must be verified in an interactive session with a real TTY.
+- **patch_stdout rendering** — the test suite confirms that `console.print` flows
+  through the dynamic `Console.file` property, but the visual ordering of output
+  above the prompt versus inline can only be checked visually.
+- **Ctrl-C interaction with prompt_toolkit** — the tests confirm that
+  `KeyboardInterrupt` is caught and the loop continues, but the interplay between
+  the OS SIGINT signal and prompt_toolkit's key binding cannot be exercised in a
+  headless test environment.
+- **Approval contention with real `Confirm.ask`** — the arbiter logic is
+  unit-tested via `_input_provider` injection; the actual terminal hand-off between
+  `prompt_async()` and a `run_in_executor(Confirm.ask)` requires a TTY to prove.

--- a/docs/designs/steering.md
+++ b/docs/designs/steering.md
@@ -1,0 +1,619 @@
+# Design: Mid-Turn Steering for the Streaming Orchestrator (Thin Slice)
+
+Status: Ready for implementation
+Scope: Two repos, branch `feat/steering` in both.
+- Orchestrator: `amplifier-module-loop-streaming/amplifier_module_loop_streaming/__init__.py` (`StreamingOrchestrator`)
+- App-CLI: `amplifier-app-cli/amplifier_app_cli/` (`main.py`, `approval_provider.py`, `session_runner.py`)
+
+> This spec is complete enough to build from without further design decisions.
+> Line numbers are anchors-at-time-of-writing; the implementer MUST re-confirm by
+> reading the named function and the quoted nearby code, because line numbers drift.
+
+---
+
+## 1. Outcome (what "done" means)
+
+A user types a message while the agent is actively working a turn. The message is
+queued and injected as a **user-role** message at the next safe boundary — the
+top-of-iteration point that sits *after the current tool round completes and before
+the next provider call*. The model demonstrably acts on it: the
+`orchestrator:steering_injected` event appears in `events.jsonl` AND the agent's
+subsequent tool calls / final answer visibly change to follow the redirect.
+
+Default semantics: **act after the next tool call completes.** Success is "the agent
+acts on the redirect," not "a message arrived."
+
+This is the THIN slice: **ONE queue, ONE drain semantics (mid-turn steer).** No
+FollowUpQueue, no drop-a-queued-steer, no child-target signaling.
+
+---
+
+## 2. The contract between the two repos (the only coupling)
+
+The orchestrator and the app are bricks connected by exactly ONE stud: a coordinator
+**capability** named `session.steer`. The orchestrator owns the queue and registers
+the capability; the app discovers and calls it. Neither imports the other.
+
+### Capability: `session.steer`
+
+| Field | Value |
+|---|---|
+| Name | `"session.steer"` |
+| Registered by | `StreamingOrchestrator` (orchestrator repo) in `mount()` |
+| Registered via | `coordinator.register_capability("session.steer", orchestrator.steer)` |
+| Value | bound method `steer(message: str) -> None` |
+| Consumed by | app-cli stdin reader via `coordinator.get_capability("session.steer")` |
+| Semantics | Non-blocking enqueue. The message is injected as a user-role message at the next top-of-iteration drain. |
+| Raises | `ValueError` if `message` is empty / whitespace-only. `SteeringQueueFull` (subclass of `RuntimeError`) if the bounded queue is full. |
+| Absence | `get_capability("session.steer")` returns `None` when the mounted orchestrator does not support steering → app must fail loud to the user, never silently drop typed lines. |
+
+This mirrors the existing `session.spawn` precedent
+(`session_runner.py:520`, `register_session_spawning`) and the capability API used
+throughout the codebase: `coordinator.register_capability(name, value)` /
+`coordinator.get_capability(name)`.
+
+---
+
+## 3. Orchestrator changes (`amplifier-module-loop-streaming`)
+
+### 3.1 New file: `amplifier_module_loop_streaming/steering.py`
+
+Self-contained copy of the proven pattern (do NOT import from the attractor bundle —
+it is not a runtime dependency). Adds a bound + validating queue.
+
+```python
+"""Bounded, fail-loud steering queue for the streaming orchestrator.
+
+Mid-turn steering: the host enqueues user messages while a turn is running;
+the orchestrator drains them at the top-of-iteration boundary (after the prior
+tool round, before the next provider call) and injects each as a user-role
+message. FIFO. Fail loud — never silently drop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+
+class SteeringQueueFull(RuntimeError):
+    """Raised when steer() is called on a full bounded queue (fail loud)."""
+
+
+class SteeringQueue:
+    """FIFO queue for mid-turn steering messages.
+
+    Bounded to surface misuse loudly rather than grow without limit.
+    """
+
+    DEFAULT_MAXSIZE = 100
+
+    def __init__(self, maxsize: int = DEFAULT_MAXSIZE) -> None:
+        self._queue: asyncio.Queue[str] = asyncio.Queue(maxsize=maxsize)
+
+    def steer(self, message: str) -> None:
+        """Non-blocking enqueue of one steering message.
+
+        Raises ValueError on empty/whitespace-only input, SteeringQueueFull
+        when the bound is reached. Never blocks, never silently drops.
+        """
+        if message is None or not message.strip():
+            raise ValueError("steering message must be non-empty")
+        try:
+            self._queue.put_nowait(message)
+        except asyncio.QueueFull as exc:
+            raise SteeringQueueFull(
+                "steering queue is full; message rejected"
+            ) from exc
+
+    def drain(self) -> list[str]:
+        """Dequeue all pending messages in FIFO order (possibly empty)."""
+        messages: list[str] = []
+        while not self._queue.empty():
+            try:
+                messages.append(self._queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+        return messages
+
+    @property
+    def is_empty(self) -> bool:
+        return self._queue.empty()
+```
+
+**Decisions, justified:**
+- **Bound = 100.** Far beyond any human typing rate within a single turn; reaching it
+  signals a programming error (e.g. an app loop spamming `steer()`), so we fail loud
+  rather than mask it. The number is a named constant for easy tuning.
+- **Overflow = reject (raise `SteeringQueueFull`).** No silent drop. The app surfaces
+  the rejection to the user.
+- **Validation rejects empty/whitespace loudly** (`ValueError`) so a stray newline can
+  never become an empty user turn.
+
+### 3.2 `StreamingOrchestrator.__init__` — own the queue
+
+Anchor: the block initialising instance state, near
+`self._pending_ephemeral_injections: list[dict[str, Any]] = []`
+(`__init__.py:80`). Add:
+
+```python
+from .steering import SteeringQueue  # top-of-file import
+
+# ... in __init__, alongside the other state fields:
+self._steering_queue = SteeringQueue()
+```
+
+The orchestrator instance is mounted once per session and persists across turns, so
+the queue persists across turns too (relevant only to the last-drain edge — see 3.6).
+
+### 3.3 Public `steer()` method
+
+Add a method on `StreamingOrchestrator`:
+
+```python
+def steer(self, message: str) -> None:
+    """Queue a steering message for injection at the next iteration boundary.
+
+    Non-blocking. Raises ValueError (empty/whitespace) or SteeringQueueFull.
+    This is the target of the `session.steer` coordinator capability.
+    """
+    self._steering_queue.steer(message)
+```
+
+No logging-and-swallow: validation/overflow errors propagate to the caller (the app),
+which is responsible for surfacing them. Fail loud.
+
+### 3.4 Drain helper
+
+Add an async helper on `StreamingOrchestrator`:
+
+```python
+async def _drain_steering(self, context, hooks, iteration: int) -> int:
+    """Drain queued steering messages into context as user-role messages.
+
+    FIFO. Each message is appended via context.add_message({"role":"user",...})
+    so the very next get_messages_for_request() picks it up, and an
+    orchestrator:steering_injected event is emitted per message. Returns the
+    number of messages injected (0 = no-op, no events, streaming undisturbed).
+    """
+    messages = self._steering_queue.drain()
+    if not messages:
+        return 0
+    total = len(messages)
+    for idx, msg in enumerate(messages):
+        await context.add_message({"role": "user", "content": msg})
+        await hooks.emit(
+            "orchestrator:steering_injected",
+            {
+                "orchestrator": "loop-streaming",
+                "content": msg,
+                "iteration": iteration,
+                "queued_remaining": total - idx - 1,
+                "metadata": None,
+            },
+        )
+    return total
+```
+
+Notes:
+- Injecting a `role:"user"` message after `role:"tool"` results is consistent with this
+  file's existing behavior — the ephemeral-injection paths already append user/system
+  messages mid-stream after tool results (`__init__.py:314-320`), and the reference
+  loop-agent does the same (SteeringTurn → user message after ToolResultsTurn). The
+  provider adapters tolerate it.
+- `metadata: None` is the standard empty extensibility slot for a stable event payload.
+
+### 3.5 Primary drain point — top-of-iteration
+
+Target: `_execute_stream()`, inside `while self.max_iterations == -1 or iteration < self.max_iterations:`.
+
+Anchors:
+- Cancellation check block at the top of the loop ends with `return` (`__init__.py:234-260`).
+- `iteration += 1` (`__init__.py:262`).
+- `PROVIDER_REQUEST` emit (`__init__.py:265`).
+- `message_dicts = await context.get_messages_for_request(provider=provider)` (`__init__.py:278`).
+
+**Insertion:** immediately after `iteration += 1` and before the `PROVIDER_REQUEST`
+emit:
+
+```python
+iteration += 1
+
+# Mid-turn steering: drain queued user messages BEFORE building the request,
+# so they are part of this iteration's provider call. At iteration 1 this is
+# "before the first LLM call"; at iteration N>1 this is "after the prior tool
+# round, before the next provider call" — the single natural boundary.
+await self._drain_steering(context, hooks, iteration)
+```
+
+This single point serves BOTH the "before first LLM call" case and the "after each
+tool round" case, because the loop's top-of-iteration is exactly the post-tool /
+pre-provider boundary. It sits *before* `get_messages_for_request()`, so injected
+messages are guaranteed to be in the very next request. It is *before* the
+branch split (streaming vs non-streaming at `__init__.py:391`), so it is
+branch-independent.
+
+**Streaming is undisturbed:** the drain runs before any token is produced, and is a
+no-op (`return 0`, no events, no messages) when the queue is empty — the common case.
+It never touches `_stream_from_provider` or `_tokenize_stream`.
+
+### 3.6 Last-drain edge — decision: drain-and-revive
+
+The loop ends via `break` at two places, both *after* the model produced no tool calls
+for the turn:
+- **Non-streaming branch:** the `if not tool_calls:` block streams the final text, does
+  `await context.add_message(assistant_msg)`, then `break` (`__init__.py:582`).
+- **Streaming branch:** `else: # No more tools, we're done` → `break` (`__init__.py:416-418`).
+
+A steer enqueued *during that final provider call* arrives after the last
+top-of-iteration drain and would be stranded if we simply broke.
+
+**Decision: revive — do not end a turn while a steer is visibly queued.** Replace each
+`break` with:
+
+```python
+# Last-drain edge: if a steer arrived during the final generation, don't end
+# the turn — loop once more so the model acts on it this turn. The top-of-
+# iteration drain (3.5) performs the actual injection.
+if not self._steering_queue.is_empty:
+    continue
+break
+```
+
+**Why revive (not "leave queued"):**
+- The GOAL is "the agent demonstrably acts on it." Leaving the message queued would
+  defer it to the *next* `execute()` call, where it would be injected *after* the next
+  user prompt (the new prompt is appended at `__init__.py:215` before the loop starts) —
+  wrong order, and no action until the user types again. That silently defers and
+  reorders the redirect.
+- Revive guarantees same-turn action with minimal code: a single non-empty check at the
+  two exit points, with injection still living in ONE place (the top-of-iteration drain).
+- It is bounded: `continue` re-enters the `while`, which still honors `max_iterations`.
+  No infinite loop — `drain()` empties the queue, so a fresh provider call happens only
+  while new steers keep arriving (which is the user's intent).
+- The user may have already seen the "final" streamed text; the revived iteration then
+  produces a follow-up response addressing the steer. That is exactly the desired
+  "acts on the redirect" behavior.
+
+> The queue still persists across turns (orchestrator instance lifetime), but with
+> revive there is normally nothing left in it at turn end, so cross-turn carryover is
+> not a relied-upon path in this slice.
+
+### 3.7 Register the capability + declare the event — `mount()`
+
+Target: `mount()` (`__init__.py:39-57`).
+
+1. Add the event to the existing observability declaration so hooks-logging
+   auto-discovers it. In the `register_contributor("observability.events", "loop-streaming", lambda: [...])`
+   list, add `"orchestrator:steering_injected"`:
+
+```python
+coordinator.register_contributor(
+    "observability.events",
+    "loop-streaming",
+    lambda: [
+        "execution:start",
+        "execution:end",
+        "orchestrator:steering_injected",
+    ],
+)
+```
+
+2. After `await coordinator.mount("orchestrator", orchestrator)`, register the
+   capability:
+
+```python
+orchestrator = StreamingOrchestrator(config)
+await coordinator.mount("orchestrator", orchestrator)
+coordinator.register_capability("session.steer", orchestrator.steer)
+logger.info("Mounted StreamingOrchestrator with steering capability")
+```
+
+The `coordinator` passed to `mount()` is the session coordinator that the app queries —
+the same object on which `session.spawn`, `mention_resolver`, etc. are registered — so
+registration here is visible to the app's `get_capability("session.steer")`.
+
+**Event name decision: `orchestrator:steering_injected`** (not `agent:steering_injected`).
+Justification: this module's own events use the `orchestrator:` / `execution:`
+namespaces (`orchestrator:rate_limit_delay`, `execution:start`). The `agent:` namespace
+belongs to the loop-agent's session semantics. Staying in-namespace keeps observability
+declarations and log routing consistent for this orchestrator.
+
+---
+
+## 4. App-CLI changes (`amplifier-app-cli`)
+
+### 4.1 New: stdin arbiter (approval vs steering)
+
+Both the approval provider and the steering reader read stdin. They must never both
+consume the same keystrokes. Introduce a tiny shared arbiter that makes **approval the
+priority owner** of stdin.
+
+New file `amplifier_app_cli/stdin_arbiter.py`:
+
+```python
+"""Coordinates exclusive stdin access between approval prompts and the
+mid-turn steering reader. Approval is the priority owner: while an approval is
+in flight, the steering reader suspends entirely."""
+
+from __future__ import annotations
+
+
+class StdinArbiter:
+    def __init__(self) -> None:
+        self._approval_active = False
+
+    @property
+    def approval_active(self) -> bool:
+        return self._approval_active
+
+    def begin_approval(self) -> None:
+        self._approval_active = True
+
+    def end_approval(self) -> None:
+        self._approval_active = False
+```
+
+A plain bool is sufficient: the signal is set synchronously by the approval provider
+before it renders the prompt, and the steering reader treats it as authoritative.
+
+### 4.2 `approval_provider.py` — claim stdin during approval
+
+Target: `CLIApprovalProvider` (`approval_provider.py`).
+
+- Constructor gains an optional arbiter:
+
+```python
+def __init__(self, console: Console, arbiter: "StdinArbiter | None" = None):
+    self.console = console
+    self._arbiter = arbiter
+```
+
+- In `request_approval`, set the flag **before** rendering the panel (so it is set well
+  before any keystroke could arrive) and clear it in a `finally`. Wrap the existing body:
+
+```python
+async def request_approval(self, request: ApprovalRequest) -> ApprovalResponse:
+    if self._arbiter is not None:
+        self._arbiter.begin_approval()
+    try:
+        # ... existing body: render panel, _get_user_input(), build response ...
+        return ApprovalResponse(approved=approved, reason=...)
+    finally:
+        if self._arbiter is not None:
+            self._arbiter.end_approval()
+```
+
+`_get_user_input()` keeps reading via `loop.run_in_executor(None, Confirm.ask)`
+(`approval_provider.py:128`) — unchanged. While the flag is set, the steering reader
+will not touch stdin, so `Confirm.ask` owns it exclusively.
+
+### 4.3 `session_runner.py` — wire the arbiter
+
+Target: Step 10, approval-provider registration (`session_runner.py:276-283`).
+
+```python
+# Step 10: Register approval provider (app-layer policy)
+from .approval_provider import CLIApprovalProvider
+from .stdin_arbiter import StdinArbiter
+
+arbiter = StdinArbiter()
+session.coordinator.register_capability("cli.stdin_arbiter", arbiter)
+
+register_provider = session.coordinator.get_capability("approval.register_provider")
+if register_provider:
+    approval_provider = CLIApprovalProvider(console, arbiter=arbiter)
+    register_provider(approval_provider)
+    logger.debug("Registered CLIApprovalProvider for interactive approvals")
+```
+
+Registering the arbiter as a capability lets the steering reader (in `main.py`) discover
+it without a hard import path between the two.
+
+### 4.4 `main.py` — concurrent stdin reader during a turn
+
+Target: `_execute_with_interrupt(prompt_text)` (`main.py:2753`). Currently it creates
+`execute_task` (`main.py:2799`) and polls with a 50 ms loop until done (`main.py:2802-2807`).
+
+Add a **POSIX `select`-based** stdin reader that runs only for the duration of the turn,
+forwards each non-empty line to `session.steer`, and tears down cleanly. `select` (with a
+short timeout) is used instead of a blocking `sys.stdin.readline` in an executor so that
+teardown is prompt and leaves **no outstanding blocking read** — the root cause of leaked
+threads and stolen next-prompt input.
+
+New module-level helper:
+
+```python
+import select
+
+async def _steering_reader(steer_cap, arbiter, stop_event, console) -> None:
+    """Read stdin lines during a running turn and forward to session.steer.
+
+    Uses select() with a short timeout so it never holds a blocking read across
+    teardown. Suspends entirely while an approval prompt owns stdin.
+    """
+    loop = asyncio.get_event_loop()
+    while not stop_event.is_set():
+        # Approval owns stdin while active — do not read.
+        if arbiter is not None and arbiter.approval_active:
+            await asyncio.sleep(0.05)
+            continue
+        # Bounded readiness check off the event-loop thread; returns within 0.1s
+        # so stop_event is honored promptly (no leaked blocking read at teardown).
+        ready = await loop.run_in_executor(None, _stdin_ready, 0.1)
+        if not ready:
+            continue
+        # Re-check: approval may have claimed stdin between select and read.
+        if arbiter is not None and arbiter.approval_active:
+            continue
+        line = sys.stdin.readline()  # data is ready → returns a full TTY line
+        if line == "":  # EOF
+            break
+        text = line.strip()
+        if not text:
+            continue  # ignore blank / whitespace-only lines
+        if steer_cap is None:
+            # Fail loud — never silently drop a typed line.
+            console.print(
+                "[yellow]Steering unavailable: this orchestrator does not "
+                "support session.steer.[/yellow]"
+            )
+            continue
+        try:
+            steer_cap(text)
+            console.print("[dim]queued — applies after current step[/dim]")
+        except Exception as e:  # ValueError, SteeringQueueFull, etc.
+            console.print(f"[red]Steering rejected: {e}[/red]")
+
+
+def _stdin_ready(timeout: float) -> bool:
+    """True if stdin has data within `timeout` seconds (POSIX)."""
+    try:
+        r, _, _ = select.select([sys.stdin], [], [], timeout)
+        return bool(r)
+    except (OSError, ValueError):
+        return False
+```
+
+Wire it into `_execute_with_interrupt`:
+
+```python
+# After resetting cancellation, before/around creating execute_task:
+steer_cap = session.coordinator.get_capability("session.steer")
+arbiter = session.coordinator.get_capability("cli.stdin_arbiter")
+stop_event = asyncio.Event()
+reader_task = asyncio.create_task(
+    _steering_reader(steer_cap, arbiter, stop_event, console)
+)
+
+try:
+    execute_task = asyncio.create_task(session.execute(prompt_text))
+    # ... existing poll loop and result handling, unchanged ...
+finally:
+    signal.signal(signal.SIGINT, original_handler)   # existing line
+    stop_event.set()
+    reader_task.cancel()
+    try:
+        await reader_task
+    except asyncio.CancelledError:
+        pass
+```
+
+Behavioural notes:
+- **Fail-loud-no-capability (constraint 8):** if `steer_cap is None`, the reader still
+  captures lines and prints a visible "unavailable" message — typed lines are never
+  silently dropped.
+- **Arbitration (constraint 9):** approval sets `arbiter.approval_active` before
+  rendering its panel; the reader checks the flag both before the `select` and again
+  before `readline`, so an in-flight approval prompt always wins stdin. Because the user
+  must read the panel before typing, the flag is reliably set long before any approval
+  keystroke arrives.
+- **Teardown (constraint 11):** `select` returns within 0.1 s, so once `stop_event` is
+  set the reader exits without an outstanding blocking read; `reader_task.cancel()` +
+  `await` guarantees it is finished before `_execute_with_interrupt` returns, so it
+  cannot consume the next REPL prompt's input. This runs on normal completion, on
+  graceful/immediate cancel (Ctrl-C), and on error, because it is in the `finally`.
+- **Minimal UX (constraint 10):** one-line ack `queued — applies after current step` on
+  successful enqueue. (TTY caveat: when `select` signals readable, a cooked terminal has
+  delivered a full line, so `readline` returns immediately; documented limitation, see §6.)
+
+### 4.5 No change to the REPL loop
+
+The reader exists only inside `_execute_with_interrupt`. The REPL's
+`prompt_session.prompt_async()` (`main.py:2898`) continues to own stdin between turns,
+and the reader is guaranteed torn down before control returns to it.
+
+---
+
+## 5. End-to-end proof (local checkpoint)
+
+**Scenario (reproducible):**
+1. Start the CLI on `feat/steering` with the streaming orchestrator and a multi-tool
+   bundle.
+2. Prompt: *"List every file in this directory, then read each one and write a
+   one-paragraph summary of each."* This produces several sequential tool rounds.
+3. While the first tool round is executing, type and press Enter:
+   *"Stop — don't summarize. Just tell me the total number of files and nothing else."*
+4. Observe the one-line ack `queued — applies after current step`.
+
+**Observable "acted on" signal — BOTH must hold:**
+- **(a) Event:** `events.jsonl` contains an `orchestrator:steering_injected` record whose
+  `content` equals the typed redirect, positioned *after* a tool round and *before* the
+  next `provider:request`. (And the transcript shows a `role:"user"` message with that
+  text inserted after the in-flight round's tool results.)
+- **(b) Behavioral change:** the agent abandons the per-file-summary plan and instead
+  reports the file count — a change in its subsequent tool calls / final answer directly
+  attributable to the steer.
+
+"Acted on" = (a) AND (b). Arrival alone (a) is necessary but not sufficient; the
+behavioral divergence (b) is the success criterion. The top-of-iteration drain
+guarantees the message lands at the next boundary even if typed late in a round; the
+revive rule (§3.6) guarantees action even if typed during the final generation.
+
+---
+
+## 6. Deferred (explicitly out of this slice)
+
+- **FollowUpQueue** and post-turn follow-up semantics.
+- **Drop / cancel a queued steer** before it is drained.
+- **Child / sub-agent steer targeting** (steering a specific delegate).
+- **Windows stdin**: the reader is POSIX (`select` on `sys.stdin`). Windows support is a
+  documented limitation for this slice.
+- **Live steering in the streaming token branch with concurrent tool calls**: the
+  current `_stream_from_provider` path is text-only (`_has_pending_tools` returns
+  `False`); multi-tool turns run through the `provider.complete` path, which is where
+  the drain and revive operate. No change to the token branch beyond the shared
+  top-of-iteration drain.
+
+---
+
+## 7. Test list (unit-level)
+
+### Orchestrator (`amplifier-module-loop-streaming`)
+1. **Bounded overflow:** fill `SteeringQueue` to `maxsize`; next `steer()` raises
+   `SteeringQueueFull`.
+2. **Empty/whitespace rejection:** `steer("")`, `steer("   ")`, `steer("\n")` each raise
+   `ValueError`; nothing enqueued.
+3. **FIFO order:** enqueue `a, b, c`; `drain()` returns `["a","b","c"]`; `_drain_steering`
+   appends user messages to context in that order.
+4. **Inject + event:** after `_drain_steering`, context holds the user messages and one
+   `orchestrator:steering_injected` event per message with correct
+   `content` / `iteration` / `queued_remaining`.
+5. **Top-of-iteration drain before provider call:** mock provider returns a tool call
+   then text (2 rounds); enqueue a steer during round 1; assert the injected user message
+   is present in the messages passed to the *second* `provider.complete` (drain happened
+   before `get_messages_for_request`).
+6. **Last-drain-edge revive:** provider returns no tool calls on the first call; a steer
+   is queued before the break-check → loop performs one more provider call and the steer
+   is injected. With an empty queue, the loop breaks normally (no extra call).
+7. **Capability registered in mount:** after `mount()`,
+   `coordinator.get_capability("session.steer")` is callable and enqueues onto the
+   orchestrator's queue.
+8. **Streaming undisturbed:** with the streaming/token path and an empty queue, tokens
+   still stream and `_drain_steering` is a no-op (no messages, no events).
+
+### App-CLI (`amplifier-app-cli`)
+9. **Fail-loud-no-capability:** `get_capability("session.steer")` → `None`; a captured
+   stdin line prints the visible "Steering unavailable" message and does not crash.
+10. **Steer on line:** stdin yields `"do X\n"`; `steer_cap` called once with `"do X"`;
+    ack printed.
+11. **Empty line ignored:** blank/whitespace lines do not call `steer_cap`.
+12. **Stdin/approval arbitration:** with `arbiter.approval_active == True`, the reader
+    does not read stdin / does not call `steer_cap`; after `end_approval()`, it resumes.
+13. **Teardown, no leak:** after `_execute_with_interrupt` completes (and on
+    cancel/error), `reader_task` is done; `stop_event` honored within the bounded select
+    interval; the next prompt's input is not consumed.
+14. **Overflow surfaced:** `steer_cap` raises `SteeringQueueFull` → reader prints a
+    visible rejection and the turn continues.
+
+---
+
+## 8. Constraints honored
+
+- **Ruthless simplicity:** one queue, one injection path (top-of-iteration), one
+  capability stud. The arbiter is a single bool.
+- **No fallbacks / synthetics — fail loud:** overflow and empty input raise; missing
+  capability is surfaced to the user; no silent drops.
+- **Bricks & studs:** the orchestrator has zero knowledge of the app; the app has zero
+  knowledge of the orchestrator's internals. The only contract is the `session.steer`
+  capability (+ the `cli.stdin_arbiter` capability internal to the app).
+```

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -494,6 +494,117 @@ async def test_teardown_cancel_is_clean():
 
 
 # ---------------------------------------------------------------------------
+# Ctrl-C regression: _CtrlCInterrupt must not escape run() as a crash
+# ---------------------------------------------------------------------------
+# Background: the old code used PromptSession(interrupt_exception=KeyboardInterrupt).
+# When Ctrl-C was pressed, prompt_toolkit called app.exit(exception=KeyboardInterrupt()).
+# That KeyboardInterrupt propagated through the prompt_async() coroutine and into
+# asyncio's Task.__step_run_and_handle_result(), which:
+#
+#     except (KeyboardInterrupt, SystemExit) as exc:
+#         super().set_exception(exc)
+#         raise   ← re-raised!
+#
+# The re-raise escaped through Handle._run() (also re-raises KeyboardInterrupt),
+# through EventLoop._run_once(), and straight into asyncio.run() — crashing the
+# process.  No try/except in user code can intercept it at that stage.
+#
+# Fix: PromptSession(interrupt_exception=_CtrlCInterrupt) where _CtrlCInterrupt
+# is a plain Exception subclass.  asyncio stores it normally (no re-raise), so
+# await prompt_task raises _CtrlCInterrupt in the normal place and the
+# except _CtrlCInterrupt: continue clause in run() handles it.
+# ---------------------------------------------------------------------------
+
+
+def test_ctrl_c_interrupt_sentinel_is_plain_exception():
+    """_CtrlCInterrupt must be a regular Exception, not a BaseException.
+
+    If it were KeyboardInterrupt (or any BaseException that is not also an
+    Exception), asyncio's Task.__step_run_and_handle_result() would re-raise it
+    after storing it, crashing asyncio.run().
+    """
+    from amplifier_app_cli.steering_input import _CtrlCInterrupt
+
+    assert issubclass(_CtrlCInterrupt, Exception), (
+        "_CtrlCInterrupt must be a plain Exception subclass so asyncio's task "
+        "machinery does NOT re-raise it"
+    )
+    assert not issubclass(_CtrlCInterrupt, KeyboardInterrupt), (
+        "_CtrlCInterrupt must NOT be KeyboardInterrupt; using KeyboardInterrupt "
+        "triggers the Task.__step_run_and_handle_result() re-raise bug"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ctrl_c_during_prompt_does_not_crash_run_loop():
+    """_CtrlCInterrupt raised by the prompt is caught; run() continues normally.
+
+    Regression test for: Ctrl-C during the steering prompt crashed
+    asyncio.run() because KeyboardInterrupt escaped asyncio's task machinery.
+
+    The fix uses PromptSession(interrupt_exception=_CtrlCInterrupt).  This
+    test verifies that:
+    1. When the input provider raises _CtrlCInterrupt, run() does NOT exit/crash.
+    2. run() continues processing and enqueues the NEXT input normally.
+    """
+    from amplifier_app_cli.steering_input import _CtrlCInterrupt
+
+    call_count = 0
+    # Gate that fires when steer_cap is actually invoked (not just when the
+    # input coroutine returns — the enqueue happens one await later).
+    steer_called = asyncio.Event()
+
+    captured_texts: list[str] = []
+
+    def recording_steer_cap(text: str) -> None:
+        captured_texts.append(text)
+        steer_called.set()
+
+    async def mock_input() -> str | None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # Simulate Ctrl-C: prompt_async() would raise _CtrlCInterrupt
+            raise _CtrlCInterrupt()
+        if call_count == 2:
+            # Normal input on the next iteration — proves run() continued
+            return "steer text"
+        # Block so stop_event can terminate cleanly
+        await asyncio.sleep(10)
+        return None
+
+    stop = asyncio.Event()
+    manager = SteeringInputManager(
+        steer_cap=recording_steer_cap,
+        arbiter=None,
+        stop_event=stop,
+        console=MagicMock(),
+        _input_provider=mock_input,
+    )
+
+    run_task = asyncio.create_task(manager.run())
+
+    # Wait until steer_cap is actually called (proves loop continued + enqueued)
+    await asyncio.wait_for(steer_called.wait(), timeout=1.0)
+
+    # "steer text" was forwarded to steer_cap (loop continued after _CtrlCInterrupt)
+    assert captured_texts == ["steer text"], (
+        f"Expected ['steer text'] after Ctrl-C recovery, got {captured_texts}"
+    )
+
+    # run() must still be alive (stop_event not yet set, not crashed)
+    assert not run_task.done(), "run() unexpectedly exited after _CtrlCInterrupt"
+
+    # Clean up
+    stop.set()
+    run_task.cancel()
+    try:
+        await asyncio.wait_for(run_task, timeout=1.0)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        pass
+
+
+# ---------------------------------------------------------------------------
 # StdinArbiter unit tests (unchanged)
 # ---------------------------------------------------------------------------
 
@@ -749,41 +860,41 @@ async def test_overflow_shows_visible_rejection():
 
 
 # ---------------------------------------------------------------------------
-# A5: late steer ack communicates next-turn deferral (FAILS under old code)
+# A5: turn-end steer is NOT sent, and the ack is honest (no false promise)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_next_turn_steer_ack_communicates_deferral():
-    """When stop_event is set (turn ending/ended), _enqueue must print an ack
-    that communicates the steer will apply to the NEXT turn.
+async def test_turn_end_steer_is_not_sent_and_ack_is_honest():
+    """When stop_event is set (turn ending/ended), a steer would be wiped by the
+    orchestrator's execute()-entry clear() before the next turn — so _enqueue must
+    NOT forward it and must NOT promise "next turn". It acks honestly instead.
 
-    **FAILS under old code**: _enqueue always prints ``⧗ queued: …`` with no
-    stop_event check; there is no "next turn" acknowledgment.
-
-    Per spec §5.3 gate rule:
-      stop_event set   → ``⧗ queued for next turn: {text}``
-      stop_event clear → ``⧗ queued: {text}``  (unchanged)
+    Guards against the false-promise bug a DTU run caught: acking
+    "queued for next turn" while the orchestrator discards the steer.
     """
     steer_cap = MagicMock()
     stop = asyncio.Event()
     manager, _ = _make_manager(steer_cap=steer_cap, stop_event=stop)
 
-    # Simulate turn-ending state
+    # Simulate turn-ending/ended state
     stop.set()
 
     await manager._enqueue("steer at turn end")
 
-    # steer_cap was still called — steer is enqueued (for the next turn)
-    steer_cap.assert_called_once_with("steer at turn end")
+    # NOT forwarded — the orchestrator would clear it at next execute() entry.
+    steer_cap.assert_not_called()
 
-    # Badge increments (the steer is in the orchestrator queue)
-    assert manager.pending_count == 1
+    # Badge must NOT increment for an undelivered steer (no phantom "1 queued").
+    assert manager.pending_count == 0
 
-    # Ack must communicate "next turn"
+    # Ack is honest: says it was not sent, and does NOT falsely promise "next turn".
     printed = [str(c) for c in manager._console.print.call_args_list]
-    assert any("next turn" in msg.lower() for msg in printed), (
-        f"Expected 'next turn' in ack when stop_event is set; got: {printed}"
+    assert any("not sent" in msg.lower() for msg in printed), (
+        f"Expected an honest 'not sent' ack when the turn has ended; got: {printed}"
+    )
+    assert not any("next turn" in msg.lower() for msg in printed), (
+        f"Ack must NOT falsely promise 'next turn'; got: {printed}"
     )
 
 

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -36,6 +36,7 @@ StdinArbiter and CLIApprovalProvider integration tests are preserved unchanged.
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -51,6 +52,36 @@ from amplifier_app_cli.steering_input import SteeringInputManager
 
 class _SteeringQueueFull(RuntimeError):
     """Test stub for SteeringQueueFull."""
+
+
+# ---------------------------------------------------------------------------
+# Minimal dispatcher stand-in — calls handlers the way the Amplifier kernel
+# does: handler(event_type: str, payload: dict).
+#
+# A future signature mismatch on the handler will raise TypeError here,
+# ensuring this test path catches bugs like Defect 1 (wrong arg count).
+# ---------------------------------------------------------------------------
+
+
+class _FakeHooksRegistry:
+    """Faithful stand-in for the Amplifier hook dispatcher.
+
+    Registers handlers and calls them with the real kernel convention:
+    ``handler(event_type: str, payload: dict)``.
+
+    A handler registered with the wrong number of arguments will raise
+    ``TypeError`` at emit time, matching what the real dispatcher does.
+    """
+
+    def __init__(self) -> None:
+        self._handlers: dict[str, list] = {}
+
+    def register(self, event: str, handler: Any, **kwargs: Any) -> None:
+        self._handlers.setdefault(event, []).append(handler)
+
+    async def emit(self, event: str, payload: dict) -> None:
+        for handler in self._handlers.get(event, []):
+            await handler(event, payload)
 
 
 # ---------------------------------------------------------------------------
@@ -118,20 +149,32 @@ async def test_counter_increments_multiple_times():
 
 @pytest.mark.asyncio
 async def test_counter_decrements_on_injected_hook():
-    """on_steering_injected() decrements pending_count by 1."""
+    """on_steering_injected() decrements pending_count via the real dispatcher path.
+
+    The handler is registered on a _FakeHooksRegistry and emitted through it
+    exactly as the Amplifier kernel does — handler(event_type, payload).
+    A wrong handler signature (e.g. missing the ``event`` arg) will raise TypeError
+    here, reproducing the Defect 1 crash that was missed by direct-call tests.
+    """
     steer_cap = MagicMock()
     manager, _ = _make_manager(steer_cap=steer_cap)
 
     await manager._enqueue("do X")
     assert manager.pending_count == 1
 
-    await manager.on_steering_injected({"content": "do X"})
+    registry = _FakeHooksRegistry()
+    registry.register("orchestrator:steering_injected", manager.on_steering_injected)
+    await registry.emit("orchestrator:steering_injected", {"content": "do X"})
     assert manager.pending_count == 0
 
 
 @pytest.mark.asyncio
 async def test_counter_drains_exactly_to_zero():
-    """Enqueueing N messages and injecting N events leaves counter at exactly 0."""
+    """Enqueueing N messages and injecting N events via the dispatcher leaves counter at 0.
+
+    Uses _FakeHooksRegistry so a signature mismatch fails with TypeError, not
+    silently passes as it did before (Defect 1).
+    """
     steer_cap = MagicMock()
     manager, _ = _make_manager(steer_cap=steer_cap)
 
@@ -140,20 +183,24 @@ async def test_counter_drains_exactly_to_zero():
         await manager._enqueue(f"msg {i}")
     assert manager.pending_count == n
 
+    registry = _FakeHooksRegistry()
+    registry.register("orchestrator:steering_injected", manager.on_steering_injected)
     for _ in range(n):
-        await manager.on_steering_injected({})
+        await registry.emit("orchestrator:steering_injected", {})
     assert manager.pending_count == 0
 
 
 @pytest.mark.asyncio
 async def test_counter_never_goes_below_zero():
-    """Extra injection events do not push the counter below 0."""
+    """Extra injection events via the dispatcher do not push the counter below 0."""
     manager, _ = _make_manager(steer_cap=MagicMock())
 
     await manager._enqueue("once")
-    # Inject more times than we enqueued
-    await manager.on_steering_injected({})
-    await manager.on_steering_injected({})  # extra — should be clamped
+
+    registry = _FakeHooksRegistry()
+    registry.register("orchestrator:steering_injected", manager.on_steering_injected)
+    await registry.emit("orchestrator:steering_injected", {})
+    await registry.emit("orchestrator:steering_injected", {})  # extra — must be clamped
     assert manager.pending_count == 0
 
 
@@ -282,6 +329,53 @@ def test_toolbar_empty_string_hides_strip():
     """Toolbar returning '' causes prompt_toolkit to hide the bottom strip."""
     manager, _ = _make_manager()
     assert manager._toolbar() == ""
+
+
+# ---------------------------------------------------------------------------
+# Prompt message callable (_prompt_message)
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_message_no_pending_shows_plain_steer():
+    """_prompt_message returns a plain 'steer:' prompt when no messages are queued."""
+    manager, _ = _make_manager()
+    msg = manager._prompt_message()
+    # HTML.value holds the raw string; check it contains 'steer' and NOT 'queued'.
+    text = msg.value
+    assert "steer" in text
+    assert "queued" not in text
+
+
+def test_prompt_message_with_pending_shows_count_and_queued():
+    """_prompt_message includes the count and 'queued' when pending_count > 0."""
+    manager, _ = _make_manager()
+    manager._pending_count = 3
+    msg = manager._prompt_message()
+    text = msg.value
+    assert "queued" in text
+    assert "3" in text
+
+
+@pytest.mark.asyncio
+async def test_prompt_message_updates_after_decrement_via_dispatcher():
+    """_prompt_message reflects the count after a dispatcher-path decrement.
+
+    Simulates the full round-trip: counter set to 1, dispatcher drains it,
+    _prompt_message returns the updated (zero) prompt without 'queued'.
+    """
+    steer_cap = MagicMock()
+    manager, _ = _make_manager(steer_cap=steer_cap)
+
+    # Manually set counter (bypassing _enqueue to avoid a real prompt_toolkit App)
+    manager._pending_count = 1
+    assert "queued" in manager._prompt_message().value
+
+    registry = _FakeHooksRegistry()
+    registry.register("orchestrator:steering_injected", manager.on_steering_injected)
+    await registry.emit("orchestrator:steering_injected", {"content": "msg"})
+
+    assert manager.pending_count == 0
+    assert "queued" not in manager._prompt_message().value
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -337,6 +337,78 @@ async def test_prompt_message_updates_after_decrement_via_dispatcher():
 
 
 # ---------------------------------------------------------------------------
+# is_composing: mid-turn compose-state used by the streaming-ui coalesce gate
+# ---------------------------------------------------------------------------
+#
+# FAILING-TEST-FIRST: SteeringInputManager has no ``is_composing`` property
+# on an unmodified checkout, so these tests fail with AttributeError until
+# the property is added.  Spec:
+#   - _pt_session is None (not prompting)          -> False
+#   - _pt_session exists, current_buffer.text == "" -> False
+#   - _pt_session exists, current_buffer.text != "" -> True
+#   - any exception while inspecting internals      -> False (defensive)
+
+
+class _FakeBuffer:
+    def __init__(self, text: str = "") -> None:
+        self.text = text
+
+
+class _FakeApp:
+    def __init__(self, text: str = "") -> None:
+        self.current_buffer = _FakeBuffer(text)
+
+
+class _FakePromptSession:
+    """Minimal stand-in for prompt_toolkit's PromptSession.
+
+    Only exposes the ``.app.current_buffer.text`` path that
+    ``is_composing`` reads -- no real TTY / Application required.
+    """
+
+    def __init__(self, text: str = "") -> None:
+        self.app: Any = _FakeApp(text)
+
+
+class _RaisingApp:
+    """Simulates a torn-down / errored Application: any attribute access raises."""
+
+    @property
+    def current_buffer(self) -> Any:
+        raise RuntimeError("app not running")
+
+
+def test_is_composing_false_when_no_session():
+    """No _pt_session (not currently prompting) -> is_composing is False."""
+    manager, _ = _make_manager()
+    assert manager._pt_session is None
+    assert manager.is_composing is False
+
+
+def test_is_composing_false_when_buffer_empty():
+    """_pt_session exists but current_buffer.text is empty -> False."""
+    manager, _ = _make_manager()
+    manager._pt_session = _FakePromptSession("")
+    assert manager.is_composing is False
+
+
+def test_is_composing_true_when_buffer_nonempty():
+    """_pt_session exists and current_buffer.text is non-empty -> True."""
+    manager, _ = _make_manager()
+    manager._pt_session = _FakePromptSession("draft steer text")
+    assert manager.is_composing is True
+
+
+def test_is_composing_false_on_internal_exception():
+    """Any exception while inspecting prompt_toolkit internals -> False (defensive)."""
+    manager, _ = _make_manager()
+    broken_session = _FakePromptSession.__new__(_FakePromptSession)
+    broken_session.app = _RaisingApp()
+    manager._pt_session = broken_session
+    assert manager.is_composing is False
+
+
+# ---------------------------------------------------------------------------
 # run() with injected input: arbiter releases reader when approval_active
 # ---------------------------------------------------------------------------
 

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -1,0 +1,444 @@
+"""Unit tests for mid-turn steering (app-cli side).
+
+Covers spec tests 9–14 from docs/designs/steering.md §7 (App-CLI section):
+
+9.  fail-loud-no-capability
+10. steer-on-line
+11. empty-line-ignored
+12. stdin/approval arbitration suspends reader
+13. teardown leaves no leak / does not steal next prompt
+14. overflow surfaced
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from amplifier_app_cli.main import _steering_reader  # type: ignore[attr-defined]
+from amplifier_app_cli.stdin_arbiter import StdinArbiter
+
+
+# ---------------------------------------------------------------------------
+# Stub for SteeringQueueFull (produced by the orchestrator module, which is
+# not a test dependency here — we just need something that is a RuntimeError
+# subclass to verify the error path).
+# ---------------------------------------------------------------------------
+
+
+class _SteeringQueueFull(RuntimeError):
+    """Test stub for SteeringQueueFull."""
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_console() -> MagicMock:
+    return MagicMock()
+
+
+async def _drive_reader(
+    steer_cap,
+    arbiter: StdinArbiter | None,
+    *,
+    ready_values: list[bool],
+    readline_values: list[str],
+    stop_after_reads: bool = True,
+    timeout: float = 5.0,
+) -> MagicMock:
+    """Run _steering_reader with controlled stdin data, return the console mock.
+
+    *ready_values* controls what _stdin_ready returns on successive calls.
+    *readline_values* is the sequence sys.stdin.readline returns.
+
+    The reader is stopped by setting stop_event when ready_values are exhausted
+    (or when steer_cap is called, if stop_after_reads=True).
+    """
+    console = _make_console()
+    stop_event = asyncio.Event()
+
+    ready_iter = iter(ready_values)
+    exhausted = False
+
+    def fake_ready(_timeout: float) -> bool:
+        nonlocal exhausted
+        try:
+            val = next(ready_iter)
+        except StopIteration:
+            exhausted = True
+            stop_event.set()
+            return False
+        return val
+
+    with (
+        patch("amplifier_app_cli.main._stdin_ready", fake_ready),
+        patch("sys.stdin") as mock_stdin,
+    ):
+        mock_stdin.readline.side_effect = readline_values
+
+        await asyncio.wait_for(
+            _steering_reader(steer_cap, arbiter, stop_event, console),
+            timeout=timeout,
+        )
+
+    return console
+
+
+# ---------------------------------------------------------------------------
+# Test 9 — fail-loud-no-capability
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fail_loud_no_capability():
+    """Spec 9: steer_cap is None → visible message, no crash, no silent drop."""
+    console = await _drive_reader(
+        steer_cap=None,
+        arbiter=None,
+        ready_values=[True, False],  # ready once, then exhaust
+        readline_values=["redirect: do this instead\n"],
+    )
+
+    # A visible "unavailable" message must be printed
+    printed_messages = [str(call) for call in console.print.call_args_list]
+    assert any("Steering unavailable" in msg for msg in printed_messages), (
+        f"Expected 'Steering unavailable' in console output; got: {printed_messages}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 10 — steer-on-line
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_steer_on_line():
+    """Spec 10: a non-empty typed line calls steer_cap and prints ack."""
+    steer_cap = MagicMock()
+    arbiter = StdinArbiter()
+    stop_event = asyncio.Event()
+    console = _make_console()
+
+    call_count = 0
+
+    def fake_ready(_timeout: float) -> bool:
+        nonlocal call_count
+        call_count += 1
+        return call_count == 1  # True on first call only
+
+    async def stopper():
+        """Wait for steer_cap to be invoked, then stop the reader."""
+        while not steer_cap.called:
+            await asyncio.sleep(0.005)
+        stop_event.set()
+
+    with (
+        patch("amplifier_app_cli.main._stdin_ready", fake_ready),
+        patch("sys.stdin") as mock_stdin,
+    ):
+        mock_stdin.readline.return_value = "do X\n"
+
+        await asyncio.gather(
+            asyncio.wait_for(
+                _steering_reader(steer_cap, arbiter, stop_event, console),
+                timeout=5.0,
+            ),
+            stopper(),
+        )
+
+    steer_cap.assert_called_once_with("do X")
+    printed = [str(c) for c in console.print.call_args_list]
+    assert any("queued" in msg for msg in printed), (
+        f"Expected ack in output; got: {printed}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 11 — empty-line-ignored
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_line_ignored():
+    """Spec 11: blank and whitespace-only lines do not call steer_cap."""
+    steer_cap = MagicMock()
+    console = await _drive_reader(
+        steer_cap=steer_cap,
+        arbiter=None,
+        ready_values=[True, True, True, False],  # 3 reads, then exhaust
+        readline_values=["   \n", "\n", "\t  \n"],
+    )
+
+    steer_cap.assert_not_called()
+    # No ack should have been printed either
+    printed = [str(c) for c in console.print.call_args_list]
+    assert not any("queued" in msg for msg in printed)
+
+
+# ---------------------------------------------------------------------------
+# Test 12 — stdin / approval arbitration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_arbitration_suspends_reader_during_approval():
+    """Spec 12: while arbiter.approval_active, reader does not call _stdin_ready or steer_cap."""
+    steer_cap = MagicMock()
+    arbiter = StdinArbiter()
+    stop_event = asyncio.Event()
+    console = _make_console()
+
+    ready_calls_approval_state: list[bool] = []
+
+    def fake_ready(_timeout: float) -> bool:
+        # Record whether approval was active at the time of each _stdin_ready call.
+        ready_calls_approval_state.append(arbiter.approval_active)
+        return True  # Always data-ready once we get here
+
+    # Phase 1: approval active from the start
+    arbiter.begin_approval()
+
+    async def controller():
+        # Verify no reads happen during approval
+        await asyncio.sleep(0.15)
+        assert not steer_cap.called, (
+            "steer_cap must not be called while approval is active"
+        )
+        assert not ready_calls_approval_state, (
+            "_stdin_ready must not be called during approval"
+        )
+
+        # Phase 2: release approval — reader should now pick up the one queued line
+        arbiter.end_approval()
+
+    with (
+        patch("amplifier_app_cli.main._stdin_ready", fake_ready),
+        patch("sys.stdin") as mock_stdin,
+    ):
+        # readline returns the line once, then "" (EOF) so the reader exits cleanly
+        # without needing stop_event and without calling steer_cap more than once.
+        mock_stdin.readline.side_effect = ["do X\n", ""]
+
+        await asyncio.gather(
+            asyncio.wait_for(
+                _steering_reader(steer_cap, arbiter, stop_event, console),
+                timeout=5.0,
+            ),
+            controller(),
+        )
+
+    # After approval ended, the line was processed exactly once
+    steer_cap.assert_called_once_with("do X")
+    # _stdin_ready was only called when approval was NOT active
+    assert all(not was_active for was_active in ready_calls_approval_state), (
+        "ready() was called while approval was active"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 13 — teardown / no stolen next-prompt input
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_reader_exits_on_stop_event():
+    """Spec 13: reader exits cleanly within the bounded select interval after stop_event is set."""
+    console = _make_console()
+    arbiter = StdinArbiter()
+    stop_event = asyncio.Event()
+
+    # _stdin_ready returns False (no data) every call — reader loops without reading
+    with patch("amplifier_app_cli.main._stdin_ready", lambda _t: False):
+
+        async def set_stop():
+            await asyncio.sleep(0.05)
+            stop_event.set()
+
+        # Both tasks must complete: reader exits, stopper finishes
+        await asyncio.gather(
+            asyncio.wait_for(
+                _steering_reader(None, arbiter, stop_event, console),
+                timeout=2.0,
+            ),
+            set_stop(),
+        )
+
+    # Reader exited cleanly
+    assert stop_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_teardown_cancel_exits_promptly():
+    """Spec 13: reader task can be cancelled and awaited without hanging."""
+    arbiter = StdinArbiter()
+    stop_event = asyncio.Event()
+
+    with patch("amplifier_app_cli.main._stdin_ready", lambda _t: False):
+        task = asyncio.create_task(
+            _steering_reader(None, arbiter, stop_event, _make_console())
+        )
+
+        # Let it start
+        await asyncio.sleep(0.05)
+
+        # Signal stop then cancel (matching the finally block in _execute_with_interrupt)
+        stop_event.set()
+        task.cancel()
+        try:
+            await asyncio.wait_for(task, timeout=1.0)
+        except asyncio.CancelledError:
+            pass
+
+        assert task.done()
+
+
+# ---------------------------------------------------------------------------
+# Test 14 — overflow surfaced
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_overflow_surfaced():
+    """Spec 14: SteeringQueueFull → reader prints visible rejection; turn continues."""
+    steer_cap = MagicMock(side_effect=_SteeringQueueFull("queue full"))
+    arbiter = StdinArbiter()
+    stop_event = asyncio.Event()
+    console = _make_console()
+
+    call_count = 0
+
+    def fake_ready(_timeout: float) -> bool:
+        nonlocal call_count
+        call_count += 1
+        return call_count == 1
+
+    async def stopper():
+        # Wait until steer_cap is attempted, then stop
+        while not steer_cap.called:
+            await asyncio.sleep(0.005)
+        stop_event.set()
+
+    with (
+        patch("amplifier_app_cli.main._stdin_ready", fake_ready),
+        patch("sys.stdin") as mock_stdin,
+    ):
+        mock_stdin.readline.return_value = "do X\n"
+
+        await asyncio.gather(
+            asyncio.wait_for(
+                _steering_reader(steer_cap, arbiter, stop_event, console),
+                timeout=5.0,
+            ),
+            stopper(),
+        )
+
+    # steer_cap was called
+    steer_cap.assert_called_once_with("do X")
+
+    # A visible rejection message must be printed
+    printed = [str(c) for c in console.print.call_args_list]
+    assert any("Steering rejected" in msg for msg in printed), (
+        f"Expected rejection message; got: {printed}"
+    )
+    # The ack must NOT be printed
+    assert not any("queued" in msg for msg in printed)
+
+
+# ---------------------------------------------------------------------------
+# StdinArbiter unit tests (belt-and-suspenders)
+# ---------------------------------------------------------------------------
+
+
+def test_arbiter_starts_inactive():
+    arbiter = StdinArbiter()
+    assert not arbiter.approval_active
+
+
+def test_arbiter_begin_end():
+    arbiter = StdinArbiter()
+    arbiter.begin_approval()
+    assert arbiter.approval_active
+    arbiter.end_approval()
+    assert not arbiter.approval_active
+
+
+def test_arbiter_multiple_cycles():
+    arbiter = StdinArbiter()
+    for _ in range(3):
+        arbiter.begin_approval()
+        assert arbiter.approval_active
+        arbiter.end_approval()
+        assert not arbiter.approval_active
+
+
+# ---------------------------------------------------------------------------
+# approval_provider arbiter integration (test begin/end called correctly)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_approval_provider_sets_arbiter():
+    """Approval provider sets arbiter.approval_active before and clears after request."""
+    from amplifier_app_cli.approval_provider import CLIApprovalProvider
+    from amplifier_core import ApprovalRequest
+
+    arbiter = StdinArbiter()
+    console = MagicMock()
+    console.width = 80
+
+    provider = CLIApprovalProvider(console, arbiter=arbiter)  # type: ignore[call-arg]
+
+    # Track arbiter state during _do_request_approval
+    states_during: list[bool] = []
+
+    async def fake_do_request(req):
+        states_during.append(arbiter.approval_active)
+        from amplifier_core import ApprovalResponse
+
+        return ApprovalResponse(approved=True, reason="ok")
+
+    request = ApprovalRequest(
+        tool_name="test_tool",
+        action="test_action",
+        risk_level="low",
+    )
+
+    with patch.object(provider, "_do_request_approval", side_effect=fake_do_request):
+        assert not arbiter.approval_active
+        await provider.request_approval(request)
+        assert not arbiter.approval_active  # cleared in finally
+
+    # Was active during the inner call
+    assert states_during == [True]
+
+
+@pytest.mark.asyncio
+async def test_approval_provider_clears_arbiter_on_exception():
+    """Arbiter is cleared even if _do_request_approval raises."""
+    from amplifier_app_cli.approval_provider import CLIApprovalProvider
+    from amplifier_core import ApprovalRequest
+
+    arbiter = StdinArbiter()
+    console = MagicMock()
+    console.width = 80
+
+    provider = CLIApprovalProvider(console, arbiter=arbiter)  # type: ignore[call-arg]
+
+    request = ApprovalRequest(
+        tool_name="t",
+        action="a",
+        risk_level="low",
+    )
+
+    async def boom(_req):
+        raise RuntimeError("something went wrong")
+
+    with patch.object(provider, "_do_request_approval", side_effect=boom):
+        with pytest.raises(RuntimeError):
+            await provider.request_approval(request)
+
+    assert not arbiter.approval_active

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -961,3 +961,233 @@ async def test_split_ansi_escape_survives_prompt_redraw():
         "Tracking per §3.5 of steering-drain.md. Reassess if real-terminal "
         "corruption is observed."
     )
+
+
+# ===========================================================================
+# Steering input reuse -- @-mention expansion + mid-turn command rejection
+# (docs/designs/steering-input-reuse.md, "Decisions (locked, post-council)")
+#
+# Fork A (locked): _enqueue reuses the EXISTING CommandProcessor.process_input
+# + process_runtime_mentions directly -- no shared wrapper, no REPL changes.
+# Command policy (locked): REJECT-ALL mid-turn -- no /mode whitelist, no
+# handle_command call on the steering path.
+#
+# These tests construct SteeringInputManager with the new ``command_processor``
+# / ``session`` / ``_mentions_expander`` constructor kwargs that do not exist
+# yet on current code -- they MUST fail (TypeError: unexpected keyword
+# argument) until SteeringInputManager.__init__ is updated.
+# ===========================================================================
+
+
+def _make_reuse_manager(
+    *,
+    steer_cap=None,
+    command_processor=None,
+    session=None,
+    mentions_expander=None,
+    stop_event: asyncio.Event | None = None,
+) -> tuple[SteeringInputManager, asyncio.Event]:
+    """Construct a SteeringInputManager wired for the input-reuse path.
+
+    Kept separate from ``_make_manager`` so the pre-existing 30 tests are
+    unaffected by this helper (and by the constructor surface it exercises).
+    """
+    stop = stop_event or asyncio.Event()
+    console = _make_console()
+    manager = SteeringInputManager(
+        steer_cap,
+        None,  # arbiter
+        stop,
+        console,
+        command_processor=command_processor,
+        session=session,
+        _mentions_expander=mentions_expander,
+    )
+    return manager, stop
+
+
+@pytest.mark.asyncio
+async def test_steered_mention_input_is_expanded_before_steer():
+    """A steered '@file.py look at this' is classified as a prompt by the
+    SAME CommandProcessor.process_input used by the REPL, then @-mentions are
+    expanded via the SAME process_runtime_mentions -- steer_cap must receive
+    the EXPANDED text, not the raw '@file.py ...' string.
+
+    FAILS now: SteeringInputManager.__init__ does not accept
+    command_processor/session/_mentions_expander, so this raises TypeError.
+    """
+    raw = "@file.py look at this"
+    expanded_text = "<context_file path='file.py'>...</context_file>\nlook at this"
+
+    command_processor = MagicMock()
+    command_processor.process_input.return_value = ("prompt", {"text": raw})
+
+    expander_calls: list[tuple[Any, str]] = []
+
+    async def fake_expander(session, text):
+        expander_calls.append((session, text))
+        return expanded_text
+
+    steer_cap = MagicMock()
+    session_sentinel = object()
+
+    manager, _ = _make_reuse_manager(
+        steer_cap=steer_cap,
+        command_processor=command_processor,
+        session=session_sentinel,
+        mentions_expander=fake_expander,
+    )
+
+    await manager._enqueue(raw)
+
+    command_processor.process_input.assert_called_once_with(raw)
+    assert expander_calls == [(session_sentinel, raw)]
+    # The critical assertion: steer_cap got the EXPANDED text, not the raw one.
+    steer_cap.assert_called_once_with(expanded_text)
+    assert manager.pending_count == 1
+
+
+@pytest.mark.parametrize("steered_text", ["/mode plan", "/foo"])
+@pytest.mark.asyncio
+async def test_steered_slash_command_is_rejected_mid_turn(steered_text):
+    """A steered slash command (whitelisted /mode or unrecognized /foo) is
+    REJECTED mid-turn per the locked command policy -- NOT applied, NOT
+    injected raw. steer_cap must not be called; badge must not increment;
+    an honest, actionable rejection must be printed. No handle_command call.
+
+    FAILS now: current _enqueue has no command-classification step at all and
+    forwards the raw slash text straight to steer_cap.
+    """
+    command_processor = MagicMock()
+    command_processor.process_input.return_value = (
+        "handle_mode" if steered_text.startswith("/mode") else "unknown_command",
+        {"command": steered_text.split()[0]},
+    )
+
+    steer_cap = MagicMock()
+    manager, _ = _make_reuse_manager(
+        steer_cap=steer_cap,
+        command_processor=command_processor,
+        session=object(),
+    )
+
+    await manager._enqueue(steered_text)
+
+    steer_cap.assert_not_called()
+    assert manager.pending_count == 0
+    # No handle_command path exists on the manager at all -- nothing to call.
+    assert not command_processor.handle_command.called
+
+    printed = [str(c) for c in manager._console.print.call_args_list]
+    assert any("mid-turn" in msg.lower() and steered_text in msg for msg in printed), (
+        f"Expected an honest mid-turn rejection naming the command; got: {printed}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_steered_mention_expansion_exception_is_caught_fail_loud():
+    """If process_runtime_mentions raises (bad/huge/missing @path, permission
+    error), _enqueue must catch it, print a fail-loud console message, NOT
+    call steer_cap, NOT increment the badge, and the exception must NEVER
+    escape (it would strand the drain loop per the locked edge-handling
+    requirement).
+
+    FAILS now: no expansion step exists, so nothing can raise from it and
+    this test fails on the missing constructor kwargs (TypeError).
+    """
+    command_processor = MagicMock()
+    command_processor.process_input.return_value = (
+        "prompt",
+        {"text": "@missing/huge/file.bin look"},
+    )
+
+    async def boom_expander(session, text):
+        raise PermissionError("cannot read @missing/huge/file.bin")
+
+    steer_cap = MagicMock()
+    manager, _ = _make_reuse_manager(
+        steer_cap=steer_cap,
+        command_processor=command_processor,
+        session=object(),
+        mentions_expander=boom_expander,
+    )
+
+    # Must not raise -- the exception must never escape _enqueue.
+    await manager._enqueue("@missing/huge/file.bin look")
+
+    steer_cap.assert_not_called()
+    assert manager.pending_count == 0
+
+    printed = [str(c) for c in manager._console.print.call_args_list]
+    assert any(
+        "couldn't expand mentions" in msg.lower() or "expand" in msg.lower()
+        for msg in printed
+    ), f"Expected a fail-loud expansion-error message; got: {printed}"
+
+
+@pytest.mark.asyncio
+async def test_steered_plain_text_still_steered_no_regression():
+    """Plain text with no @-mentions and no slash still reaches steer_cap
+    (via the same classify + expand pipeline; the expander returns it
+    unchanged since there's nothing to expand). No regression vs. the old
+    raw-passthrough behavior for the common case.
+    """
+    command_processor = MagicMock()
+    command_processor.process_input.return_value = ("prompt", {"text": "hello"})
+
+    async def passthrough_expander(session, text):
+        return text  # nothing to expand
+
+    steer_cap = MagicMock()
+    manager, _ = _make_reuse_manager(
+        steer_cap=steer_cap,
+        command_processor=command_processor,
+        session=object(),
+        mentions_expander=passthrough_expander,
+    )
+
+    await manager._enqueue("hello")
+
+    steer_cap.assert_called_once_with("hello")
+    assert manager.pending_count == 1
+
+
+@pytest.mark.parametrize(
+    "text,action,data",
+    [
+        ("/", "unknown_command", {"command": "/"}),
+        ("//x", "unknown_command", {"command": "//x"}),
+        ("@", "prompt", {"text": "@"}),
+        ("@ ", "prompt", {"text": "@ "}),
+    ],
+)
+@pytest.mark.asyncio
+async def test_steered_delimiter_only_inputs_do_not_crash(text, action, data):
+    """Delimiter-only inputs ('/', '//x', '@', '@ ') must classify + handle
+    without crashing -- per the locked edge-handling requirements. '/' and
+    '//x' classify as unrecognized commands (rejected, not steered); '@' and
+    '@ ' classify as prompts (steered after expansion).
+    """
+    command_processor = MagicMock()
+    command_processor.process_input.return_value = (action, data)
+
+    async def identity_expander(session, t):
+        return t
+
+    steer_cap = MagicMock()
+    manager, _ = _make_reuse_manager(
+        steer_cap=steer_cap,
+        command_processor=command_processor,
+        session=object(),
+        mentions_expander=identity_expander,
+    )
+
+    # Must not raise.
+    await manager._enqueue(text)
+
+    if action == "prompt":
+        steer_cap.assert_called_once()
+        assert manager.pending_count == 1
+    else:
+        steer_cap.assert_not_called()
+        assert manager.pending_count == 0

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -306,7 +306,7 @@ def test_prompt_message_no_pending_shows_plain_steer():
 def test_prompt_message_with_pending_shows_count_and_queued():
     """_prompt_message includes the count and 'queued' when pending_count > 0."""
     manager, _ = _make_manager()
-    manager._pending_count = 3
+    manager._enqueued_total = 3  # monotonic model: badge = max(0, 3 - 0) = 3
     msg = manager._prompt_message()
     text = msg.value
     assert "queued" in text
@@ -323,8 +323,8 @@ async def test_prompt_message_updates_after_decrement_via_dispatcher():
     steer_cap = MagicMock()
     manager, _ = _make_manager(steer_cap=steer_cap)
 
-    # Manually set counter (bypassing _enqueue to avoid a real prompt_toolkit App)
-    manager._pending_count = 1
+    # Manually set enqueued counter (bypassing _enqueue to avoid a real prompt_toolkit App)
+    manager._enqueued_total = 1  # monotonic model: badge = max(0, 1 - 0) = 1
     assert "queued" in manager._prompt_message().value
 
     registry = _FakeHooksRegistry()
@@ -585,3 +585,267 @@ async def test_approval_provider_clears_arbiter_on_exception():
             await provider.request_approval(request)
 
     assert not arbiter.approval_active
+
+
+# ===========================================================================
+# Spec §4.2 — app-cli drain-semantics hardening (steering-drain.md)
+# A1–A6: failing-test-first per spec
+# ===========================================================================
+
+
+# ---------------------------------------------------------------------------
+# A1: badge == enqueued_total − injected_total (FAILS under old code)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_badge_is_enqueued_minus_injected():
+    """Badge = max(0, _enqueued_total - _injected_total) at every step.
+
+    The monotonic pair (_enqueued_total, _injected_total) must be the
+    authoritative source of truth for pending_count.  Interleaves enqueue
+    and inject in several orders and asserts the invariant at each step.
+
+    **FAILS under old code** (lone _pending_count): _enqueued_total and
+    _injected_total do not exist → AttributeError.
+    """
+    steer_cap = MagicMock()
+    manager, _ = _make_manager(steer_cap=steer_cap)
+
+    # Initial state
+    assert manager._enqueued_total == 0  # AttributeError on old code → FAIL
+    assert manager._injected_total == 0
+    assert manager.pending_count == 0
+
+    # Enqueue first steer
+    await manager._enqueue("alpha")
+    assert manager._enqueued_total == 1
+    assert manager._injected_total == 0
+    assert manager.pending_count == max(0, 1 - 0)  # 1
+
+    # Inject it
+    await manager.on_steering_injected("orchestrator:steering_injected", {})
+    assert manager._enqueued_total == 1
+    assert manager._injected_total == 1
+    assert manager.pending_count == max(0, 1 - 1)  # 0
+
+    # Enqueue two more in quick succession
+    await manager._enqueue("beta")
+    await manager._enqueue("gamma")
+    assert manager._enqueued_total == 3
+    assert manager._injected_total == 1
+    assert manager.pending_count == max(0, 3 - 1)  # 2
+
+    # Drain one
+    await manager.on_steering_injected("orchestrator:steering_injected", {})
+    assert manager.pending_count == max(0, 3 - 2)  # 1
+
+    # Drain the last
+    await manager.on_steering_injected("orchestrator:steering_injected", {})
+    assert manager.pending_count == max(0, 3 - 3)  # 0
+    assert manager._enqueued_total == 3
+    assert manager._injected_total == 3
+
+
+# ---------------------------------------------------------------------------
+# A2: badge never negative — regression guard under new model (PASSES now)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extra_injected_event_cannot_drive_badge_negative():
+    """Extra inject events beyond enqueued count cannot drive badge below 0.
+
+    PASSES under old code (guard ``if _pending_count > 0``) and must continue
+    to pass under the monotonic model (``max(0, ...)``).  Added as an
+    explicit regression guard per spec §3.4.
+    """
+    steer_cap = MagicMock()
+    manager, _ = _make_manager(steer_cap=steer_cap)
+
+    registry = _FakeHooksRegistry()
+    registry.register("orchestrator:steering_injected", manager.on_steering_injected)
+
+    await manager._enqueue("one")
+    assert manager.pending_count == 1
+
+    # Fire 5 inject events — 4 more than enqueued
+    for _ in range(5):
+        await registry.emit("orchestrator:steering_injected", {})
+
+    assert manager.pending_count == 0
+    assert manager.pending_count >= 0  # explicit non-negative guard
+
+
+# ---------------------------------------------------------------------------
+# A3: lost inject event does not stick phantom (FAILS under old code)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lost_injected_event_does_not_stick_phantom():
+    """Monotonic pair self-heals: a late inject event drives the badge to 0.
+
+    Scenario: two steers are enqueued; one inject event is delayed (simulating
+    a lost/out-of-order event).  The badge reflects the true outstanding count
+    while the event is delayed.  When the delayed event finally arrives, the
+    badge self-heals to the correct value.
+
+    Under the old lone-decrement model the internal counter is a single
+    opaque int with no memory of how many events were received vs enqueued.
+    The monotonic pair makes the state fully inspectable.
+
+    **FAILS under old code**: _enqueued_total / _injected_total do not exist
+    → AttributeError.
+    """
+    steer_cap = MagicMock()
+    manager, _ = _make_manager(steer_cap=steer_cap)
+
+    # Enqueue two steers
+    await manager._enqueue("msg1")
+    await manager._enqueue("msg2")
+    assert manager._enqueued_total == 2  # AttributeError on old code → FAIL
+    assert manager._injected_total == 0
+    assert manager.pending_count == 2
+
+    # Only one inject event arrives (the other is "delayed")
+    await manager.on_steering_injected("orchestrator:steering_injected", {})
+    assert manager._enqueued_total == 2
+    assert manager._injected_total == 1
+    assert manager.pending_count == 1  # one genuinely outstanding
+
+    # The delayed inject event finally arrives — badge self-heals to 0
+    await manager.on_steering_injected("orchestrator:steering_injected", {})
+    assert manager._enqueued_total == 2
+    assert manager._injected_total == 2
+    assert manager.pending_count == 0  # no phantom "1 queued" remains
+
+
+# ---------------------------------------------------------------------------
+# A4: overflow shows visible rejection — regression guard (PASSES now)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_overflow_shows_visible_rejection():
+    """SteeringQueueFull raises a visible rejection; badge does NOT increment.
+
+    PASSES under old code (already working).  Added as explicit regression
+    guard per spec §3.1.
+    """
+    steer_cap = MagicMock(side_effect=_SteeringQueueFull("queue full"))
+    manager, _ = _make_manager(steer_cap=steer_cap)
+
+    await manager._enqueue("too much")
+
+    steer_cap.assert_called_once_with("too much")
+
+    printed = [str(c) for c in manager._console.print.call_args_list]
+    assert any("rejected" in msg.lower() for msg in printed), (
+        f"Expected visible 'rejected' message on overflow; got: {printed}"
+    )
+    # Badge must NOT increment on failure
+    assert manager.pending_count == 0
+
+
+# ---------------------------------------------------------------------------
+# A5: late steer ack communicates next-turn deferral (FAILS under old code)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_next_turn_steer_ack_communicates_deferral():
+    """When stop_event is set (turn ending/ended), _enqueue must print an ack
+    that communicates the steer will apply to the NEXT turn.
+
+    **FAILS under old code**: _enqueue always prints ``⧗ queued: …`` with no
+    stop_event check; there is no "next turn" acknowledgment.
+
+    Per spec §5.3 gate rule:
+      stop_event set   → ``⧗ queued for next turn: {text}``
+      stop_event clear → ``⧗ queued: {text}``  (unchanged)
+    """
+    steer_cap = MagicMock()
+    stop = asyncio.Event()
+    manager, _ = _make_manager(steer_cap=steer_cap, stop_event=stop)
+
+    # Simulate turn-ending state
+    stop.set()
+
+    await manager._enqueue("steer at turn end")
+
+    # steer_cap was still called — steer is enqueued (for the next turn)
+    steer_cap.assert_called_once_with("steer at turn end")
+
+    # Badge increments (the steer is in the orchestrator queue)
+    assert manager.pending_count == 1
+
+    # Ack must communicate "next turn"
+    printed = [str(c) for c in manager._console.print.call_args_list]
+    assert any("next turn" in msg.lower() for msg in printed), (
+        f"Expected 'next turn' in ack when stop_event is set; got: {printed}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_live_turn_steer_ack_does_not_say_next_turn():
+    """When stop_event is NOT set (turn live), the ack is ``⧗ queued: …``
+    without any "next turn" text.
+
+    Companion guard for A5 — verifies the normal live-turn path is unchanged.
+    PASSES under both old and new code.
+    """
+    steer_cap = MagicMock()
+    stop = asyncio.Event()
+    manager, _ = _make_manager(steer_cap=steer_cap, stop_event=stop)
+
+    # stop_event NOT set — turn is live
+    assert not stop.is_set()
+
+    await manager._enqueue("live steer")
+
+    steer_cap.assert_called_once_with("live steer")
+
+    printed = [str(c) for c in manager._console.print.call_args_list]
+    assert any("queued" in msg.lower() for msg in printed), (
+        f"Expected a 'queued' ack for live-turn steer; got: {printed}"
+    )
+    assert not any("next turn" in msg.lower() for msg in printed), (
+        f"Live-turn ack must NOT say 'next turn'; got: {printed}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A6: ANSI/OSC escape split probe — xfail (parked, investigating §3.5)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "Probe for §3.5 of steering-drain.md: patch_stdout(raw=True) may "
+        "split an ANSI/OSC escape sequence across two writes with a prompt "
+        "redraw interleaved. Unconfirmed reproduction — tracking as risk. "
+        "Do NOT implement a fix without first reproducing corruption in a "
+        "real terminal session. Parked."
+    ),
+)
+@pytest.mark.asyncio
+async def test_split_ansi_escape_survives_prompt_redraw():
+    """PROBE: A split ANSI/OSC escape written across two flush-calls should
+    survive a prompt_toolkit ``app.invalidate()`` redraw interleaved between
+    the halves.
+
+    This test cannot be reproduced with the unit-test harness because
+    ``_input_provider`` is injected (no real ``_pt_session``, so
+    ``invalidate()`` is never called).  It is kept as a tracking placeholder
+    so the risk described in §3.5 stays visible in the test suite rather than
+    being silently closed.
+
+    Current status: unconfirmed reproduction.  Assess before fixing.
+    """
+    pytest.xfail(
+        "Cannot reproduce with unit-test harness (no real PTY / PromptSession). "
+        "Tracking per §3.5 of steering-drain.md. Reassess if real-terminal "
+        "corruption is observed."
+    )

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -1,13 +1,36 @@
-"""Unit tests for mid-turn steering (app-cli side).
+"""Unit tests for mid-turn steering UX (app-cli side).
 
-Covers spec tests 9–14 from docs/designs/steering.md §7 (App-CLI section):
+Tests the SteeringInputManager introduced in the anchored-input + queued-badge
+feature.  All tests cover the logic layer (_enqueue, on_steering_injected,
+_toolbar, run() with injected input) so no real TTY or prompt_toolkit app is
+required.
 
-9.  fail-loud-no-capability
-10. steer-on-line
-11. empty-line-ignored
-12. stdin/approval arbitration suspends reader
-13. teardown leaves no leak / does not steal next prompt
-14. overflow surfaced
+Spec coverage
+~~~~~~~~~~~~~
+Counter:
+  - increments after a successful session.steer() enqueue
+  - decrements on each simulated 'orchestrator:steering_injected' callback
+  - drains exactly to 0 (not negative) when all steers are injected
+
+Empty / whitespace:
+  - blank and whitespace-only lines are silently ignored
+
+Fail-loud:
+  - steer_cap is None  → visible "unavailable" message
+  - steer_cap raises SteeringQueueFull → visible "rejected" message
+
+Arbiter:
+  - while approval_active the run() loop does NOT forward input
+  - after end_approval() the reader resumes and processes the next line
+
+Teardown:
+  - setting stop_event causes run() to exit within the poll interval
+
+Toolbar text:
+  - empty string when no messages queued
+  - badge text including count when messages are queued
+
+StdinArbiter and CLIApprovalProvider integration tests are preserved unchanged.
 """
 
 from __future__ import annotations
@@ -17,14 +40,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from amplifier_app_cli.main import _steering_reader  # type: ignore[attr-defined]
 from amplifier_app_cli.stdin_arbiter import StdinArbiter
+from amplifier_app_cli.steering_input import SteeringInputManager
 
 
 # ---------------------------------------------------------------------------
-# Stub for SteeringQueueFull (produced by the orchestrator module, which is
-# not a test dependency here — we just need something that is a RuntimeError
-# subclass to verify the error path).
+# Stub for SteeringQueueFull (produced by the orchestrator, not a test dep)
 # ---------------------------------------------------------------------------
 
 
@@ -41,315 +62,388 @@ def _make_console() -> MagicMock:
     return MagicMock()
 
 
-async def _drive_reader(
-    steer_cap,
-    arbiter: StdinArbiter | None,
+def _make_manager(
+    steer_cap=None,
+    arbiter=None,
     *,
-    ready_values: list[bool],
-    readline_values: list[str],
-    stop_after_reads: bool = True,
-    timeout: float = 5.0,
-) -> MagicMock:
-    """Run _steering_reader with controlled stdin data, return the console mock.
-
-    *ready_values* controls what _stdin_ready returns on successive calls.
-    *readline_values* is the sequence sys.stdin.readline returns.
-
-    The reader is stopped by setting stop_event when ready_values are exhausted
-    (or when steer_cap is called, if stop_after_reads=True).
-    """
+    stop_event: asyncio.Event | None = None,
+    input_provider=None,
+) -> tuple[SteeringInputManager, asyncio.Event]:
+    """Create a SteeringInputManager wired for testing."""
+    stop = stop_event or asyncio.Event()
     console = _make_console()
-    stop_event = asyncio.Event()
-
-    ready_iter = iter(ready_values)
-    exhausted = False
-
-    def fake_ready(_timeout: float) -> bool:
-        nonlocal exhausted
-        try:
-            val = next(ready_iter)
-        except StopIteration:
-            exhausted = True
-            stop_event.set()
-            return False
-        return val
-
-    with (
-        patch("amplifier_app_cli.main._stdin_ready", fake_ready),
-        patch("sys.stdin") as mock_stdin,
-    ):
-        mock_stdin.readline.side_effect = readline_values
-
-        await asyncio.wait_for(
-            _steering_reader(steer_cap, arbiter, stop_event, console),
-            timeout=timeout,
-        )
-
-    return console
+    manager = SteeringInputManager(
+        steer_cap,
+        arbiter,
+        stop,
+        console,
+        _input_provider=input_provider,
+    )
+    return manager, stop
 
 
 # ---------------------------------------------------------------------------
-# Test 9 — fail-loud-no-capability
+# Counter: increments on enqueue
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_counter_increments_on_enqueue():
+    """Successful steer enqueue increments pending_count by 1."""
+    steer_cap = MagicMock()
+    manager, _ = _make_manager(steer_cap=steer_cap)
+
+    assert manager.pending_count == 0
+    await manager._enqueue("do X")
+    assert manager.pending_count == 1
+    steer_cap.assert_called_once_with("do X")
+
+
+@pytest.mark.asyncio
+async def test_counter_increments_multiple_times():
+    """Each successful enqueue increments the counter independently."""
+    steer_cap = MagicMock()
+    manager, _ = _make_manager(steer_cap=steer_cap)
+
+    await manager._enqueue("first")
+    await manager._enqueue("second")
+    await manager._enqueue("third")
+    assert manager.pending_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Counter: decrements on orchestrator:steering_injected hook callback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_counter_decrements_on_injected_hook():
+    """on_steering_injected() decrements pending_count by 1."""
+    steer_cap = MagicMock()
+    manager, _ = _make_manager(steer_cap=steer_cap)
+
+    await manager._enqueue("do X")
+    assert manager.pending_count == 1
+
+    await manager.on_steering_injected({"content": "do X"})
+    assert manager.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_counter_drains_exactly_to_zero():
+    """Enqueueing N messages and injecting N events leaves counter at exactly 0."""
+    steer_cap = MagicMock()
+    manager, _ = _make_manager(steer_cap=steer_cap)
+
+    n = 5
+    for i in range(n):
+        await manager._enqueue(f"msg {i}")
+    assert manager.pending_count == n
+
+    for _ in range(n):
+        await manager.on_steering_injected({})
+    assert manager.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_counter_never_goes_below_zero():
+    """Extra injection events do not push the counter below 0."""
+    manager, _ = _make_manager(steer_cap=MagicMock())
+
+    await manager._enqueue("once")
+    # Inject more times than we enqueued
+    await manager.on_steering_injected({})
+    await manager.on_steering_injected({})  # extra — should be clamped
+    assert manager.pending_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Empty / whitespace ignored
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_string_ignored():
+    """Empty string does not call steer_cap or change counter."""
+    steer_cap = MagicMock()
+    manager, _ = _make_manager(steer_cap=steer_cap)
+
+    await manager._enqueue("")
+    steer_cap.assert_not_called()
+    assert manager.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_ignored():
+    """Whitespace-only strings (spaces, tabs, newlines) are silently ignored."""
+    steer_cap = MagicMock()
+    manager, _ = _make_manager(steer_cap=steer_cap)
+
+    for text in ("   ", "\t", "\n", "  \t  \n  "):
+        await manager._enqueue(text)
+
+    steer_cap.assert_not_called()
+    assert manager.pending_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud: steer_cap is None
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_fail_loud_no_capability():
-    """Spec 9: steer_cap is None → visible message, no crash, no silent drop."""
-    console = await _drive_reader(
-        steer_cap=None,
-        arbiter=None,
-        ready_values=[True, False],  # ready once, then exhaust
-        readline_values=["redirect: do this instead\n"],
+    """When steer_cap is None a visible 'unavailable' message is printed; no crash."""
+    manager, _ = _make_manager(steer_cap=None)
+
+    await manager._enqueue("redirect me")
+
+    printed = [str(c) for c in manager._console.print.call_args_list]
+    assert any("Steering unavailable" in msg for msg in printed), (
+        f"Expected 'Steering unavailable'; got: {printed}"
     )
-
-    # A visible "unavailable" message must be printed
-    printed_messages = [str(call) for call in console.print.call_args_list]
-    assert any("Steering unavailable" in msg for msg in printed_messages), (
-        f"Expected 'Steering unavailable' in console output; got: {printed_messages}"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Test 10 — steer-on-line
-# ---------------------------------------------------------------------------
+    assert manager.pending_count == 0
 
 
 @pytest.mark.asyncio
-async def test_steer_on_line():
-    """Spec 10: a non-empty typed line calls steer_cap and prints ack."""
-    steer_cap = MagicMock()
-    arbiter = StdinArbiter()
-    stop_event = asyncio.Event()
-    console = _make_console()
+async def test_fail_loud_no_capability_no_crash_on_repeated_calls():
+    """Multiple enqueues with no steer_cap each print a visible message."""
+    manager, _ = _make_manager(steer_cap=None)
 
-    call_count = 0
+    await manager._enqueue("first")
+    await manager._enqueue("second")
 
-    def fake_ready(_timeout: float) -> bool:
-        nonlocal call_count
-        call_count += 1
-        return call_count == 1  # True on first call only
-
-    async def stopper():
-        """Wait for steer_cap to be invoked, then stop the reader."""
-        while not steer_cap.called:
-            await asyncio.sleep(0.005)
-        stop_event.set()
-
-    with (
-        patch("amplifier_app_cli.main._stdin_ready", fake_ready),
-        patch("sys.stdin") as mock_stdin,
-    ):
-        mock_stdin.readline.return_value = "do X\n"
-
-        await asyncio.gather(
-            asyncio.wait_for(
-                _steering_reader(steer_cap, arbiter, stop_event, console),
-                timeout=5.0,
-            ),
-            stopper(),
-        )
-
-    steer_cap.assert_called_once_with("do X")
-    printed = [str(c) for c in console.print.call_args_list]
-    assert any("queued" in msg for msg in printed), (
-        f"Expected ack in output; got: {printed}"
-    )
+    calls = manager._console.print.call_args_list
+    printed = [str(c) for c in calls]
+    unavailable_count = sum(1 for msg in printed if "Steering unavailable" in msg)
+    assert unavailable_count == 2
 
 
 # ---------------------------------------------------------------------------
-# Test 11 — empty-line-ignored
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_empty_line_ignored():
-    """Spec 11: blank and whitespace-only lines do not call steer_cap."""
-    steer_cap = MagicMock()
-    console = await _drive_reader(
-        steer_cap=steer_cap,
-        arbiter=None,
-        ready_values=[True, True, True, False],  # 3 reads, then exhaust
-        readline_values=["   \n", "\n", "\t  \n"],
-    )
-
-    steer_cap.assert_not_called()
-    # No ack should have been printed either
-    printed = [str(c) for c in console.print.call_args_list]
-    assert not any("queued" in msg for msg in printed)
-
-
-# ---------------------------------------------------------------------------
-# Test 12 — stdin / approval arbitration
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_arbitration_suspends_reader_during_approval():
-    """Spec 12: while arbiter.approval_active, reader does not call _stdin_ready or steer_cap."""
-    steer_cap = MagicMock()
-    arbiter = StdinArbiter()
-    stop_event = asyncio.Event()
-    console = _make_console()
-
-    ready_calls_approval_state: list[bool] = []
-
-    def fake_ready(_timeout: float) -> bool:
-        # Record whether approval was active at the time of each _stdin_ready call.
-        ready_calls_approval_state.append(arbiter.approval_active)
-        return True  # Always data-ready once we get here
-
-    # Phase 1: approval active from the start
-    arbiter.begin_approval()
-
-    async def controller():
-        # Verify no reads happen during approval
-        await asyncio.sleep(0.15)
-        assert not steer_cap.called, (
-            "steer_cap must not be called while approval is active"
-        )
-        assert not ready_calls_approval_state, (
-            "_stdin_ready must not be called during approval"
-        )
-
-        # Phase 2: release approval — reader should now pick up the one queued line
-        arbiter.end_approval()
-
-    with (
-        patch("amplifier_app_cli.main._stdin_ready", fake_ready),
-        patch("sys.stdin") as mock_stdin,
-    ):
-        # readline returns the line once, then "" (EOF) so the reader exits cleanly
-        # without needing stop_event and without calling steer_cap more than once.
-        mock_stdin.readline.side_effect = ["do X\n", ""]
-
-        await asyncio.gather(
-            asyncio.wait_for(
-                _steering_reader(steer_cap, arbiter, stop_event, console),
-                timeout=5.0,
-            ),
-            controller(),
-        )
-
-    # After approval ended, the line was processed exactly once
-    steer_cap.assert_called_once_with("do X")
-    # _stdin_ready was only called when approval was NOT active
-    assert all(not was_active for was_active in ready_calls_approval_state), (
-        "ready() was called while approval was active"
-    )
-
-
-# ---------------------------------------------------------------------------
-# Test 13 — teardown / no stolen next-prompt input
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-async def test_teardown_reader_exits_on_stop_event():
-    """Spec 13: reader exits cleanly within the bounded select interval after stop_event is set."""
-    console = _make_console()
-    arbiter = StdinArbiter()
-    stop_event = asyncio.Event()
-
-    # _stdin_ready returns False (no data) every call — reader loops without reading
-    with patch("amplifier_app_cli.main._stdin_ready", lambda _t: False):
-
-        async def set_stop():
-            await asyncio.sleep(0.05)
-            stop_event.set()
-
-        # Both tasks must complete: reader exits, stopper finishes
-        await asyncio.gather(
-            asyncio.wait_for(
-                _steering_reader(None, arbiter, stop_event, console),
-                timeout=2.0,
-            ),
-            set_stop(),
-        )
-
-    # Reader exited cleanly
-    assert stop_event.is_set()
-
-
-@pytest.mark.asyncio
-async def test_teardown_cancel_exits_promptly():
-    """Spec 13: reader task can be cancelled and awaited without hanging."""
-    arbiter = StdinArbiter()
-    stop_event = asyncio.Event()
-
-    with patch("amplifier_app_cli.main._stdin_ready", lambda _t: False):
-        task = asyncio.create_task(
-            _steering_reader(None, arbiter, stop_event, _make_console())
-        )
-
-        # Let it start
-        await asyncio.sleep(0.05)
-
-        # Signal stop then cancel (matching the finally block in _execute_with_interrupt)
-        stop_event.set()
-        task.cancel()
-        try:
-            await asyncio.wait_for(task, timeout=1.0)
-        except asyncio.CancelledError:
-            pass
-
-        assert task.done()
-
-
-# ---------------------------------------------------------------------------
-# Test 14 — overflow surfaced
+# Overflow surfaced
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_overflow_surfaced():
-    """Spec 14: SteeringQueueFull → reader prints visible rejection; turn continues."""
+    """SteeringQueueFull → visible rejection message; counter unchanged."""
     steer_cap = MagicMock(side_effect=_SteeringQueueFull("queue full"))
+    manager, _ = _make_manager(steer_cap=steer_cap)
+
+    await manager._enqueue("do X")
+
+    steer_cap.assert_called_once_with("do X")
+    printed = [str(c) for c in manager._console.print.call_args_list]
+    assert any("Steering rejected" in msg for msg in printed), (
+        f"Expected 'Steering rejected'; got: {printed}"
+    )
+    # Counter must NOT increment on failure
+    assert manager.pending_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Toolbar text
+# ---------------------------------------------------------------------------
+
+
+def test_toolbar_empty_when_no_pending():
+    """Toolbar returns empty string when pending_count == 0."""
+    manager, _ = _make_manager()
+    assert manager._toolbar() == ""
+
+
+def test_toolbar_singular_when_one_pending():
+    """Toolbar shows 'message' (singular) when pending_count == 1."""
+    steer_cap = MagicMock()
+    manager, _ = _make_manager(steer_cap=steer_cap)
+    manager._pending_count = 1
+    toolbar = manager._toolbar()
+    assert "1 message queued" in toolbar
+    assert "messages" not in toolbar
+
+
+def test_toolbar_plural_when_multiple_pending():
+    """Toolbar shows 'messages' (plural) when pending_count > 1."""
+    manager, _ = _make_manager()
+    manager._pending_count = 3
+    toolbar = manager._toolbar()
+    assert "3 messages queued" in toolbar
+
+
+def test_toolbar_contains_queued_indicator():
+    """Toolbar includes the ⧗ indicator when messages are pending."""
+    manager, _ = _make_manager()
+    manager._pending_count = 2
+    toolbar = manager._toolbar()
+    assert "\u29d7" in toolbar  # ⧗
+
+
+def test_toolbar_empty_string_hides_strip():
+    """Toolbar returning '' causes prompt_toolkit to hide the bottom strip."""
+    manager, _ = _make_manager()
+    assert manager._toolbar() == ""
+
+
+# ---------------------------------------------------------------------------
+# run() with injected input: arbiter releases reader when approval_active
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_arbiter_suspends_reader_during_approval():
+    """While arbiter.approval_active the run() loop does not forward input."""
+    input_queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def mock_input() -> str:
+        return await input_queue.get()
+
+    steer_cap = MagicMock()
     arbiter = StdinArbiter()
     stop_event = asyncio.Event()
     console = _make_console()
 
-    call_count = 0
+    manager = SteeringInputManager(
+        steer_cap,
+        arbiter,
+        stop_event,
+        console,
+        _input_provider=mock_input,
+    )
 
-    def fake_ready(_timeout: float) -> bool:
-        nonlocal call_count
-        call_count += 1
-        return call_count == 1
+    # Activate approval before starting run()
+    arbiter.begin_approval()
+    run_task = asyncio.create_task(manager.run())
 
-    async def stopper():
-        # Wait until steer_cap is attempted, then stop
-        while not steer_cap.called:
-            await asyncio.sleep(0.005)
-        stop_event.set()
+    # Give the loop a chance to spin a few times — approval is active
+    await asyncio.sleep(0.15)
+    assert not steer_cap.called, (
+        "steer_cap must not be called while approval_active is True"
+    )
 
-    with (
-        patch("amplifier_app_cli.main._stdin_ready", fake_ready),
-        patch("sys.stdin") as mock_stdin,
-    ):
-        mock_stdin.readline.return_value = "do X\n"
+    # Release approval and deliver one line of input
+    arbiter.end_approval()
+    await input_queue.put("do X")
 
-        await asyncio.gather(
-            asyncio.wait_for(
-                _steering_reader(steer_cap, arbiter, stop_event, console),
-                timeout=5.0,
-            ),
-            stopper(),
-        )
+    # Wait for the line to be processed
+    await asyncio.sleep(0.15)
 
-    # steer_cap was called
+    # Cleanup
+    stop_event.set()
+    run_task.cancel()
+    try:
+        await asyncio.wait_for(run_task, timeout=1.0)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        pass
+
     steer_cap.assert_called_once_with("do X")
 
-    # A visible rejection message must be printed
-    printed = [str(c) for c in console.print.call_args_list]
-    assert any("Steering rejected" in msg for msg in printed), (
-        f"Expected rejection message; got: {printed}"
+
+@pytest.mark.asyncio
+async def test_arbiter_resumes_after_approval_ends():
+    """After end_approval() the reader processes the next queued line."""
+    input_queue: asyncio.Queue[str] = asyncio.Queue()
+
+    async def mock_input() -> str:
+        return await input_queue.get()
+
+    steer_cap = MagicMock()
+    arbiter = StdinArbiter()
+    stop_event = asyncio.Event()
+    console = _make_console()
+
+    manager = SteeringInputManager(
+        steer_cap,
+        arbiter,
+        stop_event,
+        console,
+        _input_provider=mock_input,
     )
-    # The ack must NOT be printed
-    assert not any("queued" in msg for msg in printed)
+
+    run_task = asyncio.create_task(manager.run())
+
+    # Put a line while approval is inactive — should be processed
+    await input_queue.put("before approval")
+    await asyncio.sleep(0.15)
+    assert steer_cap.call_count == 1
+
+    # Activate approval, put a second line — should NOT be processed yet
+    arbiter.begin_approval()
+    await input_queue.put("during approval")
+    await asyncio.sleep(0.15)
+    # Prompt was aborted for approval; "during approval" is still in the queue
+    # but the run loop is waiting for approval to end.
+    # Because we put "during approval" into the queue WHILE approval was active
+    # and the prompt task was cancelled, it will be picked up once approval ends.
+
+    # Release approval
+    arbiter.end_approval()
+    await asyncio.sleep(0.2)
+
+    stop_event.set()
+    run_task.cancel()
+    try:
+        await asyncio.wait_for(run_task, timeout=1.0)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        pass
+
+    # Both messages should have been processed
+    assert steer_cap.call_count >= 2
 
 
 # ---------------------------------------------------------------------------
-# StdinArbiter unit tests (belt-and-suspenders)
+# run() teardown: stop_event causes clean exit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_teardown_on_stop_event():
+    """Setting stop_event causes run() to exit within the poll interval."""
+    # mock_input blocks indefinitely so the loop is in the polling phase
+    never_returns: asyncio.Event = asyncio.Event()
+
+    async def mock_input() -> str:
+        await never_returns.wait()  # blocks until we set it
+        return ""
+
+    manager, stop = _make_manager(input_provider=mock_input)
+    run_task = asyncio.create_task(manager.run())
+
+    # Let the prompt task start
+    await asyncio.sleep(0.05)
+
+    # Signal stop
+    stop.set()
+
+    # run() should exit within ~100 ms (one poll cycle)
+    await asyncio.wait_for(run_task, timeout=1.0)
+    assert run_task.done()
+
+
+@pytest.mark.asyncio
+async def test_teardown_cancel_is_clean():
+    """Cancelling the run() task does not raise unhandled exceptions."""
+    never_returns: asyncio.Event = asyncio.Event()
+
+    async def mock_input() -> str:
+        await never_returns.wait()
+        return ""
+
+    manager, _ = _make_manager(input_provider=mock_input)
+    run_task = asyncio.create_task(manager.run())
+
+    await asyncio.sleep(0.05)
+    run_task.cancel()
+
+    try:
+        await asyncio.wait_for(run_task, timeout=1.0)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        pass
+
+    assert run_task.done()
+
+
+# ---------------------------------------------------------------------------
+# StdinArbiter unit tests (unchanged)
 # ---------------------------------------------------------------------------
 
 
@@ -376,13 +470,13 @@ def test_arbiter_multiple_cycles():
 
 
 # ---------------------------------------------------------------------------
-# approval_provider arbiter integration (test begin/end called correctly)
+# CLIApprovalProvider arbiter integration (unchanged)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
 async def test_approval_provider_sets_arbiter():
-    """Approval provider sets arbiter.approval_active before and clears after request."""
+    """Approval provider sets arbiter.approval_active before and clears after."""
     from amplifier_app_cli.approval_provider import CLIApprovalProvider
     from amplifier_core import ApprovalRequest
 
@@ -392,7 +486,6 @@ async def test_approval_provider_sets_arbiter():
 
     provider = CLIApprovalProvider(console, arbiter=arbiter)  # type: ignore[call-arg]
 
-    # Track arbiter state during _do_request_approval
     states_during: list[bool] = []
 
     async def fake_do_request(req):
@@ -410,9 +503,8 @@ async def test_approval_provider_sets_arbiter():
     with patch.object(provider, "_do_request_approval", side_effect=fake_do_request):
         assert not arbiter.approval_active
         await provider.request_approval(request)
-        assert not arbiter.approval_active  # cleared in finally
+        assert not arbiter.approval_active
 
-    # Was active during the inner call
     assert states_during == [True]
 
 

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -293,24 +293,25 @@ async def test_overflow_surfaced():
 # ---------------------------------------------------------------------------
 
 
-def test_prompt_message_no_pending_shows_plain_steer():
-    """_prompt_message returns a plain 'steer:' prompt when no messages are queued."""
+def test_prompt_message_no_pending_hides_steer_label():
+    """_prompt_message hides the 'steer' label (empty) when no messages are queued."""
     manager, _ = _make_manager()
     msg = manager._prompt_message()
-    # HTML.value holds the raw string; check it contains 'steer' and NOT 'queued'.
+    # HTML.value holds the raw string; the 'steer' label is hidden, and no 'queued'.
     text = msg.value
-    assert "steer" in text
+    assert "steer" not in text
     assert "queued" not in text
 
 
 def test_prompt_message_with_pending_shows_count_and_queued():
-    """_prompt_message includes the count and 'queued' when pending_count > 0."""
+    """_prompt_message shows the count + 'queued' (no 'steer' label) when pending_count > 0."""
     manager, _ = _make_manager()
     manager._enqueued_total = 3  # monotonic model: badge = max(0, 3 - 0) = 3
     msg = manager._prompt_message()
     text = msg.value
     assert "queued" in text
     assert "3" in text
+    assert "steer" not in text
 
 
 @pytest.mark.asyncio

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -2,8 +2,8 @@
 
 Tests the SteeringInputManager introduced in the anchored-input + queued-badge
 feature.  All tests cover the logic layer (_enqueue, on_steering_injected,
-_toolbar, run() with injected input) so no real TTY or prompt_toolkit app is
-required.
+_prompt_message, run() with injected input) so no real TTY or prompt_toolkit
+app is required.
 
 Spec coverage
 ~~~~~~~~~~~~~
@@ -286,49 +286,6 @@ async def test_overflow_surfaced():
     )
     # Counter must NOT increment on failure
     assert manager.pending_count == 0
-
-
-# ---------------------------------------------------------------------------
-# Toolbar text
-# ---------------------------------------------------------------------------
-
-
-def test_toolbar_empty_when_no_pending():
-    """Toolbar returns empty string when pending_count == 0."""
-    manager, _ = _make_manager()
-    assert manager._toolbar() == ""
-
-
-def test_toolbar_singular_when_one_pending():
-    """Toolbar shows 'message' (singular) when pending_count == 1."""
-    steer_cap = MagicMock()
-    manager, _ = _make_manager(steer_cap=steer_cap)
-    manager._pending_count = 1
-    toolbar = manager._toolbar()
-    assert "1 message queued" in toolbar
-    assert "messages" not in toolbar
-
-
-def test_toolbar_plural_when_multiple_pending():
-    """Toolbar shows 'messages' (plural) when pending_count > 1."""
-    manager, _ = _make_manager()
-    manager._pending_count = 3
-    toolbar = manager._toolbar()
-    assert "3 messages queued" in toolbar
-
-
-def test_toolbar_contains_queued_indicator():
-    """Toolbar includes the ⧗ indicator when messages are pending."""
-    manager, _ = _make_manager()
-    manager._pending_count = 2
-    toolbar = manager._toolbar()
-    assert "\u29d7" in toolbar  # ⧗
-
-
-def test_toolbar_empty_string_hides_strip():
-    """Toolbar returning '' causes prompt_toolkit to hide the bottom strip."""
-    manager, _ = _make_manager()
-    assert manager._toolbar() == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Mid-turn steering — type a message while the agent is working and it's acted on between tool rounds (redirect it, add context, @-mentions) instead of waiting for the turn to finish. Ships across 3 repos; proven end-to-end in a Digital Twin Universe.

## What this PR does

Concurrent bottom-pinned steering prompt during a turn (self-healing queued-count badge, hidden label, honest acks); Ctrl-C cancels cleanly with no REPL crash; steered input flows through the SAME processing as normal REPL input — @-mention expansion works, and slash commands are recognized and rejected mid-turn (reject-all for now; a `/mode` mid-turn whitelist and a FollowUpQueue are intentionally deferred); plus `is_composing` wiring for the streaming throttle in the companion hooks-streaming-ui PR. Full steering test suite + python_check clean. 

DTU-proven: mid-turn redirect, `@file` expansion, `/help` rejected (not injected raw), Ctrl-C graceful.

## Companion PRs

- [amplifier-module-loop-streaming: mid-turn steering mechanism](#) (https://github.com/microsoft/amplifier-module-loop-streaming/pull/29)
- [amplifier-module-hooks-streaming-ui: streaming that coexists with a pinned prompt](#) (link after all three exist)