### PR TITLE
fix(providers): resolve ambiguous provider type to highest-priority instance, not first-in-list

### DIFF
--- a/amplifier_app_cli/commands/routing.py
+++ b/amplifier_app_cli/commands/routing.py
@@ -847,6 +847,7 @@ def _get_provider_config(
     provider's ``config`` sub-dict, or ``None`` if no matching provider is
     found.
     """
+    matches: list[dict[str, Any]] = []
     for p in settings.get_provider_overrides():
         p_module = p.get("module", "")
         p_type = (
@@ -859,8 +860,21 @@ def _get_provider_config(
             or p_type == provider_name
             or p_module == provider_name
         ):
-            return p.get("config", {})
-    return None
+            matches.append(p)
+
+    if not matches:
+        return None
+
+    # Multiple instances of the same module can share a bare type/module
+    # name match (matching by 'id' is already unambiguous). Resolve
+    # deterministically to the highest-priority (lowest config.priority
+    # number) instance instead of whichever is first in list order.
+    def _priority(p: dict[str, Any]) -> int:
+        config = p.get("config", {})
+        return config.get("priority", 100) if isinstance(config, dict) else 100
+
+    best = min(matches, key=_priority)
+    return best.get("config", {})
 
 
 def _build_model_cache(

--- a/amplifier_app_cli/provider_manager.py
+++ b/amplifier_app_cli/provider_manager.py
@@ -187,21 +187,36 @@ class ProviderManager:
             logger.debug("get_provider_config: reading from merged settings")
 
         logger.debug(f"get_provider_config: found {len(providers)} providers")
+        matches: list[dict[str, Any]] = []
         for provider in providers:
             module = provider.get("module")
             logger.debug(
                 f"get_provider_config: checking module '{module}' against '{provider_id}'"
             )
             if module == provider_id:
-                config = provider.get("config", {})
-                logger.debug(
-                    f"get_provider_config: found matching config with keys: {list(config.keys())}"
-                )
-                return config
+                matches.append(provider)
+
+        if not matches:
+            logger.debug(
+                f"get_provider_config: no matching provider found for '{provider_id}'"
+            )
+            return None
+
+        # Multiple instances of the same module can be configured (distinct
+        # ids, different priorities). Matching on 'module' alone is
+        # ambiguous, so resolve deterministically to the highest-priority
+        # (lowest priority number) instance rather than the first in list
+        # order. Mirrors _select_provider_by_priority() in effective_config.py.
+        def _priority(p: dict[str, Any]) -> int:
+            config = p.get("config", {})
+            return config.get("priority", 100) if isinstance(config, dict) else 100
+
+        best = min(matches, key=_priority)
+        config = best.get("config", {})
         logger.debug(
-            f"get_provider_config: no matching provider found for '{provider_id}'"
+            f"get_provider_config: found matching config with keys: {list(config.keys())}"
         )
-        return None
+        return config
 
     def list_providers(self) -> list[tuple[str, str, str]]:
         """List available provider module IDs via dynamic discovery.

--- a/tests/test_provider_manager.py
+++ b/tests/test_provider_manager.py
@@ -4,11 +4,34 @@ from amplifier_app_cli.paths import create_config_manager
 from amplifier_app_cli.provider_manager import ProviderManager
 
 
+def _write_local_providers(tmp_path, providers: list[dict]) -> None:
+    """Seed the local-scope provider list directly (bypasses use_provider's
+    priority auto-assignment so tests can control priority explicitly)."""
+    settings_path = tmp_path / ".amplifier" / "settings.local.yaml"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(
+        yaml.dump({"config": {"providers": providers}}), encoding="utf-8"
+    )
+
+
+def _make_manager(tmp_path, monkeypatch) -> ProviderManager:
+    monkeypatch.chdir(tmp_path)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(
+        "amplifier_app_cli.paths.Path.home", classmethod(lambda cls: fake_home)
+    )
+    config_manager = create_config_manager()
+    return ProviderManager(config_manager)
+
+
 def test_provider_override_persists_under_config_section(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     fake_home = tmp_path / "home"
     fake_home.mkdir()
-    monkeypatch.setattr("amplifier_app_cli.paths.Path.home", classmethod(lambda cls: fake_home))
+    monkeypatch.setattr(
+        "amplifier_app_cli.paths.Path.home", classmethod(lambda cls: fake_home)
+    )
 
     config_manager = create_config_manager()
     manager = ProviderManager(config_manager)
@@ -25,7 +48,9 @@ def test_provider_override_persists_under_config_section(tmp_path, monkeypatch):
     file_contents = yaml.safe_load(settings_path.read_text())
     provider_entry = file_contents["config"]["providers"][0]
     assert provider_entry["module"] == "provider-anthropic"
-    assert provider_entry["source"].startswith("git+https://github.com/microsoft/amplifier-module-provider-anthropic")
+    assert provider_entry["source"].startswith(
+        "git+https://github.com/microsoft/amplifier-module-provider-anthropic"
+    )
 
     provider = manager.get_current_provider()
     assert provider is not None
@@ -38,3 +63,67 @@ def test_provider_override_persists_under_config_section(tmp_path, monkeypatch):
     config_section = cleared_contents.get("config") or {}
     assert "providers" not in config_section
     assert manager.get_current_provider() is None
+
+
+class TestGetProviderConfigPrioritySelection:
+    """BUG 1 regression: get_provider_config() matched only on 'module' and
+    returned the FIRST list-order match, ignoring priority, whenever 2+
+    instances of the same module are configured (e.g. two provider-anthropic
+    entries with distinct ids/priorities). This silently served the wrong
+    instance's config to any caller resolving by bare module id --
+    concretely, ``amplifier provider models anthropic`` via
+    commands/provider.py:744.
+    """
+
+    def test_selects_highest_priority_instance_not_first_in_list(
+        self, tmp_path, monkeypatch
+    ):
+        """Two provider-anthropic instances, priority 2 listed BEFORE
+        priority 1 (lower number = higher precedence). Must return the
+        priority=1 instance's config, not whichever is first in the list.
+        """
+        manager = _make_manager(tmp_path, monkeypatch)
+        _write_local_providers(
+            tmp_path,
+            [
+                {
+                    "module": "provider-anthropic",
+                    "id": "anthropic-secondary",
+                    "config": {"priority": 2, "default_model": "wrong-instance"},
+                },
+                {
+                    "module": "provider-anthropic",
+                    "id": "anthropic-primary",
+                    "config": {"priority": 1, "default_model": "correct-instance"},
+                },
+            ],
+        )
+
+        config = manager.get_provider_config("provider-anthropic")
+
+        assert config is not None, "Expected a config dict, got None"
+        assert config.get("default_model") == "correct-instance", (
+            "get_provider_config() must resolve to the highest-priority "
+            f"(lowest priority number) instance, got: {config}"
+        )
+
+    def test_returns_none_when_no_instance_of_module_exists(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression guard: the 'genuinely not found' contract must be
+        preserved as None -- this must NOT change to raising or returning {}.
+        """
+        manager = _make_manager(tmp_path, monkeypatch)
+        _write_local_providers(
+            tmp_path,
+            [
+                {
+                    "module": "provider-openai",
+                    "config": {"priority": 1, "default_model": "gpt-5"},
+                },
+            ],
+        )
+
+        config = manager.get_provider_config("provider-anthropic")
+
+        assert config is None, f"Expected None for unconfigured module, got: {config}"

--- a/tests/test_routing_commands.py
+++ b/tests/test_routing_commands.py
@@ -2024,6 +2024,79 @@ class TestGetProviderConfig:
             f"Expected ornith's own config (not qwen-3.6's), got: {config}"
         )
 
+    def test_selects_highest_priority_instance_when_type_is_ambiguous(self, tmp_path):
+        """BUG 2 regression: two instances of the same module, each with its
+        OWN distinct id (so ``get_provider_overrides()`` keeps them as two
+        separate entries -- id-less duplicates of the same module collapse
+        into one entry at the settings merge layer, which is a different,
+        already-handled case; see
+        test_get_provider_names_multi_instance_without_ids_falls_back_to_type).
+
+        When ``_get_provider_config()`` is called with the bare TYPE name
+        (e.g. ``"openai"``, as opposed to either instance's id), both entries
+        match on ``p_type == provider_name``. It must resolve to the
+        highest-priority (lowest priority number) instance -- not whichever
+        happens to be first in list order.
+
+        Config-spec-based, priority-aware resolution per amplifier-foundation
+        PR #267 / amplifier-bundle-routing-matrix PR #31.
+        """
+        from amplifier_app_cli.commands.routing import _get_provider_config
+
+        settings = _make_settings(tmp_path)
+        _seed_provider(
+            settings,
+            [
+                {
+                    "module": "provider-openai",
+                    "id": "openai-secondary",
+                    "config": {"priority": 2, "default_model": "wrong-instance"},
+                },
+                {
+                    "module": "provider-openai",
+                    "id": "openai-primary",
+                    "config": {"priority": 1, "default_model": "correct-instance"},
+                },
+            ],
+        )
+
+        config = _get_provider_config("openai", settings)
+
+        assert config is not None, "Expected a config dict, got None"
+        assert config.get("default_model") == "correct-instance", (
+            "_get_provider_config() must resolve to the highest-priority "
+            f"(lowest priority number) instance, got: {config}"
+        )
+
+    def test_selects_highest_priority_when_matched_by_module_name(self, tmp_path):
+        """Same priority-ambiguity bug, but matching via the full module name
+        (e.g. 'provider-anthropic') rather than the bare type name."""
+        from amplifier_app_cli.commands.routing import _get_provider_config
+
+        settings = _make_settings(tmp_path)
+        _seed_provider(
+            settings,
+            [
+                {
+                    "module": "provider-anthropic",
+                    "id": "anthropic-secondary",
+                    "config": {"priority": 5, "default_model": "wrong-instance"},
+                },
+                {
+                    "module": "provider-anthropic",
+                    "id": "anthropic-primary",
+                    "config": {"priority": 1, "default_model": "correct-instance"},
+                },
+            ],
+        )
+
+        config = _get_provider_config("provider-anthropic", settings)
+
+        assert config is not None
+        assert config.get("default_model") == "correct-instance", (
+            f"Expected the priority=1 instance's config, got: {config}"
+        )
+
 
 class TestResolveProviderModule:
     """Tests for _resolve_provider_module() -- BUG 4 fix.


### PR DESCRIPTION
## Summary
- `ProviderManager.get_provider_config()` matched only on `module ==`, returning the first list-order match when 2+ instances of one provider module exist -- confirmed live via a concrete reproduction: seeding two `provider-anthropic` instances at priorities 1 and 2, running the equivalent of `amplifier provider models anthropic` returned the priority-2 instance's config, silently ignoring priority-1. Root cause traced through `_normalize_module_id()` (`commands/provider.py`), which does no id-disambiguation -- it just string-prefixes the user's literal CLI argument, so a bare type name reaches the same ambiguous key check every time.
- `commands/routing.py::_get_provider_config()` had the identical shape (id/type/module triple-equality match, first-match-wins) -- confirmed live via 4 call sites (`_build_model_cache`, `_list_models_for_provider`, `_prompt_provider_and_model`, `_edit_role`), all fed bare provider names from `_get_provider_names()`, which collapses id-less multi-instance entries to a single bare-type entry per its own existing regression test.
- Fix: both functions now collect all matches instead of returning at first match, then select the highest-priority instance (lowest `priority` config value, defaulting to 100 when absent) when 2+ match -- same pattern already shipped in `amplifier-foundation` (PR #267) and `amplifier-bundle-routing-matrix` (PR #31). The existing "genuinely not found -> None" contract is explicitly preserved and covered by regression tests; only the ambiguous-multiple-matches case changed.

## Test plan
- [x] `uv run pytest tests/test_provider_manager.py tests/test_routing_commands.py -q` -- **84 passed**, run independently.
- [x] Red-green regression verified independently: reverting only the two production files (keeping the new tests) makes 3 tests fail with the exact wrong-instance-selected symptom (e.g. `AssertionError: Expected the priority=1 instance's config, got: {'default_model': 'wrong-instance', 'priority': 5}`); restoring the fix makes all 84 pass.
- [x] Full-suite regression: 906 passed baseline vs 910 fixed (exactly +4 new tests); same 30 pre-existing unrelated ImportError-cascade failures on both sides (confirmed via grep, all trace to an unrelated stale `amplifier-foundation` dependency in this workspace, none touch the changed files).
- [x] `python_check` clean on all 4 changed files.

Generated with [Amplifier](https://github.com/microsoft/amplifier)
