### PR TITLE
fix(providers): harden _find_provider_entry against id-less multi-instance collision

### DIFF
--- a/amplifier_app_cli/commands/provider.py
+++ b/amplifier_app_cli/commands/provider.py
@@ -66,23 +66,40 @@ def _find_provider_entry(
     """Find a provider entry by name/id.
 
     Matches against:
-    - 'id' field (for multi-instance providers)
-    - 'module' field stripped of 'provider-' prefix
-    - full 'module' field
+    - 'id' field (for multi-instance providers) -- unambiguous by definition
+      (ids are expected to be unique), so an id match is returned immediately.
+    - 'module' field stripped of 'provider-' prefix, or the full 'module'
+      field -- this can match 2+ instances of the same module when none of
+      them (or multiple of them) have a distinct id set. In that ambiguous
+      case, resolve deterministically to the highest-priority (lowest
+      `config.priority` value, defaulting to 100 when absent) instance
+      instead of whichever happens to be first in list order. Mirrors
+      ProviderManager.get_provider_config() and
+      commands/routing.py::_get_provider_config().
     """
     for p in providers:
-        # Match by id field
         if p.get("id") == name:
             return p
-        # Match by module name (with or without prefix)
-        module = p.get("module", "")
-        if (
+
+    matches: list[dict[str, Any]] = [
+        p
+        for p in providers
+        if (module := p.get("module", ""))
+        and (
             module == name
             or module == f"provider-{name}"
             or _display_name(module) == name
-        ):
-            return p
-    return None
+        )
+    ]
+
+    if not matches:
+        return None
+
+    def _priority(p: dict[str, Any]) -> int:
+        config = p.get("config", {})
+        return config.get("priority", 100) if isinstance(config, dict) else 100
+
+    return min(matches, key=_priority)
 
 
 def _get_max_priority(providers: list[dict[str, Any]]) -> int:

--- a/tests/test_provider_commands.py
+++ b/tests/test_provider_commands.py
@@ -1103,3 +1103,119 @@ class TestRunPFlag:
             f"spark2-gemma should keep original priority 2, "
             f"got {spark2['config']['priority']}"
         )
+
+
+class TestFindProviderEntryPrioritySelection:
+    """BUG 3 regression: ``_find_provider_entry()`` is the third function with
+    the same first-match-wins anti-pattern already fixed twice in this repo
+    (PR #214, for ``ProviderManager.get_provider_config()`` and
+    ``commands/routing.py::_get_provider_config()``).
+
+    It matches on 'id' first (unambiguous, ids are unique), then falls back to
+    matching on the bare/full 'module' name. Nothing enforces that only one
+    id-less (or display-name-colliding) instance of a module exists -- if a
+    user hand-edits settings.yaml to create 2+ such instances, the function
+    silently returns whichever is first in list order instead of being
+    priority-aware, exactly like the two sibling bugs fixed in PR #214.
+
+    Called from provider_remove(), provider_edit(), and provider_test() --
+    all 3 CLI-facing sites where a user types a bare provider type name.
+    """
+
+    def test_selects_highest_priority_instance_not_first_in_list(self):
+        """Two id-less instances of the same module ('anthropic'), with the
+        LOWER priority instance (priority=5) listed BEFORE the HIGHER
+        priority instance (priority=1, lower number = higher precedence).
+        Must resolve to the priority=1 instance, not whichever is first in
+        list order.
+        """
+        from amplifier_app_cli.commands.provider import _find_provider_entry
+
+        providers = [
+            {
+                "module": "provider-anthropic",
+                "config": {"priority": 5, "default_model": "wrong-instance"},
+            },
+            {
+                "module": "provider-anthropic",
+                "config": {"priority": 1, "default_model": "correct-instance"},
+            },
+        ]
+
+        entry = _find_provider_entry(providers, "anthropic")
+
+        assert entry is not None, "Expected a matching entry, got None"
+        assert entry["config"].get("default_model") == "correct-instance", (
+            "_find_provider_entry() must resolve to the highest-priority "
+            f"(lowest priority number) instance, got: {entry}"
+        )
+
+    def test_selects_highest_priority_instance_when_matched_by_full_module_name(
+        self,
+    ):
+        """Same ambiguity, but matching via the full module id
+        ('provider-openai') rather than the bare display name."""
+        from amplifier_app_cli.commands.provider import _find_provider_entry
+
+        providers = [
+            {
+                "module": "provider-openai",
+                "config": {"priority": 3, "default_model": "wrong-instance"},
+            },
+            {
+                "module": "provider-openai",
+                "config": {"priority": 1, "default_model": "correct-instance"},
+            },
+        ]
+
+        entry = _find_provider_entry(providers, "provider-openai")
+
+        assert entry is not None
+        assert entry["config"].get("default_model") == "correct-instance", (
+            f"Expected the priority=1 instance, got: {entry}"
+        )
+
+    def test_id_match_is_unambiguous_and_unaffected_by_priority(self):
+        """Regression guard: matching by an explicit 'id' is unambiguous by
+        definition (ids are unique) and must return that exact entry
+        regardless of priority values on other entries of the same module.
+        """
+        from amplifier_app_cli.commands.provider import _find_provider_entry
+
+        providers = [
+            {
+                "module": "provider-openai",
+                "config": {"priority": 1, "default_model": "unnamed-instance"},
+            },
+            {
+                "id": "openai-2",
+                "module": "provider-openai",
+                "config": {"priority": 99, "default_model": "named-instance"},
+            },
+        ]
+
+        entry = _find_provider_entry(providers, "openai-2")
+
+        assert entry is not None
+        assert entry.get("id") == "openai-2"
+        assert entry["config"].get("default_model") == "named-instance", (
+            f"Expected the id-matched entry, got: {entry}"
+        )
+
+    def test_returns_none_when_no_match_found(self):
+        """Regression guard: the 'genuinely not found' contract must be
+        preserved as None -- all 3 CLI call sites branch on this explicitly
+        for their error messages.
+        """
+        from amplifier_app_cli.commands.provider import _find_provider_entry
+
+        providers = [
+            {
+                "module": "provider-openai",
+                "config": {"priority": 1, "default_model": "gpt-5"},
+            },
+        ]
+
+        entry = _find_provider_entry(providers, "anthropic")
+
+        assert entry is None, f"Expected None for unconfigured module, got: {entry}"


### PR DESCRIPTION
## Summary
- Third instance of the same anti-pattern fixed in this repo this session (after PR #214 fixed the other two sibling functions). `_find_provider_entry()` (commands/provider.py) correctly disambiguates when 2+ instances of one module each have a distinct `id:`, but that's a convention (enforced by provider_add()'s UX prompt), not a contract -- nothing in the code prevents 2+ id-less instances of one module, or a display-name collision, from silently resolving to whichever is first in list order.
- Fix: when multiple entries match ambiguously (no unique id match), select the highest-priority instance (lowest `config.priority`, default 100) instead of first-in-list -- same pattern as PR #214's two functions. The existing "not found -> None" contract used by all 3 CLI-facing call sites (provider_remove/provider_edit/provider_test) is explicitly preserved and covered by regression tests.

## Test plan
- `uv run pytest tests/test_provider_commands.py -k PrioritySelection -v` -- 4 passed, run independently.
- Red-green regression verified independently: reverting only `commands/provider.py` causes 2 of the 4 new tests to fail with the exact wrong-instance-selected symptom (`assert 'wrong-instance' == 'correct-instance'`); restoring the fix passes all 4.
- Full module suite: `uv run pytest tests/test_provider_commands.py -q` -- 41 passed.
- Full-repo regression (git-stash baseline, fix removed / tests present): 912 passed -> 914 passed fixed (exactly +2 new tests), same 30 pre-existing unrelated ImportError-cascade failures on both sides (stale foreign `amplifier-foundation` dependency in this workspace -- confirmed present on `origin/main`, unrelated to changed files).
- `python_check` clean on changed files (3 pre-existing, unrelated pyright/ruff errors on `tests/test_provider_commands.py:912,931` confirmed present verbatim on `origin/main` before this change -- out of scope, untouched by this diff).

Generated with [Amplifier](https://github.com/microsoft/amplifier)