### PR TITLE
fix(routing): resolve instance ids to module type before model discovery

### DIFF
--- a/amplifier_app_cli/commands/routing.py
+++ b/amplifier_app_cli/commands/routing.py
@@ -863,7 +863,13 @@ def _build_model_cache(
         for pname in provider_names:
             try:
                 cfg = _get_provider_config(pname, settings)
-                models = get_provider_models(pname, collected_config=cfg)
+                # pname may be an instance id (e.g. "ornith") when multiple
+                # instances of one module are configured -- resolve to the
+                # actual module id so the right provider implementation is
+                # loaded for model listing. The cache stays keyed by the
+                # original pname so downstream lookups by display name work.
+                provider_id = _resolve_provider_module(pname, settings)
+                models = get_provider_models(provider_id, collected_config=cfg)
                 model_cache[pname] = models
             except Exception:
                 model_cache[pname] = []
@@ -891,7 +897,19 @@ def _list_models_for_provider(
         collected_config = (
             _get_provider_config(provider_name, settings) if settings else None
         )
-        models = get_provider_models(provider_name, collected_config=collected_config)
+        # provider_name may be an instance id (e.g. "ornith") when multiple
+        # instances of one module are configured -- resolve to the actual
+        # module id so the right provider implementation is loaded.
+        provider_id = (
+            _resolve_provider_module(provider_name, settings)
+            if settings
+            else (
+                f"provider-{provider_name}"
+                if not provider_name.startswith("provider-")
+                else provider_name
+            )
+        )
+        models = get_provider_models(provider_id, collected_config=collected_config)
         return [str(getattr(m, "name", m)) for m in models]
     except Exception:
         return []

--- a/tests/test_routing_commands.py
+++ b/tests/test_routing_commands.py
@@ -1187,6 +1187,107 @@ class TestRoutingCreateModelCache:
         )
 
 
+class TestModelDiscoveryResolvesInstanceId:
+    """Tests that model-discovery call sites resolve instance ids to module ids.
+
+    _get_provider_names() returns an instance id (e.g. "ornith") instead of a
+    module type name when multiple instances of the same module are
+    configured. get_provider_models() -> load_provider_class() needs the real
+    module id (e.g. "provider-chat-completions"), not the instance id, or
+    class resolution silently fails and no models are returned ("could not
+    fetch models" in the wizard). _build_model_cache() and
+    _list_models_for_provider() must resolve via _resolve_provider_module()
+    before calling get_provider_models(), exactly like the already-working
+    call site in _edit_role().
+    """
+
+    def _seed_multi_instance(self, settings):
+        _seed_provider(
+            settings,
+            [
+                {
+                    "module": "provider-chat-completions",
+                    "id": "qwen-3.6",
+                    "config": {"base_url": "http://box:8080/v1"},
+                },
+                {
+                    "module": "provider-chat-completions",
+                    "id": "ornith",
+                    "config": {"base_url": "http://r11:8081/v1"},
+                },
+            ],
+        )
+
+    def test_build_model_cache_resolves_instance_ids_for_both_providers(
+        self, tmp_path
+    ):
+        """_build_model_cache must fetch models for BOTH instance ids of a
+        multi-instance module -- not silently return [] for either."""
+        from unittest.mock import MagicMock
+
+        from amplifier_app_cli.commands.routing import _build_model_cache
+
+        settings = _make_settings(tmp_path)
+        self._seed_multi_instance(settings)
+
+        mock_model = MagicMock()
+        mock_model.id = "some-model"
+        mock_model.name = "some-model"
+
+        calls: list[str] = []
+
+        def fake_get_provider_models(provider_name, collected_config=None):
+            calls.append(provider_name)
+            return [mock_model]
+
+        with patch(
+            "amplifier_app_cli.commands.routing.get_provider_models",
+            side_effect=fake_get_provider_models,
+        ):
+            result = _build_model_cache(["qwen-3.6", "ornith"], settings)
+
+        # get_provider_models must be called with the resolved module id
+        # (provider-chat-completions), never the raw instance id.
+        assert calls == ["provider-chat-completions", "provider-chat-completions"], (
+            f"Expected get_provider_models called with resolved module id "
+            f"for both instances, got: {calls}"
+        )
+
+        # Cache must still be keyed by the ORIGINAL instance id so downstream
+        # lookups by display name (e.g. model_cache.get(provider)) work.
+        assert result.get("qwen-3.6") == [mock_model], (
+            f"Expected models cached under instance id 'qwen-3.6', got: {result}"
+        )
+        assert result.get("ornith") == [mock_model], (
+            f"Expected models cached under instance id 'ornith', got: {result}"
+        )
+
+    def test_list_models_for_provider_resolves_instance_id(self, tmp_path):
+        """_list_models_for_provider must resolve an instance id to its
+        module id before calling get_provider_models()."""
+        from amplifier_app_cli.commands.routing import _list_models_for_provider
+
+        settings = _make_settings(tmp_path)
+        self._seed_multi_instance(settings)
+
+        captured: dict[str, str] = {}
+
+        def fake_get_provider_models(provider_name, collected_config=None):
+            captured["provider_name"] = provider_name
+            return []
+
+        with patch(
+            "amplifier_app_cli.provider_loader.get_provider_models",
+            side_effect=fake_get_provider_models,
+        ):
+            _list_models_for_provider("ornith", settings=settings)
+
+        assert captured.get("provider_name") == "provider-chat-completions", (
+            f"Expected get_provider_models called with resolved module id "
+            f"'provider-chat-completions', got: {captured.get('provider_name')}"
+        )
+
+
 # ============================================================
 # Task 5: DRY _prompt_provider_and_model() — calls _prompt_model_selection()
 # ============================================================


### PR DESCRIPTION
## Summary

- `_get_provider_names()` correctly returns a provider's **instance id** (e.g. `ornith`, `qwen-3.6`) instead of its bare module type when 2+ instances of the same module are configured (needed for routing-matrix disambiguation, from PR #211).
- But two call sites — `_build_model_cache()` and `_list_models_for_provider()` — passed that instance id straight to `get_provider_models()`, which calls `load_provider_class()` expecting an actual **module type** (e.g. `chat-completions`), not an arbitrary user-chosen id.
- Confirmed live: `load_provider_class("ornith")` returned `None` while `load_provider_class("openai")` resolved correctly. This caused the routing wizard to show "could not fetch models" for every multi-instance provider, and "No configured provider can serve this role" when resolving a model glob against one.

**Fix:** both call sites now resolve the selector via the existing `_resolve_provider_module()` helper (already used correctly at one other call site, `_edit_role()`) before calling `get_provider_models()`. `model_cache` stays keyed by the original display name so downstream lookups still work.

## Test plan

- `uv run pytest tests/test_routing_commands.py -q` — **76 passed** (74 existing + 2 new)
- Red-green regression verified: reverting only the `routing.py` fix (keeping the new tests) makes both new tests fail with the exact bug signature (`got: ornith`, expected `provider-chat-completions`); restoring the fix makes them pass.
- Behavior independently verified against the live Ornith server: `_list_models_for_provider("ornith", settings=settings)` now returns the real model instead of an empty list.
- ruff-lint clean, pyright clean, stub-check clean.

**Note:** full-repo test run shows pre-existing, unrelated failures (4 collection errors from `amplifier_foundation` import mismatches, 30 failures in session-spawner/working-dir tests) — confirmed via `git stash` comparison to exist on pristine `main` independent of this change; out of scope for this PR.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)