### PR TITLE
fix: honor external cancellation in arbiter-abort branch instead of swallowing it

### DIFF
--- a/amplifier_app_cli/steering_input.py
+++ b/amplifier_app_cli/steering_input.py
@@ -349,6 +349,12 @@ class SteeringInputManager:
         else:
             _message = None  # not used in the test / injected path
 
+        # Tracks the current child input task (if any) so the outer
+        # ``finally`` below can guarantee it is never left orphaned — see
+        # that block for why this is necessary in addition to the explicit
+        # cancel+await branches inside the poll loop.
+        prompt_task: asyncio.Task[str | None] | None = None
+
         try:
             while not self._stop_event.is_set():
                 # Suspend during approval — yield stdin to Confirm.ask.
@@ -359,9 +365,7 @@ class SteeringInputManager:
                 # Launch input as a cancellable task so we can abort it when
                 # approval starts mid-prompt or stop_event fires.
                 if self._input_provider is not None:
-                    prompt_task: asyncio.Task[str | None] = asyncio.create_task(
-                        self._input_provider()
-                    )
+                    prompt_task = asyncio.create_task(self._input_provider())
                 else:
                     assert self._pt_session is not None
                     prompt_task = asyncio.create_task(
@@ -467,3 +471,29 @@ class SteeringInputManager:
 
         finally:
             self._pt_session = None
+            # Orphan-prevention net (see the module docstring's "Teardown"
+            # note and the ``prompt_task`` comment above): cancellation
+            # delivered to run() overwhelmingly lands at the bare
+            # ``await asyncio.sleep(0.05)`` in the inner poll loop above —
+            # a point with no cleanup logic of its own — rather than at one
+            # of the three explicit cancel+await branches inside that loop.
+            # When that happens, control skips straight from the interrupted
+            # await to this ``finally``, leaving ``prompt_task`` alive and
+            # still holding prompt_toolkit's raw_mode() terminal context.
+            # This block is the single, unconditional backstop: whatever
+            # path got us here (return, break, normal fall-through, or a
+            # propagating CancelledError/other exception), any live
+            # prompt_task is cancelled and awaited before run() truly exits.
+            # Safe to run even when the explicit branches already handled
+            # cleanup (prompt_task.done() is then True and this is a no-op),
+            # and safe to await here even while a CancelledError is actively
+            # propagating out of this function (a single external cancel
+            # request delivers exactly one CancelledError at the interrupted
+            # await; further awaits in ``finally`` proceed normally unless
+            # cancelled again).
+            if prompt_task is not None and not prompt_task.done():
+                prompt_task.cancel()
+                try:
+                    await prompt_task
+                except (asyncio.CancelledError, KeyboardInterrupt, Exception):
+                    pass

--- a/amplifier_app_cli/steering_input.py
+++ b/amplifier_app_cli/steering_input.py
@@ -464,11 +464,37 @@ class SteeringInputManager:
                         prompt_task.cancel()
                         try:
                             await prompt_task
-                        except (
-                            asyncio.CancelledError,
-                            KeyboardInterrupt,
-                            EOFError,
-                        ):
+                        except asyncio.CancelledError:
+                            # Distinguish "prompt_task itself finished
+                            # cancelling" (expected -- we just cancelled it
+                            # above as part of the normal abort-for-approval
+                            # flow) from "run()'s OWN task was externally
+                            # cancelled while suspended at this await" (must
+                            # be honored, not swallowed).
+                            # Task.cancelling() (3.11+) reports the number of
+                            # pending cancellation requests on the CURRENT
+                            # task specifically -- it is 0 here in the normal
+                            # case (only prompt_task was cancelled), but > 0
+                            # if something called .cancel() on run()'s own
+                            # task while it was suspended right here. Without
+                            # this check, that external cancellation would be
+                            # silently absorbed (classic asyncio anti-pattern:
+                            # catching CancelledError without re-raising does
+                            # not cancel the enclosing task, it just
+                            # continues running) and run() would fall through
+                            # to the "wait for approval to finish" loop below
+                            # -- hanging indefinitely if stop_event is never
+                            # set and approval never ends, relying entirely
+                            # on the caller's stop_event-before-cancel()
+                            # ordering convention instead of being
+                            # self-defending. Re-raising here lets the
+                            # cancellation propagate normally per asyncio's
+                            # expected contract, regardless of caller
+                            # ordering.
+                            current = asyncio.current_task()
+                            if current is not None and current.cancelling():
+                                raise
+                        except (KeyboardInterrupt, EOFError):
                             pass
                         # Wait for approval to finish before restarting.
                         while (

--- a/amplifier_app_cli/steering_input.py
+++ b/amplifier_app_cli/steering_input.py
@@ -495,5 +495,5 @@ class SteeringInputManager:
                 prompt_task.cancel()
                 try:
                     await prompt_task
-                except (asyncio.CancelledError, KeyboardInterrupt, Exception):
-                    pass
+                except (asyncio.CancelledError, KeyboardInterrupt, Exception) as exc:
+                    logger.debug("Orphan prompt_task cleanup error: %s", exc)

--- a/amplifier_app_cli/steering_input.py
+++ b/amplifier_app_cli/steering_input.py
@@ -537,6 +537,12 @@ class SteeringInputManager:
                     # Safety net: should not be raised with the current
                     # PromptSession(interrupt_exception=_CtrlCInterrupt) setup,
                     # but kept in case a future code path reaches this point.
+                    # Mirrors the _CtrlCInterrupt branch above exactly -- if
+                    # this safety net is ever actually exercised, a Ctrl-C
+                    # must still forward to session.coordinator.cancellation
+                    # the same way, or the bug just fixed above would
+                    # silently reappear on this path.
+                    self._handle_ctrl_c()
                     continue
                 except EOFError:
                     # Ctrl-D: user is done with steering input.

--- a/amplifier_app_cli/steering_input.py
+++ b/amplifier_app_cli/steering_input.py
@@ -216,6 +216,69 @@ class SteeringInputManager:
                 pass  # App not running or already cleaned up; non-fatal
 
     # ------------------------------------------------------------------
+    # Ctrl-C forwarding (see the module docstring's "Ctrl-C / SIGINT"
+    # section and the ``except _CtrlCInterrupt`` clause in ``run()``)
+    # ------------------------------------------------------------------
+
+    def _handle_ctrl_c(self) -> None:
+        """Forward a steering-prompt Ctrl-C to ``session.coordinator.cancellation``.
+
+        Mirrors ``_execute_with_interrupt``'s ``sigint_handler`` in
+        ``main.py`` *exactly* -- same escalation (first Ctrl-C this turn ->
+        ``request_graceful()``, a subsequent one -> ``request_immediate()``)
+        and the same visible console messages -- because a physical Ctrl-C
+        pressed while this prompt holds ``raw_mode()`` never reaches that
+        OS-signal handler at all (``raw_mode()`` clears ``ISIG`` along with
+        ``ECHO``/``ICANON``, so the ``\\x03`` byte never becomes a
+        kernel-delivered ``SIGINT`` while the steering prompt has focus).
+
+        Operates on ``self._session.coordinator.cancellation`` -- the SAME
+        shared ``CancellationToken`` object ``_execute_with_interrupt``'s own
+        poll loop reads (``cancellation.is_immediate``) to decide whether to
+        cancel the running ``execute_task``. Because both paths mutate the
+        identical object, the downstream effect (whether the turn actually
+        stops, and how) is identical regardless of which path caught the
+        keypress -- no separate turn-cancellation wiring is needed here.
+
+        Defensive: silently does nothing if ``self._session`` is ``None``
+        (back-compat for callers/tests that don't wire a session -- the
+        pre-fix behavior) or if ``session.coordinator.cancellation`` is
+        unavailable/misbehaves for any reason (logged at debug, never
+        raised -- must not crash the steering loop).
+        """
+        if self._session is None:
+            return
+        try:
+            cancellation = self._session.coordinator.cancellation
+        except Exception as exc:
+            logger.debug("Steering Ctrl-C: no cancellation token available: %s", exc)
+            return
+
+        try:
+            if cancellation.is_cancelled:
+                # Second (or later) Ctrl-C this turn - request immediate
+                # cancellation. Message matches sigint_handler's verbatim.
+                cancellation.request_immediate()
+                self._console.print("\n[bold red]Cancelling immediately...[/bold red]")
+            else:
+                # First Ctrl-C this turn - request graceful cancellation.
+                # Message matches sigint_handler's verbatim, including the
+                # running-tools variant.
+                cancellation.request_graceful()
+                running_tools = cancellation.running_tool_names
+                if running_tools:
+                    tools_str = ", ".join(running_tools)
+                    self._console.print(
+                        f"\n[yellow]Stopping after current operation in [bold]{tools_str}[/bold]... (Ctrl+C again to force)[/yellow]"
+                    )
+                else:
+                    self._console.print(
+                        "\n[yellow]Stopping after current operation completes... (Ctrl+C again to force)[/yellow]"
+                    )
+        except Exception as exc:
+            logger.debug("Steering Ctrl-C cancellation forwarding failed: %s", exc)
+
+    # ------------------------------------------------------------------
     # Prompt message (callable passed to prompt_toolkit as ``message=``)
     # ------------------------------------------------------------------
 
@@ -445,11 +508,30 @@ class SteeringInputManager:
                     # PromptSession raised _CtrlCInterrupt (not KeyboardInterrupt)
                     # so asyncio's task machinery stores it normally and does NOT
                     # re-raise, allowing this except clause to be reached.
-                    # The OS SIGINT was handled by sigint_handler in
-                    # _execute_with_interrupt (kept active via handle_sigint=False),
-                    # which updated the cancellation token.  The poll loop in
-                    # _execute_with_interrupt will detect the cancellation on its
-                    # next 50 ms tick and cancel execute_task.
+                    #
+                    # IMPORTANT: the OS SIGINT does NOT reach sigint_handler here.
+                    # prompt_toolkit's raw_mode() (active for the entire duration
+                    # the steering prompt holds focus) clears ISIG along with
+                    # ECHO/ICANON on the tty (see
+                    # prompt_toolkit.input.vt100.raw_mode._patch_lflag), so a
+                    # physical Ctrl-C keypress never generates a kernel-delivered
+                    # SIGINT while this prompt is active -- it arrives ONLY as
+                    # the raw ``\x03`` byte, consumed entirely by this except
+                    # clause. Confirmed empirically (real pty + real
+                    # CancellationToken harness, and live in a running CLI
+                    # session): before this forwarding call, a Ctrl-C pressed
+                    # mid-turn had NO effect on cancellation at all -- the turn
+                    # ran to full completion as if nothing had been pressed.
+                    #
+                    # _handle_ctrl_c() mirrors _execute_with_interrupt's
+                    # sigint_handler escalation exactly (same
+                    # request_graceful()/request_immediate() calls on the SAME
+                    # shared session.coordinator.cancellation object, same
+                    # visible console messages), so the downstream effect is
+                    # identical regardless of which path caught the keypress:
+                    # main.py's execute-task poll loop reacts to
+                    # cancellation.is_immediate the same way either way.
+                    self._handle_ctrl_c()
                     continue
                 except KeyboardInterrupt:
                     # Safety net: should not be raised with the current

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,9 @@ amplifier-foundation = { git = "https://github.com/microsoft/amplifier-foundatio
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = "--import-mode=importlib"
+addopts = "--import-mode=importlib -m \"not integration\""
 asyncio_mode = "strict"
+markers = [
+    "integration: marks tests that fork a real pty child process and probe real termios state (deselected by default; run with '-m integration')",
+]
 

--- a/tests/test_ctrlc_functional_integration.py
+++ b/tests/test_ctrlc_functional_integration.py
@@ -1,0 +1,412 @@
+"""Integration tests: real pty + real CancellationToken proof that a physical
+Ctrl-C keypress during a mid-turn steering prompt actually cancels the turn.
+
+Background
+~~~~~~~~~~
+A physical Ctrl-C keypress during an active turn does NOT generate a real OS
+``SIGINT`` while the steering prompt holds ``prompt_toolkit``'s
+``raw_mode()`` -- ``raw_mode()`` clears ``ISIG`` along with ``ECHO``/
+``ICANON`` on the tty (``prompt_toolkit.input.vt100.raw_mode._patch_lflag``),
+so the ``\\x03`` byte never becomes a kernel-delivered ``SIGINT`` while this
+prompt has focus. It is consumed entirely by the steering ``PromptSession``'s
+``interrupt_exception=_CtrlCInterrupt`` key binding and caught by
+``SteeringInputManager.run()``'s ``except _CtrlCInterrupt`` clause.
+
+Before the fix, that clause silently ``continue``d: no console feedback, and
+``session.coordinator.cancellation`` was never touched -- a real turn ran to
+full completion as if Ctrl-C had never been pressed (confirmed both via this
+harness and live in a running CLI session).
+
+The fix (``SteeringInputManager._handle_ctrl_c()``) forwards a
+``_CtrlCInterrupt`` to ``self._session.coordinator.cancellation`` with the
+SAME graceful-then-immediate escalation and the SAME visible console
+messages as ``main.py``'s OS-signal ``sigint_handler`` in
+``_execute_with_interrupt``. Because both paths mutate the identical shared
+``CancellationToken`` object that ``_execute_with_interrupt``'s own poll loop
+reads (``cancellation.is_immediate``) to decide whether to force-cancel the
+running ``execute_task``, the downstream effect is identical regardless of
+which path caught the keypress.
+
+These tests run the REAL ``SteeringInputManager`` and the REAL
+``amplifier_core.cancellation.CancellationToken`` inside a real forked pty
+child process (not mocked event-loop internals), driving a long-running fake
+"execute_task" (standing in for ``session.execute()``) through the exact
+poll-loop pattern ``_execute_with_interrupt`` uses, and assert on the
+FUNCTIONAL outcome: did the cancellation token's state change, was the
+running task actually force-cancelled, how long did it take -- not just
+termios state (that is covered separately by
+``test_terminal_echo_integration.py``).
+
+Marked ``@pytest.mark.integration`` for the same reason as
+``test_terminal_echo_integration.py``: forks a real process and allocates a
+real pty pair. Run explicitly with::
+
+    pytest -m integration tests/test_ctrlc_functional_integration.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pty
+import signal
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Long enough that "ran to completion untouched" and "force-cancelled early"
+# are unambiguous outcomes at the timing granularities used below.
+FAKE_TASK_DURATION = 3.0
+
+
+def _child_main(scenario: str, result_path: str, ready_path: str) -> None:
+    """Runs inside the forked pty child. Mirrors main.py's
+    ``_execute_with_interrupt`` structure with a fake long-running
+    execute_task standing in for ``session.execute()``, and writes a JSON
+    result describing the functional outcome to ``result_path`` before
+    exiting.
+
+    Writes ``ready_path`` the instant ``raw_mode()`` is actually entered
+    (prompt_toolkit's ``Application.run_async()``, called from the
+    steering prompt's ``prompt_async()``) -- this is the deterministic
+    readiness signal the parent waits on before sending any keystrokes,
+    instead of a fixed sleep. This matters here specifically (unlike the
+    termios-only tests) because sending the ``\\x03`` byte too early --
+    before ``raw_mode()`` has cleared ``ISIG`` -- delivers a REAL kernel
+    SIGINT instead of the raw byte, which would be caught by this script's
+    OWN bare ``sigint_handler`` mirror (no console message) rather than by
+    ``SteeringInputManager``'s ``_CtrlCInterrupt`` path (which prints a
+    message) -- silently testing the wrong code path and flaking under
+    slower startup conditions (e.g. running under pytest's import/collection
+    overhead vs. a bare script).
+    """
+    # Re-derive sys.stdin/stdout/stderr from the raw fds BEFORE any other
+    # imports. This process was created via ``pty.fork()``, which connects
+    # fds 0/1/2 to the pty slave at the OS level -- but the forked child's
+    # Python-level ``sys.stdin``/``sys.stdout``/``sys.stderr`` objects are
+    # inherited by value from the parent (this test) process's memory at
+    # fork time. Under a test runner that captures/replaces those objects
+    # (e.g. pytest's default output capturing), the inherited objects do
+    # NOT necessarily behave like a real terminal stream even though the
+    # underlying fds are correct, which can cause prompt_toolkit's
+    # tty-detection/raw-mode setup to behave differently than it would in
+    # a bare script invocation. Rebuilding them from the raw fds makes this
+    # child's behavior deterministic regardless of the parent's I/O
+    # capturing configuration.
+    sys.stdin = os.fdopen(0, "r", closefd=False)
+    sys.stdout = os.fdopen(1, "w", closefd=False)
+    sys.stderr = os.fdopen(2, "w", closefd=False)
+
+    import asyncio
+
+    from amplifier_core.cancellation import CancellationToken
+    from prompt_toolkit.input import vt100 as pt_vt100
+    from prompt_toolkit.patch_stdout import patch_stdout
+
+    from amplifier_app_cli.steering_input import SteeringInputManager
+
+    _orig_raw_enter = pt_vt100.raw_mode.__enter__
+
+    def _traced_raw_enter(self):
+        result = _orig_raw_enter(self)
+        Path(ready_path).write_text("ready")
+        return result
+
+    pt_vt100.raw_mode.__enter__ = _traced_raw_enter
+
+    messages: list[str] = []
+
+    class _RecordingConsole:
+        def print(self, *a, **_k):
+            if a:
+                messages.append(str(a[0]))
+
+    class _FakeCoordinator:
+        def __init__(self, cancellation_token):
+            self.cancellation = cancellation_token
+
+    class _FakeSession:
+        """Exposes only what SteeringInputManager needs:
+        ``.coordinator.cancellation`` -- the SAME CancellationToken instance
+        main.py's own execute-task poll loop would read in production.
+        """
+
+        def __init__(self, cancellation_token):
+            self.coordinator = _FakeCoordinator(cancellation_token)
+
+    async def fake_execute_task(duration: float) -> str:
+        """Stands in for ``session.execute(prompt_text)``: a single
+        long-running coroutine with no cancellation-token polling of its
+        own (that's the orchestrator's job in the real system) -- the only
+        thing that can stop it early is asyncio-level `.cancel()` from the
+        OUTER poll loop below, mirroring main.py's
+        ``_execute_with_interrupt`` (~lines 2868-2873).
+        """
+        await asyncio.sleep(duration)
+        return "fake response"
+
+    async def run_scenario() -> dict:
+        cancellation = CancellationToken()
+
+        def sigint_handler(signum, frame):
+            """Verbatim mirror of main.py's sigint_handler -- exercises the
+            OS-signal path for scenarios that send a real SIGINT.
+            """
+            if cancellation.is_cancelled:
+                cancellation.request_immediate()
+            else:
+                cancellation.request_graceful()
+
+        original_handler = signal.signal(signal.SIGINT, sigint_handler)
+
+        stop_event = asyncio.Event()
+
+        class _FakeArbiter:
+            approval_active = False
+
+        manager = SteeringInputManager(
+            steer_cap=lambda text: None,
+            arbiter=_FakeArbiter(),
+            stop_event=stop_event,
+            console=_RecordingConsole(),
+            session=_FakeSession(cancellation),
+        )
+
+        t_start = asyncio.get_event_loop().time()
+        task_cancelled = False
+        with patch_stdout(raw=True):
+            reader_task = asyncio.create_task(manager.run())
+            try:
+                execute_task = asyncio.create_task(
+                    fake_execute_task(FAKE_TASK_DURATION)
+                )
+
+                # Verbatim mirror of main.py's poll loop: ONLY checks
+                # is_immediate, every 50ms.
+                while not execute_task.done():
+                    if cancellation.is_immediate:
+                        execute_task.cancel()
+                        task_cancelled = True
+                        break
+                    await asyncio.sleep(0.05)
+
+                try:
+                    await execute_task
+                except asyncio.CancelledError:
+                    task_cancelled = True
+            finally:
+                stop_event.set()
+                reader_task.cancel()
+                try:
+                    await reader_task
+                except asyncio.CancelledError:
+                    pass
+
+        elapsed = asyncio.get_event_loop().time() - t_start
+        signal.signal(signal.SIGINT, original_handler)
+
+        return {
+            "scenario": scenario,
+            "elapsed": elapsed,
+            "state": cancellation.state,
+            "is_cancelled": cancellation.is_cancelled,
+            "is_immediate": cancellation.is_immediate,
+            "task_cancelled": task_cancelled,
+            "messages": messages,
+        }
+
+    result = asyncio.run(run_scenario())
+    Path(result_path).write_text(json.dumps(result))
+
+
+def _run_pty_scenario(scenario: str, timeout: float = 8.0) -> dict:
+    result_path = f"/tmp/test_ctrlc_functional_{scenario}_{os.getpid()}.json"
+    ready_path = f"/tmp/test_ctrlc_functional_ready_{scenario}_{os.getpid()}.marker"
+    for p in (result_path, ready_path):
+        if os.path.exists(p):
+            os.remove(p)
+
+    pid, master_fd = pty.fork()
+    if pid == 0:
+        sys.path.insert(0, str(REPO_ROOT))
+        try:
+            _child_main(scenario, result_path, ready_path)
+        except BaseException:
+            os._exit(1)
+        os._exit(0)
+
+    # Wait for the deterministic readiness signal (raw_mode actually
+    # entered) instead of a fixed sleep -- see _child_main's docstring for
+    # why sending keystrokes before raw_mode clears ISIG would silently
+    # test the wrong code path (a real kernel SIGINT instead of the raw
+    # byte).
+    ready_deadline = time.time() + 5.0
+    while not os.path.exists(ready_path):
+        if time.time() > ready_deadline:
+            raise TimeoutError(
+                f"child never signaled raw_mode readiness for scenario={scenario!r}"
+            )
+        time.sleep(0.01)
+    # Tiny settle margin: raw_mode.__enter__ has returned, but give
+    # prompt_toolkit's own input-reader registration a moment to actually
+    # start polling the fd before we write to it.
+    time.sleep(0.05)
+
+    def send(text: str) -> None:
+        os.write(master_fd, text.encode())
+
+    if scenario == "single_ctrlc":
+        # One physical \x03 keypress, NO real OS signal at all -- the exact
+        # keystroke a user's terminal sends while raw_mode() has ISIG off.
+        send("\x03")
+    elif scenario == "double_ctrlc":
+        # Two keypresses, NO real signal -- proves the keystroke-only path
+        # escalates graceful -> immediate on its own.
+        send("\x03")
+        time.sleep(0.1)
+        send("\x03")
+    elif scenario == "typing_then_ctrlc":
+        # Ctrl-C arrives mid-compose of a steer message.
+        send("hello wor")
+        time.sleep(0.1)
+        send("\x03")
+    elif scenario == "sigint_only":
+        # Regression: the pre-existing real-OS-signal path must still work.
+        try:
+            os.kill(pid, signal.SIGINT)
+        except ProcessLookupError:
+            pass
+
+    deadline = time.time() + timeout
+    exited = False
+    while time.time() < deadline:
+        try:
+            wpid, _status = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            exited = True
+            break
+        if wpid == pid:
+            exited = True
+            break
+        time.sleep(0.05)
+
+    if not exited:
+        try:
+            os.kill(pid, signal.SIGKILL)
+            os.waitpid(pid, 0)
+        except ProcessLookupError:
+            pass
+
+    os.set_blocking(master_fd, False)
+    try:
+        for _ in range(20):
+            try:
+                chunk = os.read(master_fd, 65536)
+            except (BlockingIOError, OSError):
+                break
+            if not chunk:
+                break
+    except OSError:
+        pass
+    os.close(master_fd)
+
+    if not os.path.exists(result_path):
+        return {
+            "scenario": scenario,
+            "exited_cleanly": False,
+            "error": "no result file written",
+        }
+
+    result = json.loads(Path(result_path).read_text())
+    result["exited_cleanly"] = exited
+    os.remove(result_path)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_single_ctrlc_requests_graceful_cancellation():
+    """Headline proof (part 1): ONE physical Ctrl-C keypress during a turn,
+    with NO OS signal involved at all, must move
+    session.coordinator.cancellation to the graceful state and print the
+    same feedback sigint_handler prints on a first Ctrl-C.
+
+    Before the fix: state stayed 'none', is_cancelled was False, and the
+    fake task ran to full completion untouched (confirmed via this same
+    scenario in the prior investigation pass).
+    """
+    result = _run_pty_scenario("single_ctrlc")
+    assert result.get("exited_cleanly"), f"child did not exit cleanly: {result}"
+    assert result["state"] == "graceful", (
+        f"expected graceful cancellation, got: {result}"
+    )
+    assert result["is_cancelled"] is True
+    assert any("Stopping after current operation" in m for m in result["messages"]), (
+        f"expected sigint_handler's first-Ctrl-C message, got messages={result['messages']!r}"
+    )
+    # A single Ctrl-C only requests graceful -- matches production semantics
+    # exactly (only a SECOND Ctrl-C forces is_immediate, which is what the
+    # execute-task poll loop actually checks) -- so the fake task should run
+    # to (approximately) full completion, not be force-cancelled early.
+    assert result["task_cancelled"] is False
+    assert result["elapsed"] >= FAKE_TASK_DURATION * 0.9
+
+
+def test_double_ctrlc_requests_immediate_cancellation_and_stops_the_task():
+    """Headline proof (part 2): TWO physical Ctrl-C keypresses, still with
+    NO OS signal at all, must escalate to immediate cancellation AND
+    actually force-cancel the running task -- the identical downstream
+    effect a real double OS SIGINT produces today.
+    """
+    result = _run_pty_scenario("double_ctrlc")
+    assert result.get("exited_cleanly"), f"child did not exit cleanly: {result}"
+    assert result["state"] == "immediate", (
+        f"expected immediate cancellation, got: {result}"
+    )
+    assert result["is_cancelled"] is True
+    assert result["is_immediate"] is True
+    assert any("Cancelling immediately" in m for m in result["messages"]), (
+        f"expected sigint_handler's second-Ctrl-C message, got messages={result['messages']!r}"
+    )
+    # The task must have actually been force-cancelled, not merely flagged.
+    assert result["task_cancelled"] is True, (
+        f"expected the fake task to be force-cancelled: {result}"
+    )
+    assert result["elapsed"] < FAKE_TASK_DURATION * 0.9, (
+        f"expected the task to stop well before its full duration: {result}"
+    )
+
+
+def test_ctrlc_mid_compose_still_forwards_to_cancellation():
+    """A Ctrl-C that interrupts an in-progress steer compose (user was
+    mid-typing) must still forward to cancellation -- not be absorbed by
+    the compose buffer.
+    """
+    result = _run_pty_scenario("typing_then_ctrlc")
+    assert result.get("exited_cleanly"), f"child did not exit cleanly: {result}"
+    assert result["state"] == "graceful", (
+        f"expected graceful cancellation, got: {result}"
+    )
+    assert result["is_cancelled"] is True
+
+
+def test_sigint_only_regression_still_works():
+    """Regression: the pre-existing real-OS-SIGINT path (main.py's
+    sigint_handler, exercised outside the steering prompt's raw_mode focus
+    window) must be unaffected by this fix.
+    """
+    result = _run_pty_scenario("sigint_only")
+    assert result.get("exited_cleanly"), f"child did not exit cleanly: {result}"
+    assert result["state"] == "graceful", (
+        f"expected graceful cancellation, got: {result}"
+    )
+    assert result["is_cancelled"] is True

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -958,6 +958,111 @@ async def test_steering_ctrl_c_without_session_does_not_crash():
         pass
 
 
+def test_run_keyboard_interrupt_branch_calls_handle_ctrl_c():
+    """Symmetric guard: the ``except KeyboardInterrupt:`` branch in run()'s
+    poll loop (the "safety net... kept in case a future code path reaches
+    this point") must forward to session.coordinator.cancellation exactly
+    like the ``except _CtrlCInterrupt:`` branch does -- i.e. it must call
+    ``self._handle_ctrl_c()`` too, not a bare ``continue``.
+
+    Without this, the safety net's own comment is self-defeating: the
+    moment that path is ever actually exercised, the just-fixed Ctrl-C bug
+    (keypress has zero effect on cancellation, no console feedback) would
+    silently reappear on this parallel path.
+
+    IMPORTANT (why this is a static/AST check, not a live runtime test):
+    a real ``KeyboardInterrupt`` raised *inside* an ``asyncio.create_task()``
+    coroutine is NOT safely testable end-to-end on CPython 3.11+. This was
+    verified empirically while writing this guard: doing so reproduces
+    exactly the crash the module's own docstring warns about --
+    ``Task.__step_run_and_handle_result()`` catches ``KeyboardInterrupt``,
+    stores it, and *re-raises* it, and that re-raise escapes the event
+    loop's own step handling (``Handle._run()`` / ``_run_once()``)
+    *before* run()'s ``await prompt_task`` ever gets control back to see
+    it -- crashing the whole process (or, as observed while authoring this
+    test, aborting the entire pytest session outright, independent of any
+    try/except in run()). This is precisely why the module never lets a
+    real ``KeyboardInterrupt`` reach ``prompt_task`` in the first place
+    (see ``_CtrlCInterrupt`` and the module docstring's "Ctrl-C / SIGINT"
+    section) -- and precisely why this branch is a dead "safety net" today
+    that can only safely be verified statically, not by reproducing the
+    exact scenario it defends against.
+
+    ``_handle_ctrl_c()``'s own escalation behavior (graceful -> immediate,
+    matching messages) is already thoroughly exercised via the safe
+    ``_CtrlCInterrupt`` path in
+    ``test_steering_ctrl_c_forwards_to_session_cancellation`` above (a
+    plain ``Exception`` subclass, so it does NOT trigger the dangerous
+    Task re-raise) -- this test only needs to confirm the KeyboardInterrupt
+    branch *also* calls that same already-proven method.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    from amplifier_app_cli.steering_input import SteeringInputManager
+
+    source = textwrap.dedent(inspect.getsource(SteeringInputManager.run))
+    tree = ast.parse(source)
+
+    keyboard_interrupt_handlers = [
+        handler
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Try)
+        for handler in node.handlers
+        if handler.type is not None
+        and (
+            (
+                isinstance(handler.type, ast.Name)
+                and handler.type.id == "KeyboardInterrupt"
+            )
+            or (
+                isinstance(handler.type, ast.Tuple)
+                and any(
+                    isinstance(elt, ast.Name) and elt.id == "KeyboardInterrupt"
+                    for elt in handler.type.elts
+                )
+            )
+        )
+    ]
+
+    # There are two `except KeyboardInterrupt` mentions in run(): the
+    # dedicated `except KeyboardInterrupt:` clause (the safety net this
+    # test targets) and the tuple-form
+    # `except (asyncio.CancelledError, KeyboardInterrupt, EOFError): pass`
+    # used in the explicit cancel+await cleanup branches (arbiter-abort,
+    # stop_event teardown) -- those are deliberately bare passes (they are
+    # ABORTING prompt_task, not receiving a live keypress) and must NOT be
+    # touched by this guard.
+    dedicated_handlers = [
+        h
+        for h in keyboard_interrupt_handlers
+        if isinstance(h.type, ast.Name) and h.type.id == "KeyboardInterrupt"
+    ]
+    assert len(dedicated_handlers) == 1, (
+        "expected exactly one dedicated `except KeyboardInterrupt:` clause "
+        f"in run(), found {len(dedicated_handlers)} -- this guard's "
+        "assumptions about the source structure no longer hold, update it"
+    )
+    handler = dedicated_handlers[0]
+
+    calls_handle_ctrl_c = any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "_handle_ctrl_c"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "self"
+        for node in ast.walk(ast.Module(body=handler.body, type_ignores=[]))
+    )
+    assert calls_handle_ctrl_c, (
+        "expected run()'s `except KeyboardInterrupt:` branch to call "
+        "self._handle_ctrl_c() (mirroring the except _CtrlCInterrupt: "
+        "branch) -- found a bare continue/pass instead, which reintroduces "
+        "the just-fixed bug (keypress has zero effect on cancellation) the "
+        "moment this safety-net path is ever actually exercised"
+    )
+
+
 # ---------------------------------------------------------------------------
 # StdinArbiter unit tests (unchanged)
 # ---------------------------------------------------------------------------

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -753,6 +753,212 @@ async def test_ctrl_c_during_prompt_does_not_crash_run_loop():
 
 
 # ---------------------------------------------------------------------------
+# Ctrl-C functional gap: _CtrlCInterrupt must forward to
+# session.coordinator.cancellation, mirroring main.py's OS-signal
+# sigint_handler escalation semantics
+# ---------------------------------------------------------------------------
+# Background (confirmed via a real pty + real CancellationToken harness,
+# investigate_ctrlc_functional.py, and independently reconfirmed live in a
+# DTU through the actual CLI): a physical Ctrl-C keypress during a turn
+# NEVER generates a real OS SIGINT while the steering prompt holds
+# prompt_toolkit's raw_mode() -- raw_mode() clears ISIG along with ECHO/
+# ICANON (see prompt_toolkit.input.vt100.raw_mode._patch_lflag), so the
+# \x03 byte is consumed entirely by the PromptSession's
+# interrupt_exception=_CtrlCInterrupt key binding and never reaches the
+# kernel-delivered SIGINT that main.py's sigint_handler is registered for.
+#
+# Before this fix, run()'s `except _CtrlCInterrupt: continue` swallowed the
+# keypress with NO console feedback and NO effect on
+# session.coordinator.cancellation -- the turn ran to full completion as if
+# Ctrl-C had never been pressed. This block proves that gap is closed: a
+# _CtrlCInterrupt now escalates through the exact same
+# request_graceful()/request_immediate() sequence and prints the exact same
+# user-visible messages as the OS-signal sigint_handler in
+# _execute_with_interrupt (main.py), because both paths operate on the SAME
+# shared session.coordinator.cancellation object -- so the downstream
+# effect (the execute-task poll loop in main.py reacting to
+# cancellation.is_immediate) is identical regardless of which path caught
+# the keypress.
+# ---------------------------------------------------------------------------
+
+
+class _FakeCancellationToken:
+    """Minimal stand-in for amplifier_core.cancellation.CancellationToken.
+
+    Mirrors the real Rust-backed token's observable API surface exactly
+    (verified against the real amplifier_core._engine.RustCancellationToken
+    in this environment): is_cancelled, is_immediate, is_graceful,
+    running_tool_names, request_graceful(), request_immediate(), reset().
+    """
+
+    def __init__(self) -> None:
+        self.state = "none"
+        self.running_tool_names: list[str] = []
+
+    @property
+    def is_cancelled(self) -> bool:
+        return self.state in ("graceful", "immediate")
+
+    @property
+    def is_graceful(self) -> bool:
+        return self.state == "graceful"
+
+    @property
+    def is_immediate(self) -> bool:
+        return self.state == "immediate"
+
+    def request_graceful(self) -> None:
+        self.state = "graceful"
+
+    def request_immediate(self) -> None:
+        self.state = "immediate"
+
+    def reset(self) -> None:
+        self.state = "none"
+
+
+class _FakeCoordinator:
+    def __init__(self, cancellation: _FakeCancellationToken) -> None:
+        self.cancellation = cancellation
+
+
+class _FakeSession:
+    """Stand-in exposing only what SteeringInputManager needs from
+    ``self._session``: ``.coordinator.cancellation`` -- the same shared
+    object main.py's ``_execute_with_interrupt`` polls and mutates.
+    """
+
+    def __init__(self, cancellation: _FakeCancellationToken) -> None:
+        self.coordinator = _FakeCoordinator(cancellation)
+
+
+@pytest.mark.asyncio
+async def test_steering_ctrl_c_forwards_to_session_cancellation():
+    """First Ctrl-C during the steering prompt = graceful; second = immediate.
+
+    Must exactly mirror main.py's sigint_handler escalation semantics and
+    print the same user-visible messages, since a physical Ctrl-C during a
+    turn is caught here (raw_mode disables ISIG) and never reaches that
+    OS-signal handler at all.
+    """
+    from amplifier_app_cli.steering_input import _CtrlCInterrupt
+
+    cancellation = _FakeCancellationToken()
+    session = _FakeSession(cancellation)
+    console = MagicMock()
+
+    call_count = 0
+
+    async def mock_input() -> str | None:
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise _CtrlCInterrupt()
+        await asyncio.sleep(10)
+        return None
+
+    stop = asyncio.Event()
+    manager = SteeringInputManager(
+        steer_cap=None,
+        arbiter=None,
+        stop_event=stop,
+        console=console,
+        session=session,
+        _input_provider=mock_input,
+    )
+
+    run_task = asyncio.create_task(manager.run())
+
+    # Wait for the first _CtrlCInterrupt to be processed.
+    for _ in range(100):
+        if cancellation.state != "none":
+            break
+        await asyncio.sleep(0.02)
+
+    assert cancellation.state == "graceful", (
+        "expected the first Ctrl-C during the steering prompt to call "
+        f"request_graceful() on session.coordinator.cancellation (same as "
+        f"sigint_handler's first-Ctrl-C branch), got state={cancellation.state!r}"
+    )
+    assert any(
+        "Stopping after current operation" in str(call.args[0])
+        for call in console.print.call_args_list
+    ), (
+        "expected the same 'Stopping after current operation...' message "
+        "sigint_handler prints on the first Ctrl-C"
+    )
+
+    # Wait for the second _CtrlCInterrupt to escalate to immediate.
+    for _ in range(100):
+        if cancellation.state == "immediate":
+            break
+        await asyncio.sleep(0.02)
+
+    assert cancellation.state == "immediate", (
+        "expected a second Ctrl-C during the steering prompt to escalate to "
+        f"request_immediate() (same as sigint_handler's second-Ctrl-C "
+        f"branch), got state={cancellation.state!r}"
+    )
+    assert any(
+        "Cancelling immediately" in str(call.args[0])
+        for call in console.print.call_args_list
+    ), (
+        "expected the same 'Cancelling immediately...' message "
+        "sigint_handler prints on the second Ctrl-C"
+    )
+
+    # Clean up.
+    stop.set()
+    run_task.cancel()
+    try:
+        await asyncio.wait_for(run_task, timeout=1.0)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_steering_ctrl_c_without_session_does_not_crash():
+    """Defensive: when no session was wired (session=None, the pre-fix
+    constructor default), a _CtrlCInterrupt must still be handled the old
+    way (silently continue) -- no AttributeError, no crash. Preserves
+    backward compatibility for any caller that doesn't wire session (e.g.
+    the existing test_ctrl_c_during_prompt_does_not_crash_run_loop above).
+    """
+    from amplifier_app_cli.steering_input import _CtrlCInterrupt
+
+    call_count = 0
+
+    async def mock_input() -> str | None:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise _CtrlCInterrupt()
+        await asyncio.sleep(10)
+        return None
+
+    stop = asyncio.Event()
+    manager = SteeringInputManager(
+        steer_cap=None,
+        arbiter=None,
+        stop_event=stop,
+        console=MagicMock(),
+        _input_provider=mock_input,
+    )
+
+    run_task = asyncio.create_task(manager.run())
+    await asyncio.sleep(0.1)
+
+    assert not run_task.done(), "run() should not crash/exit when session is None"
+
+    stop.set()
+    run_task.cancel()
+    try:
+        await asyncio.wait_for(run_task, timeout=1.0)
+    except (asyncio.CancelledError, asyncio.TimeoutError):
+        pass
+
+
+# ---------------------------------------------------------------------------
 # StdinArbiter unit tests (unchanged)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -515,6 +515,114 @@ async def test_arbiter_resumes_after_approval_ends():
 
 
 # ---------------------------------------------------------------------------
+# Arbiter-abort swallowed-cancellation race
+# ---------------------------------------------------------------------------
+# Background (confirmed via Event-gated coordination during the Ctrl-C
+# functional investigation): the arbiter-abort branch inside run()'s poll
+# loop does `prompt_task.cancel(); await prompt_task` and catches
+# `(asyncio.CancelledError, KeyboardInterrupt, EOFError)` with a bare
+# `pass`, then falls through to a "wait for approval to finish" loop and
+# eventually `continue`s the outer loop -- it does NOT `return`.
+#
+# If run()'s OWN task is cancelled from OUTSIDE (by _execute_with_interrupt's
+# teardown) at the exact moment it is suspended inside THIS `await
+# prompt_task`, the bare `except CancelledError: pass` cannot distinguish
+# "prompt_task itself finished cancelling" (expected, normal abort-for-
+# approval flow) from "run()'s own task was just asked to cancel" (must be
+# honored) -- it swallows both identically. Classic asyncio anti-pattern:
+# catching CancelledError without re-raising does not cancel the enclosing
+# task, it just continues running.
+#
+# This is "safe" today ONLY because the single real caller
+# (_execute_with_interrupt) always calls stop_event.set() BEFORE
+# .cancel(), so the very next outer-loop re-check normally ends things
+# quickly -- but nothing INSIDE run() enforces or asserts that ordering.
+# If stop_event is never set (or not set before the cancel lands here),
+# run() spins forever in the "wait for approval to finish" loop, having
+# silently absorbed the external cancellation -- a real, provable hang.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_arbiter_abort_swallows_external_cancellation_regression():
+    """FAILING TEST (proves the bug): external cancellation landing inside
+    the arbiter-abort branch's ``await prompt_task`` must still result in
+    run_task ending up cancelled -- not silently absorbed.
+
+    Uses Event-gated coordination (not sleep-based timing) to force
+    run_task's external cancellation to land exactly inside the
+    arbiter-abort branch's ``await prompt_task``: ``mock_input``, once
+    cancelled, sets ``in_teardown`` and then sleeps before re-raising --
+    widening the window during which run() is suspended at that exact
+    await. Deliberately never sets ``stop_event`` or ends approval, so the
+    only way run_task can end up cancelled is if the branch itself honors
+    the external cancellation instead of falling through to the
+    wait-for-approval loop.
+    """
+    in_teardown = asyncio.Event()
+    started = asyncio.Event()
+
+    async def mock_input() -> str:
+        started.set()
+        try:
+            await asyncio.Future()  # hang until cancelled
+        except asyncio.CancelledError:
+            in_teardown.set()
+            # Widen the window: prompt_task takes a while to actually
+            # finish tearing down after being cancelled (simulates a slow
+            # raw_mode __exit__ or Application shutdown).
+            await asyncio.sleep(0.3)
+            raise
+        return ""  # unreachable; satisfies the declared return type
+
+    arbiter = StdinArbiter()
+    stop_event = asyncio.Event()
+    console = _make_console()
+
+    manager = SteeringInputManager(
+        None,
+        arbiter,
+        stop_event,
+        console,
+        _input_provider=mock_input,
+    )
+
+    run_task = asyncio.create_task(manager.run())
+
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    # Trigger the arbiter-abort branch.
+    arbiter.begin_approval()
+
+    # Wait until prompt_task's OWN CancelledError handler is running --
+    # this means run_task is now suspended at `await prompt_task` inside
+    # the arbiter-abort branch.
+    await asyncio.wait_for(in_teardown.wait(), timeout=1.0)
+
+    # Cancel run_task ITSELF, right now, while it's suspended exactly
+    # there.
+    run_task.cancel()
+
+    # Deliberately do NOT set stop_event and do NOT end_approval() -- if
+    # the swallow bug is present, run_task will hang indefinitely waiting
+    # for approval to end, having silently absorbed the cancellation.
+    done, pending = await asyncio.wait([run_task], timeout=1.0)
+
+    assert run_task not in pending, (
+        "run_task's external cancellation was silently swallowed by the "
+        "arbiter-abort branch's `except CancelledError: pass` -- the task "
+        "is still pending (hung waiting for approval to end) instead of "
+        "properly ending up cancelled, even though neither stop_event nor "
+        "arbiter.approval_active were ever touched"
+    )
+    assert run_task.cancelled(), (
+        "expected run_task to end up cancelled once its own external "
+        f".cancel() was honored; got cancelled()={run_task.cancelled()!r} "
+        f"(done={run_task.done()!r})"
+    )
+
+
+# ---------------------------------------------------------------------------
 # run() teardown: stop_event causes clean exit
 # ---------------------------------------------------------------------------
 

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -567,6 +567,81 @@ async def test_teardown_cancel_is_clean():
 
 
 # ---------------------------------------------------------------------------
+# Orphaned prompt_task regression: cancelling run() while it is suspended at
+# the inner poll's ``asyncio.sleep(0.05)`` must not leak the child prompt
+# task it created.
+# ---------------------------------------------------------------------------
+# Background (confirmed via a real pty + termios harness,
+# investigate_termios_repro.py multi_orphan): run()'s inner poll loop creates
+# a child ``prompt_task`` per prompt attempt and spends most of its time
+# suspended at a bare ``await asyncio.sleep(0.05)`` with NO cleanup logic for
+# that child task. _execute_with_interrupt's teardown does
+# ``stop_event.set(); reader_task.cancel(); await reader_task`` with no
+# yield in between, so CancelledError is delivered to run() at whatever await
+# it happens to be suspended at -- overwhelmingly the bare sleep, not one of
+# the three explicit cancel-branches. run()'s ``finally:`` only resets
+# ``self._pt_session`` and never cancels the orphaned prompt_task, which then
+# lives on holding prompt_toolkit's raw_mode() terminal context until
+# asyncio.run()'s final shutdown sweep -- whose cleanup order is NOT
+# guaranteed LIFO, so a multi-turn session can restore the WRONG (already
+# raw) terminal snapshot, leaving the real terminal echo-off after exit.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_inner_poll_sleep_does_not_orphan_prompt_task():
+    """Cancelling run() while suspended at the inner poll sleep must also
+    cancel+await the live child prompt_task -- not leave it pending.
+
+    ``mock_input`` signals ``started`` and then hangs forever (mirrors a real
+    prompt_async() call waiting on user input).  By the time ``started`` is
+    set, run()'s poll loop has necessarily reached its bare
+    ``await asyncio.sleep(0.05)`` (the unsafe point identified in the root
+    cause) with the child prompt_task still alive and un-awaited.
+    """
+    started = asyncio.Event()
+
+    async def mock_input() -> str:
+        started.set()
+        await asyncio.Future()  # never resolves; must be cancelled to end
+        return ""  # unreachable; satisfies the declared return type
+
+    manager, _ = _make_manager(input_provider=mock_input)
+    run_task = asyncio.create_task(manager.run())
+
+    # Wait until the child prompt_task has actually started -- this only
+    # happens once run_task itself has yielded at the inner poll's sleep.
+    await asyncio.wait_for(started.wait(), timeout=1.0)
+
+    tasks_before_cancel = {
+        t for t in asyncio.all_tasks() if t is not asyncio.current_task()
+    }
+
+    run_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await run_task
+
+    # Let the loop process any scheduling fallout from the cancellation.
+    await asyncio.sleep(0)
+
+    leftover = [
+        t
+        for t in asyncio.all_tasks()
+        if t is not asyncio.current_task() and not t.done()
+    ]
+    assert leftover == [], (
+        f"run() cancellation orphaned live task(s): {leftover!r} -- the "
+        "child prompt_task must be cancelled+awaited before run() returns "
+        "or propagates CancelledError, in every exit path"
+    )
+
+    # Every task that existed while the prompt was in flight must now be
+    # finished (done, whether cancelled or not) -- none left pending.
+    for t in tasks_before_cancel:
+        assert t.done(), f"orphaned task left pending: {t!r}"
+
+
+# ---------------------------------------------------------------------------
 # Ctrl-C regression: _CtrlCInterrupt must not escape run() as a crash
 # ---------------------------------------------------------------------------
 # Background: the old code used PromptSession(interrupt_exception=KeyboardInterrupt).

--- a/tests/test_terminal_echo_integration.py
+++ b/tests/test_terminal_echo_integration.py
@@ -1,0 +1,382 @@
+"""Integration tests: real pty + termios probing for the orphaned-prompt_task fix.
+
+These tests exercise ``SteeringInputManager.run()`` inside a REAL forked pty
+child process (not mocked event loop internals) and inspect the terminal's
+actual ``termios`` state via the pty master fd after the child exits, to
+prove -- at the OS level, not just at the asyncio-task level -- that no
+orphaned ``prompt_task`` is left holding prompt_toolkit's ``raw_mode()``
+terminal context after ``run()`` completes.
+
+Adapted from the standalone investigation harness
+(``investigate_termios_repro.py``, originally a workspace-root scratch
+script) used to empirically confirm the root cause of the "terminal loses
+echo after exiting an amplifier session" bug and to prove the fix in
+``steering_input.py``'s ``run()`` (see the ``finally:`` block there).
+
+Marked ``@pytest.mark.integration`` (deselected by default -- see
+``pyproject.toml``'s ``addopts``) because each test forks a real process,
+allocates a real pty pair, and does real termios syscalls; this is
+meaningfully slower and heavier than the rest of the (mocked, in-process)
+steering test suite in ``test_steering.py``. Run explicitly with::
+
+    pytest -m integration tests/test_terminal_echo_integration.py
+
+The headline scenario is ``multi_orphan``: four sequential steering "turns",
+torn down back-to-back exactly the way ``_execute_with_interrupt`` does
+(``stop_event.set(); reader_task.cancel(); await reader_task``, no yield in
+between) with ZERO Ctrl-C and ZERO signals involved. Before the fix, this
+scenario reliably corrupted the terminal (ECHO/ICANON/ISIG all cleared)
+purely from asyncio's non-LIFO shutdown-sweep ordering of the orphaned
+raw_mode contexts. After the fix, it comes out healthy every time.
+"""
+
+from __future__ import annotations
+
+import os
+import pty
+import signal
+import sys
+import termios
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LOGFILE = "/tmp/test_terminal_echo_integration.log"
+
+
+def _describe_termios(attrs: list) -> dict[str, bool]:
+    lflag = attrs[3]
+    return {
+        "ECHO": bool(lflag & termios.ECHO),
+        "ICANON": bool(lflag & termios.ICANON),
+        "ISIG": bool(lflag & termios.ISIG),
+    }
+
+
+def _is_healthy(state: dict) -> bool:
+    return state.get("ECHO") is True and state.get("ICANON") is True
+
+
+# ---------------------------------------------------------------------------
+# Child process body -- runs the REAL SteeringInputManager inside the pty
+# child, driving the exact task-creation/cancel/await pattern used by
+# main.py's ``_execute_with_interrupt``.
+# ---------------------------------------------------------------------------
+
+
+def _child_main(scenario: str) -> None:
+    import asyncio
+    import time as _time
+
+    sys.path.insert(0, str(REPO_ROOT))
+
+    from prompt_toolkit.input import vt100 as pt_vt100
+    from prompt_toolkit.patch_stdout import patch_stdout
+
+    from amplifier_app_cli.steering_input import SteeringInputManager
+
+    t0 = _time.monotonic()
+    logfh = open(LOGFILE, "a")
+
+    def log(msg: str) -> None:
+        logfh.write(f"[child +{_time.monotonic() - t0:6.3f}s] {msg}\n")
+        logfh.flush()
+
+    class _NullConsole:
+        def print(self, *a, **k):
+            pass
+
+    async def run_multi_orphan(n_turns: int) -> None:
+        """Zero-Ctrl-C repro: N steering 'turns' back to back, each torn
+        down the way ``_execute_with_interrupt`` does -- ``stop_event.set()``
+        then immediately ``reader_task.cancel()``, no yield in between --
+        guaranteed to land in the "unsafe" inner-loop sleep since the
+        manager's task has had no chance to reach a safe cancellation
+        checkpoint yet. NO Ctrl-C, NO real signals at all. Then exit
+        normally and see if the accumulated orphaned raw_mode contexts
+        (pre-fix) leave the terminal broken.
+        """
+        for i in range(n_turns):
+            stop_event = asyncio.Event()
+
+            class FakeArbiter:
+                approval_active = False
+
+            manager = SteeringInputManager(
+                steer_cap=lambda text: None,
+                arbiter=FakeArbiter(),
+                stop_event=stop_event,
+                console=_NullConsole(),
+            )
+            with patch_stdout(raw=True):
+                reader_task = asyncio.create_task(manager.run())
+                # Give run() just enough time to create prompt_task and reach
+                # its inner polling sleep (the "unsafe" point), but not
+                # enough to receive any input.
+                await asyncio.sleep(0.08)
+                log(f"turn {i}: tearing down (stop_event.set + cancel, no yield)")
+                stop_event.set()
+                reader_task.cancel()
+                try:
+                    await reader_task
+                except asyncio.CancelledError:
+                    pass
+                pending = [
+                    t for t in asyncio.all_tasks() if t is not asyncio.current_task()
+                ]
+                log(
+                    f"turn {i}: tasks still pending immediately after teardown: {len(pending)}"
+                )
+            # Immediately move on to the "next prompt" -- no delay, no wait
+            # for the orphan to clean up. Mirrors the REPL loop calling
+            # prompt_session.prompt_async() again right after
+            # _execute_with_interrupt() returns.
+        log("all turns torn down; process about to exit normally (no Ctrl-C anywhere)")
+
+    async def run_single_scenario() -> None:
+        outer_session_stop = asyncio.Event()  # unused, placeholder parity with harness
+        del outer_session_stop
+
+        stop_event = asyncio.Event()
+
+        class FakeArbiter:
+            def __init__(self):
+                self.approval_active = False
+
+        arbiter = FakeArbiter()
+
+        manager = SteeringInputManager(
+            steer_cap=lambda text: None,
+            arbiter=arbiter,
+            stop_event=stop_event,
+            console=_NullConsole(),
+        )
+
+        def sigint_handler(signum, frame):
+            sys.stderr.write("[child] sigint_handler fired\n")
+            sys.stderr.flush()
+
+        original_handler = signal.signal(signal.SIGINT, sigint_handler)
+
+        with patch_stdout(raw=True):
+            reader_task = asyncio.create_task(manager.run())
+
+            if scenario == "normal":
+                await asyncio.sleep(0.3)
+            elif scenario == "ctrlc_midturn":
+                await asyncio.sleep(0.5)
+            elif scenario == "doublectrlc":
+                await asyncio.sleep(0.6)
+            elif scenario == "sigint_only":
+                await asyncio.sleep(0.5)
+            elif scenario == "bytes_only":
+                await asyncio.sleep(0.5)
+            elif scenario == "approval_cycle":
+                await asyncio.sleep(0.15)
+                arbiter.approval_active = True
+                await asyncio.sleep(0.2)
+                arbiter.approval_active = False
+                await asyncio.sleep(0.2)
+
+            tasks_before = {
+                t for t in asyncio.all_tasks() if t is not asyncio.current_task()
+            }
+            log(f"tasks pending before teardown: {len(tasks_before)}")
+            stop_event.set()
+            reader_task.cancel()
+            try:
+                await reader_task
+            except asyncio.CancelledError:
+                pass
+
+            await asyncio.sleep(0)
+            leftover_tasks = [
+                t for t in asyncio.all_tasks() if t is not asyncio.current_task()
+            ]
+            log(
+                f"tasks pending AFTER reader_task awaited: {len(leftover_tasks)} -> {leftover_tasks}"
+            )
+
+        signal.signal(signal.SIGINT, original_handler)
+        sys.stderr.write("[child] clean exit\n")
+        sys.stderr.flush()
+        log("run_single_scenario() about to return")
+
+    # Instrument raw_mode enter/exit purely for the on-disk log (useful when
+    # debugging a failure by hand); not asserted on directly by the tests.
+    _orig_enter = pt_vt100.raw_mode.__enter__
+    _orig_exit = pt_vt100.raw_mode.__exit__
+
+    def _traced_enter(self):
+        log(f"raw_mode.__enter__ (fd={self.fileno}, id={id(self)})")
+        return _orig_enter(self)
+
+    def _traced_exit(self, *a):
+        log(f"raw_mode.__exit__  (fd={self.fileno}, id={id(self)})")
+        return _orig_exit(self, *a)
+
+    pt_vt100.raw_mode.__enter__ = _traced_enter
+    pt_vt100.raw_mode.__exit__ = _traced_exit
+
+    import asyncio as _asyncio
+
+    try:
+        if scenario == "multi_orphan":
+            _asyncio.run(run_multi_orphan(4))
+        else:
+            _asyncio.run(run_single_scenario())
+    except BaseException as e:  # noqa: BLE001
+        sys.stderr.write(f"[child] asyncio.run raised: {type(e).__name__}: {e}\n")
+        sys.stderr.flush()
+        raise
+    sys.stderr.write("[child] process exiting normally\n")
+    sys.stderr.flush()
+
+
+# ---------------------------------------------------------------------------
+# Parent-side driver: forks the pty child, optionally injects bytes/signals,
+# waits for exit, then reads back termios state via the master fd.
+# ---------------------------------------------------------------------------
+
+
+def _run_pty_scenario(scenario: str, timeout: float = 8.0) -> dict:
+    pid, master_fd = pty.fork()
+    if pid == 0:
+        # ----- CHILD -----
+        try:
+            _child_main(scenario)
+        except BaseException:
+            os._exit(1)
+        os._exit(0)
+
+    # ----- PARENT -----
+    time.sleep(0.6)  # let the child boot python/prompt_toolkit
+
+    def send(text: str) -> None:
+        os.write(master_fd, text.encode())
+
+    if scenario == "ctrlc_midturn":
+        time.sleep(0.3)
+        send("\x03")  # Ctrl-C byte (prompt_toolkit key path)
+    elif scenario == "doublectrlc":
+        time.sleep(0.3)
+        send("\x03")
+        time.sleep(0.05)
+        send("\x03")
+        try:
+            os.kill(pid, signal.SIGINT)  # real OS signal racing the byte
+        except ProcessLookupError:
+            pass
+    elif scenario == "sigint_only":
+        time.sleep(0.35)
+        try:
+            os.kill(pid, signal.SIGINT)
+        except ProcessLookupError:
+            pass
+    elif scenario == "bytes_only":
+        time.sleep(0.3)
+        send("\x03")
+        time.sleep(0.05)
+        send("\x03")
+    # "normal", "approval_cycle", "multi_orphan": driven entirely by the
+    # child's own internal timers -- no parent-side input needed.
+
+    deadline = time.time() + timeout
+    exited = False
+    status = None
+    while time.time() < deadline:
+        try:
+            wpid, status = os.waitpid(pid, os.WNOHANG)
+        except ChildProcessError:
+            exited = True
+            break
+        if wpid == pid:
+            exited = True
+            break
+        time.sleep(0.05)
+
+    if not exited:
+        try:
+            os.kill(pid, signal.SIGKILL)
+            os.waitpid(pid, 0)
+        except ProcessLookupError:
+            pass
+
+    # Drain any remaining child output (avoids leaving data in the pty buffer).
+    output = b""
+    try:
+        os.set_blocking(master_fd, False)
+        for _ in range(20):
+            try:
+                chunk = os.read(master_fd, 65536)
+            except (BlockingIOError, OSError):
+                break
+            if not chunk:
+                break
+            output += chunk
+    except OSError:
+        pass
+
+    try:
+        attrs = termios.tcgetattr(master_fd)
+        state = _describe_termios(attrs)
+    except OSError as e:
+        state = {"error": str(e)}
+
+    os.close(master_fd)
+
+    return {
+        "scenario": scenario,
+        "exit_status": status,
+        "exited_cleanly": exited,
+        "termios": state,
+        "healthy": _is_healthy(state),
+        "output": output.decode(errors="replace"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_multi_orphan_leaves_terminal_healthy():
+    """Headline proof: 4 sequential turns, zero Ctrl-C, zero signals, only
+    the standard ``stop_event.set(); cancel(); await`` teardown run 4 times
+    back-to-back. Before the fix in ``steering_input.py``'s ``run()``
+    ``finally:`` block, this reliably corrupted the terminal (ECHO/ICANON/
+    ISIG all cleared) after a completely normal process exit, because the
+    orphaned child ``prompt_task``s' ``raw_mode`` contexts were swept in a
+    non-LIFO order by asyncio's shutdown machinery. After the fix, the
+    terminal must come out healthy every time.
+    """
+    result = _run_pty_scenario("multi_orphan")
+    assert result["exited_cleanly"], f"child did not exit cleanly: {result}"
+    assert result["healthy"], f"terminal corrupted after multi_orphan: {result}"
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "normal",
+        "ctrlc_midturn",
+        "doublectrlc",
+        "sigint_only",
+        "bytes_only",
+        "approval_cycle",
+    ],
+)
+def test_scenario_leaves_terminal_healthy(scenario: str):
+    """Regression coverage for the other empirically-tested teardown paths.
+
+    None of these scenarios are known to corrupt the terminal after the
+    orphan-prevention fix; this guards against a future regression
+    reintroducing an orphaned raw_mode context on any of these paths.
+    """
+    result = _run_pty_scenario(scenario)
+    assert result["exited_cleanly"], f"child did not exit cleanly: {result}"
+    assert result["healthy"], f"terminal corrupted after {scenario}: {result}"


### PR DESCRIPTION
## Summary

Closes a genuine asyncio anti-pattern race in `SteeringInputManager.run()`'s arbiter-abort branch (steering_input.py). When an approval prompt needs exclusive terminal access mid-steering-turn, the code cancels the steering prompt_task and caught CancelledError with a bare `pass`, never re-raising or returning. If run()'s OWN task were externally cancelled at the exact moment it was suspended inside that await, the cancellation was silently swallowed — a verified, previously-proven race that was only "safe" because the single real caller always calls stop_event.set() before .cancel(). Nothing inside run() itself enforced that convention.

## The Fix

Split the except clause in the arbiter-abort branch:
- For `asyncio.CancelledError` specifically, check `asyncio.current_task().cancelling()` (3.11+) — this reports pending cancellation requests on run()'s OWN task (0 in normal case, >0 if something called .cancel() on run()'s task while suspended here)
- Re-raise when >0, letting cancellation propagate normally per asyncio's contract, instead of falling through to the approval-wait loop
- Keep `KeyboardInterrupt`/`EOFError` with bare-pass (prompt_task's own completion signals, not external cancellation indicators), preserving the legitimate abort-for-approval-then-resume flow untouched

See file changes for the exact code diff.

## Evidence Chain (Layered)

### Failing-test-first ✓
**test_arbiter_abort_swallows_external_cancellation_regression** (tests/test_steering.py)
- Uses the same Event-gated coordination technique (not sleep-based timing) that originally proved this race reproducible
- Forces run_task's external cancellation to land exactly inside the arbiter-abort branch's `await prompt_task`, with stop_event and approval_active deliberately untouched
- Before fix: run_task stays pending indefinitely (`<Task cancelling ...>` but never completes)
- After fix: run_task properly ends up cancelled

### All arbiter tests pass ✓
All 8 arbiter-related tests pass, including pre-existing approval-cycle coverage:
- `test_arbiter_suspends_reader_during_approval`
- `test_arbiter_resumes_after_approval_ends`
- Confirms the legitimate resume-after-approval path is unaffected

### Full test suite ✓
- **1065 passed**
- Same 14 pre-existing unrelated failures (unchanged from before this fix)
- All steering/arbiter tests green
- 11 deselected (integration)

### Both integration test files pass ✓
**test_terminal_echo_integration.py** and **test_ctrlc_functional_integration.py**
- 11/11 passed
- No regression — confirms earlier terminal-echo + Ctrl-C fixes (PR #220 / 842e1cd) are not disturbed by this follow-up

### Code quality ✓
- python_check clean on both changed files

### DTU verification ✓
Verified in a fresh, clean environment against the actually-installed package (not just dev machine state):
- ✓ Fix confirmed live via grep of the installed code
- ✓ Full arbiter test group re-run and green
- ✓ Both integration suites re-run and green
- ✓ Real-PTY live interactive session exercising the actual approval-interrupt-and-resume flow end-to-end:
  - Real SteeringInputManager/StdinArbiter/CLIApprovalProvider, real keystrokes
  - Steered pre-approval, triggered real approval prompt, answered it
  - Confirmed steering resumed cleanly post-approval with no hang or terminal corruption

**Note:** Did NOT attempt to force the exact scheduler-timing race live (that's what the unit-level event-gated test proves deterministically). The DTU pass instead proves the real, legitimate flow this branch serves isn't disturbed by the fix.

## Context

This is the second fix in amplifier-app-cli's steering-cancellation-hardening effort:
- **PR #220** (842e1cd): forward KeyboardInterrupt safety-net branch to cancellation too + forward mid-turn Ctrl-C to session.coordinator.cancellation
- **This PR** (61a51f0): honor external cancellation in arbiter-abort branch instead of swallowing it (flagged as a known follow-up in 842e1cd)

## Generated with [Amplifier](https://github.com/microsoft/amplifier)