### PR TITLE
fix(providers): write-back loops must target the entry resolved for reading, not re-match ambiguously

### DIFF
--- a/amplifier_app_cli/commands/provider.py
+++ b/amplifier_app_cli/commands/provider.py
@@ -1086,12 +1086,32 @@ def _manage_edit_provider(
     if entry.get("source"):
         updated_entry["source"] = entry["source"]
 
+    # Update in settings — replace the matching entry in the target scope.
+    #
+    # Same anti-pattern (and same fix) as provider_edit(): the write-back
+    # must target the SAME entry that was resolved for reading, not
+    # independently re-match `name` against each per-scope candidate in
+    # isolation. Here `entry` was selected via list index into the merged,
+    # cross-scope `providers` view (settings.get_provider_overrides()) --
+    # which can itself have already collapsed 2+ id-less same-module
+    # instances into a single deep-merged row (see
+    # AppSettings._merge_provider_lists()). Re-matching `name` per
+    # candidate against the RAW per-scope list
+    # (`_find_provider_entry([p], name)`) discards any tie-break and hits
+    # whichever raw entry happens to be first in list order, regardless of
+    # which instance's values were actually shown to the user.
+    #
+    # Fix: resolve the target entry ONCE against the full scope_providers
+    # list (the same priority-based algorithm used elsewhere), then
+    # replace by object identity.
     name = entry.get("id") or _display_name(module_id)
     scope_providers = settings.get_scope_provider_overrides(scope)
+    target_entry = _find_provider_entry(scope_providers, name)
+
     new_list = []
     replaced = False
     for p in scope_providers:
-        if not replaced and _find_provider_entry([p], name) is not None:
+        if not replaced and target_entry is not None and p is target_entry:
             new_list.append(updated_entry)
             replaced = True
         else:

--- a/amplifier_app_cli/commands/provider.py
+++ b/amplifier_app_cli/commands/provider.py
@@ -598,13 +598,32 @@ def provider_edit(name: str, scope: str) -> None:
     if entry.get("source"):
         updated_entry["source"] = entry["source"]
 
-    # Update in settings — replace the matching entry in the target scope
+    # Update in settings — replace the matching entry in the target scope.
+    #
+    # We must replace the SAME entry that was resolved (by priority) above
+    # for reading, not independently re-match `name` against each candidate
+    # in isolation. Re-matching `_find_provider_entry([p], name)` per
+    # iteration discards the priority tie-break: with 2+ id-less/module-
+    # matching instances, whichever happens to be first in scope_providers
+    # would "match" regardless of which entry was actually read into the
+    # wizard, silently overwriting the wrong instance (see PR history in
+    # resolve_provider_entry()'s docstring for the read-side version of this
+    # anti-pattern).
+    #
+    # Fix: resolve the target entry ONCE against the full scope_providers
+    # list (same priority-based algorithm used for the read above, applied
+    # to this specific scope), then replace by object identity. entry
+    # objects returned by resolve_provider_entry()/_find_provider_entry()
+    # are references into the list passed in — never copies — so identity
+    # comparison against scope_providers is reliable.
     target_scope = cast(Scope, scope)
     scope_providers = settings.get_scope_provider_overrides(target_scope)
+    target_entry = _find_provider_entry(scope_providers, name)
+
     new_list = []
     replaced = False
     for p in scope_providers:
-        if not replaced and _find_provider_entry([p], name) is not None:
+        if not replaced and target_entry is not None and p is target_entry:
             new_list.append(updated_entry)
             replaced = True
         else:

--- a/tests/test_provider_commands.py
+++ b/tests/test_provider_commands.py
@@ -747,6 +747,201 @@ class TestProviderEdit:
         )
 
 
+class TestProviderEditMultiInstance:
+    """Regression tests for the write-back-targets-wrong-entry bug.
+
+    provider_edit() resolves the entry to edit via resolve_provider_entry()
+    (priority-based, unambiguous) for the READ side, but the WRITE-back loop
+    previously re-matched each scope-provider candidate independently via
+    ``_find_provider_entry([p], name)`` on a single-element list -- discarding
+    the priority resolution and updating whichever id-less/module-matching
+    entry happened to be first in list order instead of the entry that was
+    actually read and shown in the wizard.
+
+    Confirmed via live DTU repro: 2 same-module instances, low-priority
+    entry ("wrong-instance") listed first, high-priority entry
+    ("correct-instance") listed second. `provider edit anthropic` correctly
+    READ "correct-instance" into the wizard, but the write-back loop matched
+    and overwrote "wrong-instance" instead -- leaving a duplicate
+    `id: correct-instance` and corrupting "wrong-instance"'s config in place.
+    """
+
+    def _seed_two_instance_scope(self, settings: AppSettings) -> None:
+        """Seed 2 same-module instances directly (bypasses set_provider_override,
+        which dedupes by module and would drop one of them).
+
+        Order matters for reproducing the bug: the low-priority ("less
+        preferred") entry is listed FIRST, the high-priority ("preferred",
+        lower config.priority number wins) entry is listed SECOND -- matching
+        the exact DTU repro list order.
+        """
+        scope_data = {
+            "config": {
+                "providers": [
+                    {
+                        "id": "wrong-instance",
+                        "module": "provider-anthropic",
+                        "config": {
+                            "default_model": "claude-old-wrong",
+                            "api_key": "wrong-key",
+                            "priority": 10,
+                        },
+                    },
+                    {
+                        "id": "correct-instance",
+                        "module": "provider-anthropic",
+                        "config": {
+                            "default_model": "claude-old-correct",
+                            "api_key": "correct-key",
+                            "priority": 1,
+                        },
+                    },
+                ]
+            }
+        }
+        settings._write_scope("global", scope_data)
+
+    def test_provider_edit_ambiguous_multi_instance_updates_resolved_entry(
+        self, tmp_path
+    ):
+        """`provider edit anthropic` (bare type name) must update the entry
+        that was actually resolved for reading (highest priority /
+        lowest config.priority number = "correct-instance"), leaving the
+        other same-module instance ("wrong-instance") completely untouched
+        and producing no duplicate/orphaned entry.
+        """
+        settings = _make_settings(tmp_path)
+        self._seed_two_instance_scope(settings)
+
+        from amplifier_app_cli.commands.provider import provider
+
+        runner = CliRunner()
+        with (
+            patch(
+                "amplifier_app_cli.commands.provider._get_settings",
+                return_value=settings,
+            ),
+            patch("amplifier_app_cli.commands.provider._ensure_providers_ready"),
+            patch(
+                "amplifier_app_cli.commands.provider.configure_provider",
+                return_value={
+                    "default_model": "claude-new",
+                    "api_key": "new-key",
+                },
+            ),
+            patch("amplifier_app_cli.commands.provider.KeyManager"),
+        ):
+            result = runner.invoke(provider, ["edit", "anthropic"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+        providers = settings.get_scope_provider_overrides("global")
+
+        # No duplicate/orphaned entry: exactly 2 entries, unique ids.
+        ids = [p.get("id") for p in providers]
+        assert len(providers) == 2, f"Expected 2 entries, got: {providers}"
+        assert len(set(ids)) == 2, f"Duplicate id created: {providers}"
+        assert set(ids) == {"wrong-instance", "correct-instance"}
+
+        by_id = {p["id"]: p for p in providers}
+
+        # correct-instance (the one actually resolved+shown by the wizard)
+        # must have received the edit.
+        correct = by_id["correct-instance"]
+        assert correct["config"]["default_model"] == "claude-new"
+        assert correct["config"]["api_key"] == "new-key"
+        assert correct["config"]["priority"] == 1  # priority preserved
+
+        # wrong-instance must be completely unchanged.
+        wrong = by_id["wrong-instance"]
+        assert wrong["config"]["default_model"] == "claude-old-wrong"
+        assert wrong["config"]["api_key"] == "wrong-key"
+        assert wrong["config"]["priority"] == 10
+
+    def test_provider_edit_by_distinct_id_unaffected(self, tmp_path):
+        """Regression: editing by an explicit, distinct instance id must
+        continue to update only that instance (unambiguous by definition),
+        leaving the sibling instance untouched.
+        """
+        settings = _make_settings(tmp_path)
+        self._seed_two_instance_scope(settings)
+
+        from amplifier_app_cli.commands.provider import provider
+
+        runner = CliRunner()
+        with (
+            patch(
+                "amplifier_app_cli.commands.provider._get_settings",
+                return_value=settings,
+            ),
+            patch("amplifier_app_cli.commands.provider._ensure_providers_ready"),
+            patch(
+                "amplifier_app_cli.commands.provider.configure_provider",
+                return_value={
+                    "default_model": "claude-new",
+                    "api_key": "new-key",
+                },
+            ),
+            patch("amplifier_app_cli.commands.provider.KeyManager"),
+        ):
+            result = runner.invoke(provider, ["edit", "wrong-instance"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+        providers = settings.get_scope_provider_overrides("global")
+        by_id = {p["id"]: p for p in providers}
+        assert len(providers) == 2
+
+        assert by_id["wrong-instance"]["config"]["default_model"] == "claude-new"
+        assert by_id["wrong-instance"]["config"]["api_key"] == "new-key"
+
+        # correct-instance untouched
+        assert (
+            by_id["correct-instance"]["config"]["default_model"] == "claude-old-correct"
+        )
+        assert by_id["correct-instance"]["config"]["api_key"] == "correct-key"
+
+    def test_provider_edit_single_instance_unaffected(self, tmp_path):
+        """Regression: the normal single-instance case (no ambiguity at all)
+        must still update the sole entry in place.
+        """
+        settings = _make_settings(tmp_path)
+        _seed_provider(
+            settings,
+            "provider-anthropic",
+            {"default_model": "claude-sonnet-4-6", "api_key": "old-key"},
+            priority=1,
+        )
+
+        from amplifier_app_cli.commands.provider import provider
+
+        runner = CliRunner()
+        with (
+            patch(
+                "amplifier_app_cli.commands.provider._get_settings",
+                return_value=settings,
+            ),
+            patch("amplifier_app_cli.commands.provider._ensure_providers_ready"),
+            patch(
+                "amplifier_app_cli.commands.provider.configure_provider",
+                return_value={
+                    "default_model": "claude-opus-4-6",
+                    "api_key": "new-key",
+                },
+            ),
+            patch("amplifier_app_cli.commands.provider.KeyManager"),
+        ):
+            result = runner.invoke(provider, ["edit", "anthropic"])
+
+        assert result.exit_code == 0, f"Output: {result.output}"
+
+        providers = settings.get_scope_provider_overrides("global")
+        assert len(providers) == 1
+        assert providers[0]["config"]["default_model"] == "claude-opus-4-6"
+        assert providers[0]["config"]["api_key"] == "new-key"
+        assert providers[0]["config"]["priority"] == 1
+
+
 # ============================================================
 # Task 10: provider test
 # ============================================================

--- a/tests/test_provider_commands.py
+++ b/tests/test_provider_commands.py
@@ -942,6 +942,238 @@ class TestProviderEditMultiInstance:
         assert providers[0]["config"]["priority"] == 1
 
 
+class TestManageEditProviderMultiInstance:
+    """Regression tests for the identical write-back-targets-wrong-entry bug
+    in `_manage_edit_provider()` (the `provider manage` interactive
+    dashboard's edit path).
+
+    Unlike `provider_edit()`, `_manage_edit_provider()` selects its entry to
+    read via LIST INDEX into the merged, cross-scope `providers` list
+    (`settings.get_provider_overrides()`) -- not by name-based resolution.
+    Two id-less same-module instances get *collapsed into one row* by that
+    merge (AppSettings._merge_provider_lists() treats the later-listed
+    instance as an "overlay" that deep-merges on top of the earlier one),
+    so the merged/displayed entry mostly reflects the second (higher-
+    priority, "correct") instance's values -- confirmed empirically:
+    seeding a low-priority instance first and high-priority instance second
+    in raw settings.yaml, `get_provider_overrides()` returns exactly ONE
+    entry whose fields come from the second ("correct") instance.
+
+    The bug: after editing that single displayed/merged row, the write-back
+    loop derives `name = entry.get("id") or _display_name(module_id)` (here,
+    the bare id-less display name, e.g. "anthropic") and then re-matches
+    `_find_provider_entry([p], name)` independently per candidate in the
+    RAW per-scope list (`settings.get_scope_provider_overrides(scope)`,
+    which still has BOTH instances, unmerged). With no priority tie-break
+    in that per-item re-match, it hits whichever raw entry is first in list
+    order -- silently overwriting the low-priority ("wrong") instance even
+    though the high-priority ("correct") instance's values were what the
+    user actually saw and edited.
+    """
+
+    def _seed_two_id_less_instance_scope(self, settings: AppSettings) -> None:
+        """Seed 2 id-less same-module instances directly into global scope
+        (bypasses set_provider_override, which dedupes by module and would
+        drop one of them). Low-priority ("wrong") listed FIRST, high-
+        priority ("correct") listed SECOND -- the exact list order that
+        makes get_provider_overrides()'s merge favor "correct"'s values
+        for the single collapsed/displayed row.
+        """
+        scope_data = {
+            "config": {
+                "providers": [
+                    {
+                        "module": "provider-anthropic",
+                        "config": {
+                            "default_model": "claude-old-wrong",
+                            "api_key": "wrong-key",
+                            "priority": 10,
+                        },
+                    },
+                    {
+                        "module": "provider-anthropic",
+                        "config": {
+                            "default_model": "claude-old-correct",
+                            "api_key": "correct-key",
+                            "priority": 1,
+                        },
+                    },
+                ]
+            }
+        }
+        settings._write_scope("global", scope_data)
+
+    def test_merged_view_collapses_to_single_correct_leaning_row(self, tmp_path):
+        """Sanity check on the premise: get_provider_overrides() must
+        collapse the 2 id-less same-module instances into exactly one row,
+        and that row's values must come from the higher-priority
+        ("correct") instance (confirms the read-side behavior this test
+        suite's write-back assertions depend on).
+        """
+        settings = _make_settings(tmp_path)
+        self._seed_two_id_less_instance_scope(settings)
+
+        merged = settings.get_provider_overrides()
+        assert len(merged) == 1, f"Expected merge to collapse to 1 row: {merged}"
+        assert merged[0]["config"]["default_model"] == "claude-old-correct"
+        assert merged[0]["config"]["api_key"] == "correct-key"
+
+    def test_manage_edit_provider_updates_correct_instance_not_first_in_scope(
+        self, tmp_path
+    ):
+        """`_manage_edit_provider()` must update the same instance whose
+        values were actually shown to the user (the higher-priority
+        "correct" instance, per the merge premise above) -- not whichever
+        raw per-scope entry happens to be first in list order. The other
+        instance ("wrong") must be completely unchanged, and no
+        duplicate/orphaned entry may be created.
+        """
+        from amplifier_app_cli.commands.provider import _manage_edit_provider
+
+        settings = _make_settings(tmp_path)
+        self._seed_two_id_less_instance_scope(settings)
+
+        # Exactly as provider_manage_loop does: fetch the merged view for
+        # display/selection, then edit index 0 (the only displayed row).
+        providers = settings.get_provider_overrides()
+        assert len(providers) == 1
+
+        with (
+            patch(
+                "amplifier_app_cli.commands.provider.configure_provider",
+                return_value={
+                    "default_model": "claude-new",
+                    "api_key": "new-key",
+                },
+            ),
+            patch("amplifier_app_cli.commands.provider.KeyManager"),
+        ):
+            _manage_edit_provider(settings, "e1", providers, scope="global")
+
+        raw = settings.get_scope_provider_overrides("global")
+        assert len(raw) == 2, f"Expected 2 entries, got: {raw}"
+
+        # No entry may have been dropped or duplicated: exactly one entry
+        # keeps "wrong-key"'s pre-edit values, and exactly one entry
+        # reflects the edit.
+        wrong_matches = [p for p in raw if p["config"].get("api_key") == "wrong-key"]
+        edited_matches = [p for p in raw if p["config"].get("api_key") == "new-key"]
+
+        assert len(wrong_matches) == 1, (
+            f"'wrong' instance was not preserved untouched: {raw}"
+        )
+        assert wrong_matches[0]["config"]["default_model"] == "claude-old-wrong"
+        assert wrong_matches[0]["config"]["priority"] == 10
+
+        assert len(edited_matches) == 1, (
+            f"Expected exactly one entry to receive the edit: {raw}"
+        )
+        assert edited_matches[0]["config"]["default_model"] == "claude-new"
+        # Priority preserved from the entry that was actually resolved/read
+        # (the "correct" instance's priority=1), not the "wrong" instance's.
+        assert edited_matches[0]["config"]["priority"] == 1
+
+    def test_manage_edit_provider_single_instance_unaffected(self, tmp_path):
+        """Regression: the normal single-instance case (no ambiguity at
+        all) must still update the sole entry in place.
+        """
+        from amplifier_app_cli.commands.provider import _manage_edit_provider
+
+        settings = _make_settings(tmp_path)
+        _seed_provider(
+            settings,
+            "provider-anthropic",
+            {"default_model": "claude-sonnet-4-6", "api_key": "old-key"},
+            priority=1,
+        )
+
+        providers = settings.get_provider_overrides()
+        assert len(providers) == 1
+
+        with (
+            patch(
+                "amplifier_app_cli.commands.provider.configure_provider",
+                return_value={
+                    "default_model": "claude-opus-4-6",
+                    "api_key": "new-key",
+                },
+            ),
+            patch("amplifier_app_cli.commands.provider.KeyManager"),
+        ):
+            _manage_edit_provider(settings, "e1", providers, scope="global")
+
+        raw = settings.get_scope_provider_overrides("global")
+        assert len(raw) == 1
+        assert raw[0]["config"]["default_model"] == "claude-opus-4-6"
+        assert raw[0]["config"]["api_key"] == "new-key"
+        assert raw[0]["config"]["priority"] == 1
+
+    def test_manage_edit_provider_by_distinct_id_unaffected(self, tmp_path):
+        """Regression: editing an entry that carries a distinct 'id' remains
+        unambiguous (id match short-circuits in _find_provider_entry) and
+        must continue to update only that instance.
+        """
+        from amplifier_app_cli.commands.provider import _manage_edit_provider
+
+        settings = _make_settings(tmp_path)
+        scope_data = {
+            "config": {
+                "providers": [
+                    {
+                        "id": "wrong-instance",
+                        "module": "provider-anthropic",
+                        "config": {
+                            "default_model": "claude-old-wrong",
+                            "api_key": "wrong-key",
+                            "priority": 10,
+                        },
+                    },
+                    {
+                        "id": "correct-instance",
+                        "module": "provider-anthropic",
+                        "config": {
+                            "default_model": "claude-old-correct",
+                            "api_key": "correct-key",
+                            "priority": 1,
+                        },
+                    },
+                ]
+            }
+        }
+        settings._write_scope("global", scope_data)
+
+        providers = settings.get_provider_overrides()
+        assert len(providers) == 2  # distinct ids -> not collapsed by merge
+
+        # Pick whichever index corresponds to "correct-instance" to edit it.
+        idx = next(
+            i for i, p in enumerate(providers, 1) if p.get("id") == "correct-instance"
+        )
+
+        with (
+            patch(
+                "amplifier_app_cli.commands.provider.configure_provider",
+                return_value={
+                    "default_model": "claude-new",
+                    "api_key": "new-key",
+                },
+            ),
+            patch("amplifier_app_cli.commands.provider.KeyManager"),
+        ):
+            _manage_edit_provider(settings, f"e{idx}", providers, scope="global")
+
+        raw = settings.get_scope_provider_overrides("global")
+        by_id = {p["id"]: p for p in raw}
+        assert len(raw) == 2
+
+        assert by_id["correct-instance"]["config"]["default_model"] == "claude-new"
+        assert by_id["correct-instance"]["config"]["api_key"] == "new-key"
+
+        # wrong-instance untouched
+        assert by_id["wrong-instance"]["config"]["default_model"] == "claude-old-wrong"
+        assert by_id["wrong-instance"]["config"]["api_key"] == "wrong-key"
+
+
 # ============================================================
 # Task 10: provider test
 # ============================================================


### PR DESCRIPTION
## Summary

Discovered during DTU validation of the recent provider-resolution DRY consolidation (#216): two write-back code paths in `commands/provider.py` (`provider_edit()` and `_manage_edit_provider()`) resolve the entry to edit correctly (via `_find_provider_entry`, priority-aware, or via a merged/collapsed view), but then re-match independently against the RAW provider list per candidate during the WRITE-back loop -- calling `_find_provider_entry([p], name)` on a single-element list each iteration, which has no priority to tie-break against. With 2+ same-module instances, this silently writes the edit to whichever raw entry is first in list order, NOT the instance that was actually shown to and edited by the user -- corrupting the wrong entry and leaving orphaned/duplicate data.

Confirmed pre-existing (not a regression from #216) via diff against commit `6986ad8`.

**Fix:** resolve the target entry ONCE (same mechanism already used for reads), then match by object identity (`p is target_entry`) during write-back instead of re-running an ambiguous name-based match per candidate. `_manage_edit_provider()` required additional investigation since its read-side mechanism differs (list-index into a merged/collapsed view via `get_provider_overrides()`'s deep-merge of id-less same-module instances, not name-based lookup) -- confirmed via an empirical probe before fixing, then applied the same identity-based fix mechanism.

## Test plan

- 48 passed (full `test_provider_commands.py`, up from 44 baseline -- 3 new tests for `provider_edit()`'s fix, 4 new tests for `_manage_edit_provider()`'s fix, one shared sanity-check test).
- Red-green regression verified independently: reverting to the commit before both fixes causes both new bug-reproduction tests to fail with the exact wrong-entry-overwritten symptom (config corrupted with the wrong new values); restoring the fix passes all 48.
- Full-suite regression: 41 failed (pre-existing, unrelated environment/dependency issues, byte-identical failure set before/after) / 957 passed baseline -> 961 passed fixed (exactly +4 new tests beyond the first fix's own +3).
- `python_check` clean, no new pyright/ruff issues vs baseline.

Generated with [Amplifier](https://github.com/microsoft/amplifier)