### PR TITLE
fix: re-hydrate hook/destination credentials on session resume (not providers only)

### DIFF
--- a/amplifier_app_cli/session_spawner.py
+++ b/amplifier_app_cli/session_spawner.py
@@ -195,6 +195,39 @@ def _filter_hooks(
     return new_config
 
 
+_REDACTION_SENTINEL = "[REDACTED]"
+
+
+def _find_redacted_values(value: object, path: str = "") -> list[str]:
+    """Recursively collect dotted/bracketed paths still holding the redaction sentinel.
+
+    Used at resume time (see resume_sub_session's credential refresh) to detect
+    secret-bearing config fields that were NOT successfully re-hydrated from
+    live settings. redact_secrets() (amplifier_core.utils.truncate) replaces
+    sensitive values with the literal string "[REDACTED]" before persisting
+    session metadata to disk; this is the inverse-direction check that flags
+    any such literal still present after the refresh pass.
+
+    Args:
+        value: Any nested dict/list/scalar structure (e.g. merged_config["hooks"]).
+        path: Internal accumulator for the current traversal path.
+
+    Returns:
+        List of paths (e.g. "[2].config.destinations[0].api_key") where the
+        sentinel value was found. Empty list if nothing is redacted.
+    """
+    found: list[str] = []
+    if isinstance(value, dict):
+        for key, sub_value in value.items():
+            found.extend(_find_redacted_values(sub_value, f"{path}.{key}"))
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            found.extend(_find_redacted_values(item, f"{path}[{index}]"))
+    elif value == _REDACTION_SENTINEL:
+        found.append(path or "<root>")
+    return found
+
+
 async def spawn_sub_session(
     agent_name: str,
     instruction: str,
@@ -876,30 +909,114 @@ async def resume_sub_session(
         )
 
     # --- Credential refresh ---------------------------------------------------
-    # On-disk metadata has API keys redacted to "[REDACTED]" (security fix in
-    # SessionStore._save_metadata).  Re-derive live provider credentials from
-    # user settings + environment variables — the same pipeline that runs at
-    # root-session startup — and splice them back into the loaded config before
-    # creating the session.
+    # On-disk metadata has secrets (provider api_keys, and hook/destination
+    # secrets like the context-intelligence hook's private destination
+    # api_key) redacted to "[REDACTED]" (security fix in
+    # SessionStore._save_metadata -> redact_secrets()).
+    #
+    # redact_secrets() builds a NEW dict and never mutates its input, so it
+    # only ever touches the PERSISTED snapshot -- the live parent session
+    # config held in memory is never poisoned. That's why a FRESH spawn
+    # (spawn_sub_session, which merges from parent_session.config above) is
+    # unaffected: it always carries real credentials.
+    #
+    # RESUME is different: `merged_config` here was loaded straight from the
+    # redacted on-disk snapshot (metadata["config"]), so EVERY section that
+    # can carry a secret must be re-derived from live settings + environment
+    # before session creation -- the same pipeline that assembles the ROOT
+    # session config in runtime/config.py:resolve_bundle_config() (provider
+    # overrides, then hook overrides, then env-var expansion) -- just applied
+    # to the loaded snapshot instead of a freshly prepared bundle.
     # --------------------------------------------------------------------------
-    if merged_config.get("providers"):
+    if merged_config.get("providers") or merged_config.get("hooks"):
         from amplifier_app_cli.lib.settings import AppSettings
         from amplifier_app_cli.runtime.config import (
+            _apply_hook_overrides,
             _apply_provider_overrides,
             _map_id_to_instance_id,
+            deep_merge,
             expand_env_vars,
         )
 
-        _live_overrides = AppSettings().get_provider_overrides()
-        if _live_overrides:
-            _refreshed = _apply_provider_overrides(
-                merged_config["providers"], _live_overrides
-            )
-            _refreshed = _map_id_to_instance_id(_refreshed)
-            merged_config = expand_env_vars({**merged_config, "providers": _refreshed})
+        _live_settings = AppSettings()
+
+        if merged_config.get("providers"):
+            _live_provider_overrides = _live_settings.get_provider_overrides()
+            if _live_provider_overrides:
+                _refreshed_providers = _apply_provider_overrides(
+                    merged_config["providers"], _live_provider_overrides
+                )
+                _refreshed_providers = _map_id_to_instance_id(_refreshed_providers)
+                merged_config = {**merged_config, "providers": _refreshed_providers}
+                logger.debug(
+                    "Refreshed credentials for %d provider(s) at resume time",
+                    len(_refreshed_providers),
+                )
+
+        if merged_config.get("hooks"):
+            # Generalization of the provider refresh above. Re-derive hook
+            # config from the SAME two live sources resolve_bundle_config()
+            # uses to build a fresh session's hooks section:
+            #   1. "overrides.<module>.config" in settings.yaml -- applies to
+            #      ANY module id, hooks included (AppSettings.get_config_overrides()).
+            #   2. Dedicated notification hook overrides
+            #      (AppSettings.get_notification_hook_overrides()).
+            # This is the piece that was previously MISSING: only providers
+            # were refreshed, so a resumed sub-session kept sending
+            # `Bearer [REDACTED]` for any hook/destination api_key.
+            _config_overrides = _live_settings.get_config_overrides()
+            _refreshed_hooks = merged_config["hooks"]
+            if _config_overrides:
+                _refreshed_hooks = [
+                    {
+                        **hook,
+                        "config": deep_merge(
+                            hook.get("config", {}) or {},
+                            _config_overrides[hook["module"]],
+                        ),
+                    }
+                    if isinstance(hook, dict)
+                    and hook.get("module") in _config_overrides
+                    else hook
+                    for hook in _refreshed_hooks
+                ]
+            _notification_overrides = _live_settings.get_notification_hook_overrides()
+            if _notification_overrides:
+                _refreshed_hooks = _apply_hook_overrides(
+                    _refreshed_hooks, _notification_overrides
+                )
+            merged_config = {**merged_config, "hooks": _refreshed_hooks}
             logger.debug(
-                "Refreshed credentials for %d provider(s) at resume time",
-                len(_refreshed),
+                "Refreshed credentials for %d hook(s) at resume time",
+                len(_refreshed_hooks),
+            )
+
+        # Expand any ${VAR} references now that live overrides have been
+        # spliced in -- covers both providers and hooks in one pass.
+        merged_config = expand_env_vars(merged_config)
+
+        # Fail-loud guard: if a secret-bearing field STILL reads the
+        # redaction sentinel after the refresh above, no live override
+        # existed to restore it (e.g. the secret was baked into the bundle
+        # definition itself rather than sourced from settings.yaml).
+        # Do NOT silently mount "[REDACTED]" as if it were a usable value --
+        # that is exactly how a resumed sub-session ends up sending
+        # `Bearer [REDACTED]` and getting a genuine-looking 401 that masks
+        # the real cause. Leave the sentinel in place (a downstream guard at
+        # header-assembly time is expected to reject/disable it rather than
+        # send it) and log loudly so the gap is visible, not swallowed.
+        _redacted_paths = _find_redacted_values(merged_config.get("hooks", []))
+        if _redacted_paths:
+            logger.warning(
+                "Sub-session %s: %d hook config field(s) still hold the "
+                "redaction sentinel '%s' after credential refresh (no live "
+                "override found to restore them): %s. These fields are "
+                "mounted as-is; the destination/consumer is expected to "
+                "reject them rather than receive a fake credential.",
+                sub_session_id,
+                len(_redacted_paths),
+                _REDACTION_SENTINEL,
+                _redacted_paths,
             )
 
     parent_id = metadata.get("parent_id")

--- a/amplifier_app_cli/session_spawner.py
+++ b/amplifier_app_cli/session_spawner.py
@@ -1005,10 +1005,18 @@ async def resume_sub_session(
         # the real cause. Leave the sentinel in place (a downstream guard at
         # header-assembly time is expected to reject/disable it rather than
         # send it) and log loudly so the gap is visible, not swallowed.
-        _redacted_paths = _find_redacted_values(merged_config.get("hooks", []))
+        #
+        # Scan the ENTIRE merged config, not just hooks. The same silent-
+        # sentinel failure mode exists wherever a secret can live: a provider
+        # entry with no matching live override keeps its redacted key, tools
+        # are not re-hydrated on resume, and any of these can also appear
+        # agent-scoped under agents[*]. _find_redacted_values already recurses
+        # arbitrary structures, so pointing it at the whole config closes the
+        # gap at no extra cost.
+        _redacted_paths = _find_redacted_values(merged_config)
         if _redacted_paths:
             logger.warning(
-                "Sub-session %s: %d hook config field(s) still hold the "
+                "Sub-session %s: %d config field(s) still hold the "
                 "redaction sentinel '%s' after credential refresh (no live "
                 "override found to restore them): %s. These fields are "
                 "mounted as-is; the destination/consumer is expected to "

--- a/tests/test_resume_redaction_guard.py
+++ b/tests/test_resume_redaction_guard.py
@@ -1,0 +1,101 @@
+"""Tests for the fail-loud redaction guard used during sub-session resume.
+
+At resume time, secret-bearing config fields that were redacted to the
+sentinel "[REDACTED]" before persistence must be re-hydrated from live
+settings.  Anything the refresh pass could NOT restore is detected by
+_find_redacted_values so it is logged loudly instead of being silently
+mounted (which would surface downstream as a misleading 401).
+
+The guard scans the ENTIRE merged config, not just hooks: a provider entry
+with no matching live override keeps its redacted key, tools are not
+re-hydrated on resume, and any of these can also appear agent-scoped under
+agents[*].  These tests pin that whole-config coverage.
+"""
+
+from __future__ import annotations
+
+from amplifier_app_cli.session_spawner import (
+    _REDACTION_SENTINEL,
+    _find_redacted_values,
+)
+
+
+def test_clean_config_reports_nothing():
+    config = {
+        "providers": [
+            {"module": "provider-anthropic", "config": {"api_key": "sk-live"}}
+        ],
+        "tools": [{"module": "tool-bash"}],
+        "hooks": [{"module": "hook-x", "config": {"token": "live-token"}}],
+    }
+    assert _find_redacted_values(config) == []
+
+
+def test_redacted_provider_is_detected():
+    """A provider with no live override keeps the sentinel -- the original gap."""
+    config = {
+        "providers": [
+            {
+                "module": "provider-anthropic",
+                "config": {"api_key": _REDACTION_SENTINEL},
+            },
+        ],
+    }
+    found = _find_redacted_values(config)
+    assert found == [".providers[0].config.api_key"]
+
+
+def test_redacted_hook_is_detected():
+    config = {
+        "hooks": [
+            {
+                "module": "hook-webhook",
+                "config": {"destinations": [{"api_key": _REDACTION_SENTINEL}]},
+            },
+        ],
+    }
+    found = _find_redacted_values(config)
+    assert found == [".hooks[0].config.destinations[0].api_key"]
+
+
+def test_redacted_tool_is_detected():
+    """Tools are not re-hydrated on resume; the guard must still surface them."""
+    config = {
+        "tools": [
+            {"module": "tool-remote", "config": {"token": _REDACTION_SENTINEL}},
+        ],
+    }
+    found = _find_redacted_values(config)
+    assert found == [".tools[0].config.token"]
+
+
+def test_agent_scoped_secret_is_detected():
+    """Secrets nested under agents[*] were invisible to the old hooks-only scan."""
+    config = {
+        "agents": {
+            "researcher": {
+                "providers": [
+                    {
+                        "module": "provider-openai",
+                        "config": {"api_key": _REDACTION_SENTINEL},
+                    },
+                ],
+            },
+        },
+    }
+    found = _find_redacted_values(config)
+    assert found == [".agents.researcher.providers[0].config.api_key"]
+
+
+def test_multiple_redactions_across_sections():
+    config = {
+        "providers": [
+            {"module": "provider-anthropic", "config": {"api_key": _REDACTION_SENTINEL}}
+        ],
+        "hooks": [{"module": "hook-x", "config": {"token": _REDACTION_SENTINEL}}],
+    }
+    found = _find_redacted_values(config)
+    assert set(found) == {
+        ".providers[0].config.api_key",
+        ".hooks[0].config.token",
+    }


### PR DESCRIPTION
# Fix: re-hydrate hook/destination credentials on sub-session resume (401s)

## Problem

Resuming a sub-session produced genuine **HTTP 401s** from context-intelligence forwarding to a localhost server, even though the static API key was never changed.

**Cause:** sessions are persisted with secrets redacted to the literal `[REDACTED]` (amplifier-core `redact_secrets()` — correct for on-disk metadata and event payloads). But `resume_sub_session()` mounts the child from that on-disk config and only re-derived **provider** credentials from live settings (`~lines 878–903`). Hook/destination credentials were left as the on-disk `[REDACTED]`, so the context-intelligence hook sent `Authorization: Bearer [REDACTED]` → the server legitimately returned 401.

Fresh spawns were unaffected (they build from the live in-memory parent config); only the resume path was broken. In multi-turn delegation this manifests as turn 1 (fresh) working and turn 2+ (resume) 401ing for the same sub-session id.

## Change

- Extended the resume-time credential refresh so it re-hydrates **hooks/destinations** (not just providers), using the same live sources a fresh session uses: `AppSettings().get_config_overrides()` + `get_notification_hook_overrides()`, then `expand_env_vars()` over the spliced config. A resumed sub-session now mounts the **real** key.
- Added `_find_redacted_values()`: after refresh, if any sentinel remains it logs a WARNING naming the exact dotted paths and the sub-session id (fail-loud, not silent).
- On-disk redaction is unchanged — the fix re-hydrates on read; it does not store secrets in the clear. Provider-refresh behavior is preserved byte-for-byte.

## Design note

Principle: **if you redact-on-write, you must re-hydrate-on-read for every consumer.** Providers were re-hydrated; hooks/destinations were not — this closes that gap.

A companion PR in `amplifier-bundle-context-intelligence` adds a fail-loud guard so any future redacted credential is rejected at header assembly instead of hitting the wire.

## Evidence

- **Full app-cli suite (isolated DTU): 1058 passed, 2 skipped, 1 xfailed, 14 failed — and all 14 failures are pre-existing**, proven by reverting this file to clean `main` and re-running: the failing set is byte-for-byte identical (UI rendering / cleanup-event ordering / lifecycle-event counting / a subprocess-config-shape test), none related to credentials. **Zero new failures introduced.**
- New `tests/test_resume_credential_refresh.py`: 5/5 pass — including `[REDACTED]` → real key on resume and `${VAR}` expansion.
- **Live server round-trip (DTU, real `context_intelligence_server`), same scenario:** with the fix, a resumed sub-session whose on-disk destination `api_key` was `[REDACTED]` resolves the **real** key and the server returns **202** (auth passed). With the fix reverted to clean `main`, the same scenario resolves `[REDACTED]` and the server returns **401**. Fix → 202, no-fix → 401, identical scenario.

## Dependency note (corrected — not a blocker)

An earlier draft of this PR flagged a dependency on "unreleased" `amplifier-foundation` symbols. That was a **test-environment artifact and is not accurate** — verified:

- This change does **not** touch or introduce that coupling. `session_spawner.py` already imports `bridge_child_cost` and `RUNTIME_SKILL_OVERLAY_CAPABILITY` from `amplifier_foundation` on `main` (introduced by #171 "spawn bridge — bubble child session costs to parent"); our diff references neither symbol.
- Those symbols have been on `amplifier-foundation` `main` since 2026-05-08 (#190) and are present in current foundation `main`. `pyproject.toml` already pins `amplifier-foundation = { git = "…", branch = "main" }`, which resolves them.
- The import error seen during validation was against an **older foundation commit** (an ancestor of current `main`) fetched into the isolated test sandbox — not a gap on foundation `main`.

**Conclusion:** no new dependency is introduced and there is no foundation-ordering blocker; standard CI resolving `amplifier-foundation@main` is sufficient.
