### PR TITLE
fix: restore cumulative session cost on resume

### DIFF
--- a/amplifier_app_cli/cost_history.py
+++ b/amplifier_app_cli/cost_history.py
@@ -1,0 +1,134 @@
+"""Restore cumulative session cost on resume (issue #284).
+
+Session LLM cost is accumulated **in-memory** in each provider module's
+``mount()`` closure (a ``_totals`` dict) and contributed to the kernel's
+``session.cost`` channel. When a session is resumed the provider re-mounts with
+that accumulator back at zero, so the cumulative session-cost counter restarts
+from zero. (Per-turn cost still displays correctly; only the running session
+total is lost.)
+
+This module reads the prior cumulative cost from the session's persisted
+``events.jsonl`` -- every ``llm:response`` event carries ``data.usage.cost_usd``
+-- and re-seeds the running total by registering a synthetic ``session.cost``
+contributor on the *resumed session's own coordinator*. This mirrors the
+``register_contributor`` pattern already used by
+``amplifier_foundation.bridge_child_cost`` to bridge child-session cost into a
+parent.
+
+Design notes:
+- ``register_contributor`` APPENDS (the kernel never overwrites on duplicate
+  name), and ``collect_contributions`` sums every registered contributor. The
+  fresh per-mount provider accumulator starts at zero on resume and only counts
+  turns executed *after* the resume, so the historical contributor and the live
+  provider contributor never double-count the same spend.
+- Everything here is best-effort and must never break session startup: missing
+  or corrupt event files simply yield no restored cost.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from decimal import Decimal
+from decimal import InvalidOperation
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Channel + event/field names defined by the kernel and provider modules.
+SESSION_COST_CHANNEL = "session.cost"
+_LLM_RESPONSE_EVENT = "llm:response"
+
+
+def sum_prior_cost_usd(events_path: Path) -> Decimal | None:
+    """Sum ``cost_usd`` across every ``llm:response`` event in ``events_path``.
+
+    Returns the cumulative cost as a ``Decimal``, or ``None`` when the file is
+    missing/unreadable or contains no cost data. Never raises.
+
+    The file is read one line at a time to stay memory-safe: ``llm:response``
+    lines can be very large (they may carry full request payloads), so parsed
+    events are never all held in memory at once. A cheap substring pre-filter
+    skips JSON-parsing unrelated lines entirely.
+    """
+    if not events_path.is_file():
+        return None
+
+    total: Decimal | None = None
+    try:
+        with events_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if _LLM_RESPONSE_EVENT not in line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if not isinstance(event, dict):
+                    continue
+                if event.get("event") != _LLM_RESPONSE_EVENT:
+                    continue
+
+                data = event.get("data")
+                usage = data.get("usage") if isinstance(data, dict) else None
+                cost = usage.get("cost_usd") if isinstance(usage, dict) else None
+                if cost is None:
+                    continue
+                try:
+                    total = (total or Decimal("0")) + Decimal(str(cost))
+                except (InvalidOperation, ValueError):
+                    continue
+    except OSError:
+        logger.debug(
+            "Could not read events for prior session cost: %s",
+            events_path,
+            exc_info=True,
+        )
+        return None
+
+    return total
+
+
+def restore_session_cost(
+    coordinator: Any,
+    session_id: str,
+    events_path: Path,
+) -> Decimal | None:
+    """Re-seed cumulative session cost on resume via a synthetic contributor.
+
+    Reads the prior cumulative cost from ``events_path`` and, when cost data
+    exists, registers a ``session.cost`` contributor on ``coordinator`` so that
+    ``collect_contributions("session.cost")`` reports the pre-resume total
+    alongside the fresh per-mount provider contributions.
+
+    Returns the restored total (a ``Decimal``), or ``None`` when there was no
+    prior cost to restore or registration failed. Never raises.
+    """
+    prior_total = sum_prior_cost_usd(events_path)
+    if prior_total is None or prior_total <= 0:
+        return None
+
+    try:
+        # Freeze the total into the callback default so it is captured by value,
+        # and stringify to match the provider modules' contributor payloads
+        # (Decimal is not JSON-serializable; sum_cost_usd accepts str or Decimal).
+        coordinator.register_contributor(
+            SESSION_COST_CHANNEL,
+            f"history:{session_id}",
+            lambda total=prior_total: {"cost_usd": str(total)},
+        )
+    except Exception:
+        logger.warning(
+            "Failed to restore prior session cost for %s; continuing without it",
+            session_id,
+            exc_info=True,
+        )
+        return None
+
+    logger.info(
+        "Restored prior session cost $%s for resumed session %s",
+        prior_total,
+        session_id,
+    )
+    return prior_total

--- a/amplifier_app_cli/session_runner.py
+++ b/amplifier_app_cli/session_runner.py
@@ -14,6 +14,7 @@ The canonical initialization order (enforced by this module):
 5. Register mention handling capability
 6. Register session spawning capability
 7. Restore transcript (resume only)
+7.5. Restore cumulative session cost (resume only)
 8. Register approval provider
 
 Philosophy:
@@ -272,6 +273,22 @@ async def create_initialized_session(
             logger.warning(
                 "Context module lacks set_messages - transcript NOT restored"
             )
+
+    # Step 7.5: Restore cumulative session cost (resume only) - issue #284
+    # Provider cost accumulators live in each provider's mount() closure and are
+    # zeroed on resume, so the running session-cost total would otherwise restart
+    # from zero. Re-seed the "session.cost" channel from the persisted
+    # events.jsonl (sibling of transcript.jsonl in the session directory) by
+    # registering a synthetic historical contributor on this session's own
+    # coordinator. Best-effort: never blocks startup.
+    if config.is_resume:
+        from .cost_history import restore_session_cost
+
+        try:
+            events_path = SessionStore().base_dir / session_id / "events.jsonl"
+            restore_session_cost(session.coordinator, session_id, events_path)
+        except Exception:
+            logger.debug("Prior session cost restore skipped", exc_info=True)
 
     # Step 10: Register approval provider (app-layer policy)
     from .approval_provider import CLIApprovalProvider

--- a/tests/test_cost_history.py
+++ b/tests/test_cost_history.py
@@ -1,0 +1,168 @@
+"""Tests for cumulative-session-cost restoration on resume (issue #284).
+
+Covers amplifier_app_cli.cost_history:
+- sum_prior_cost_usd(): parse events.jsonl and sum data.usage.cost_usd
+- restore_session_cost(): register a synthetic session.cost contributor
+
+The persisted event shape mirrors a real llm:response line: cost lives at
+data.usage.cost_usd and is stringified (Decimal is not JSON-serializable).
+"""
+
+import json
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from amplifier_app_cli.cost_history import restore_session_cost
+from amplifier_app_cli.cost_history import sum_prior_cost_usd
+
+
+def _write_events(path, events):
+    """Write a list of event dicts as JSONL to path."""
+    path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
+
+
+def _llm_response(cost, **usage):
+    """Build an llm:response event with cost at data.usage.cost_usd."""
+    usage = {"input_tokens": 10, "output_tokens": 5, **usage}
+    if cost is not None:
+        usage["cost_usd"] = cost
+    return {"event": "llm:response", "data": {"model": "test", "usage": usage}}
+
+
+# --------------------------------------------------------------------------
+# sum_prior_cost_usd
+# --------------------------------------------------------------------------
+
+
+def test_sum_returns_none_for_missing_file(tmp_path):
+    assert sum_prior_cost_usd(tmp_path / "nope.jsonl") is None
+
+
+def test_sum_returns_none_when_no_cost_events(tmp_path):
+    events = tmp_path / "events.jsonl"
+    _write_events(events, [{"event": "session:start", "data": {}}])
+    assert sum_prior_cost_usd(events) is None
+
+
+def test_sum_single_llm_response(tmp_path):
+    events = tmp_path / "events.jsonl"
+    _write_events(events, [_llm_response("0.178059")])
+    assert sum_prior_cost_usd(events) == Decimal("0.178059")
+
+
+def test_sum_multiple_llm_responses(tmp_path):
+    events = tmp_path / "events.jsonl"
+    _write_events(
+        events,
+        [
+            {"event": "session:start", "data": {}},
+            _llm_response("0.10"),
+            {"event": "tool:call", "data": {}},
+            _llm_response("0.05"),
+            _llm_response("0.02"),
+        ],
+    )
+    assert sum_prior_cost_usd(events) == Decimal("0.17")
+
+
+def test_sum_ignores_null_cost_and_bad_lines(tmp_path):
+    events = tmp_path / "events.jsonl"
+    # A malformed JSON line, a null-cost response, and a valid one.
+    content = "\n".join(
+        [
+            "{not valid json",
+            json.dumps(_llm_response(None)),
+            json.dumps(_llm_response("0.03")),
+        ]
+    )
+    events.write_text(content + "\n", encoding="utf-8")
+    assert sum_prior_cost_usd(events) == Decimal("0.03")
+
+
+def test_sum_ignores_cost_on_non_llm_response_events(tmp_path):
+    events = tmp_path / "events.jsonl"
+    # A different event type that happens to carry a usage.cost_usd must be ignored.
+    _write_events(
+        events,
+        [
+            {"event": "other:event", "data": {"usage": {"cost_usd": "9.99"}}},
+            _llm_response("0.04"),
+        ],
+    )
+    assert sum_prior_cost_usd(events) == Decimal("0.04")
+
+
+# --------------------------------------------------------------------------
+# restore_session_cost
+# --------------------------------------------------------------------------
+
+
+def test_restore_registers_history_contributor(tmp_path):
+    events = tmp_path / "events.jsonl"
+    _write_events(events, [_llm_response("0.10"), _llm_response("0.05")])
+
+    coordinator = MagicMock()
+    registered = {}
+
+    def capture_register(channel, name, callback):
+        registered[(channel, name)] = callback
+
+    coordinator.register_contributor = capture_register
+
+    total = restore_session_cost(coordinator, "sess-abc", events)
+
+    assert total == Decimal("0.15")
+    key = ("session.cost", "history:sess-abc")
+    assert key in registered
+    # Contributor payload matches the provider modules' stringified shape.
+    assert registered[key]() == {"cost_usd": "0.15"}
+
+
+def test_restore_no_events_registers_nothing(tmp_path):
+    coordinator = MagicMock()
+    total = restore_session_cost(coordinator, "sess-x", tmp_path / "missing.jsonl")
+    assert total is None
+    coordinator.register_contributor.assert_not_called()
+
+
+def test_restore_zero_cost_registers_nothing(tmp_path):
+    events = tmp_path / "events.jsonl"
+    _write_events(events, [_llm_response("0")])
+    coordinator = MagicMock()
+    total = restore_session_cost(coordinator, "sess-x", events)
+    assert total is None
+    coordinator.register_contributor.assert_not_called()
+
+
+def test_restore_swallows_registration_error(tmp_path):
+    events = tmp_path / "events.jsonl"
+    _write_events(events, [_llm_response("0.10")])
+    coordinator = MagicMock()
+    coordinator.register_contributor.side_effect = RuntimeError("boom")
+    # Must never raise even if the kernel call fails.
+    assert restore_session_cost(coordinator, "sess-x", events) is None
+
+
+def test_restore_and_fresh_provider_sum_without_double_count(tmp_path):
+    """The history contributor + a fresh provider contributor sum correctly.
+
+    Mirrors resume: the provider re-mounts with a zeroed accumulator and only
+    counts NEW turns; the history contributor supplies the pre-resume total.
+    Together they reproduce the true cumulative cost with no double counting.
+    """
+    events = tmp_path / "events.jsonl"
+    _write_events(events, [_llm_response("0.10"), _llm_response("0.05")])
+
+    contributors = []
+    coordinator = MagicMock()
+    coordinator.register_contributor = lambda ch, name, cb: contributors.append(cb)
+
+    restore_session_cost(coordinator, "sess-abc", events)  # history: 0.15
+
+    # Simulate a fresh per-mount provider contributor that recorded one new turn.
+    contributors.append(lambda: {"cost_usd": "0.07"})
+
+    # Reproduce how collect_contributions + sum_cost_usd aggregate the channel:
+    # every registered contributor is summed (str or Decimal payloads accepted).
+    total = sum(Decimal(str(cb()["cost_usd"])) for cb in contributors)
+    assert total == Decimal("0.22")


### PR DESCRIPTION
## Summary

Restores cumulative session LLM cost when a session is resumed. The cost counter currently resets to zero on resume, even though the per-turn cost display remains correct.

**Issue:** microsoft-amplifier/amplifier-support#284

## Root Cause

Each provider module accumulates session cost in-memory inside its `mount()` closure and registers a contributor function that adds the accumulated value to the kernel `session.cost` channel. On resume, the provider re-mounts with a zeroed accumulator, so the running session total restarts from zero.

Per-turn cost display remains correct because it reports only the deltas from turns executed in the current session — but the cumulative counter, which should preserve and build on prior turns, loses history.

## The Fix

Introduced a cost-history bridge (~30 lines, zero changes to provider modules or core):

**New file: `amplifier_app_cli/cost_history.py`**
- `sum_prior_cost_usd(events_path)` streams the session's persisted `events.jsonl` line-by-line (memory-safe) and sums `data.usage.cost_usd` from all `llm:response` events.
- `restore_session_cost(coordinator, session_id, events_path)` re-seeds the resumed session's coordinator by registering a synthetic `session.cost` contributor named `history:<session_id>` that contributes the prior session cost. Mirrors the existing `amplifier_foundation.bridge_child_cost` register_contributor pattern.
- Best-effort, never raises; silently no-ops on missing/malformed events or zero prior cost.

**Edit: `amplifier_app_cli/session_runner.py`**
- Added Step 7.5 in `create_initialized_session()` right after transcript restore.
- Guarded by `config.is_resume` so it only runs on resume.
- Computes events path as `SessionStore().base_dir / session_id / "events.jsonl"`.

**No double-counting:** Register_contributor appends, and the fresh provider accumulator only counts turns executed after resume, so history + live contributions together reproduce the true cumulative total.

## Testing

- `uv run pytest tests/test_cost_history.py` → **11 tests passed**
  - Summing cost from events
  - Summing with malformed/null lines (robust)
  - Ignoring non-llm:response events
  - Contributor registration  
  - Missing/zero cost files handled gracefully
  - Error-swallowing (never raises)
  - Resume scenario: no double-count between history + live

- `python_check` (ruff format+lint, pyright) → **clean** on both new files

- Cost field path confirmed empirically: `data.usage.cost_usd` (stringified decimal) in real `llm:response` events from session.

**Pre-existing note:** `tests/test_cost_bridge.py` fails to collect in a clean `uv sync` env — the installed `amplifier_foundation` 1.0.0 does not export `bridge_child_cost` / `sum_cost_usd`, indicating a pre-existing lockfile/env drift unrelated to this change. The new test is self-contained and does not depend on those exports.

## Follow-up / Out of Scope

The secondary in-memory accumulator `state["prev_total"]` in the `hooks-streaming-ui` module (a separate repository) also resets on resume. On the first post-resume turn, the per-turn delta display may transiently include restored cost (appearing to show an unexpectedly large first turn). Fixing the per-turn display presentation requires a change in that hook module and is out of scope for this app-cli fix, which restores the cumulative session total (the issue's primary complaint).

---

Generated with [Amplifier](https://github.com/microsoft/amplifier)