### PR TITLE
fix(runtime): propagate overrides.<module-id>.config into agent-scoped module declarations

### DIFF
--- a/amplifier_app_cli/runtime/config.py
+++ b/amplifier_app_cli/runtime/config.py
@@ -14,6 +14,7 @@ from rich.console import Console
 from ..lib.settings import AppSettings, NotificationFlags, get_custom_routing_dir
 from ..lib.merge_utils import merge_module_items
 from ..lib.merge_utils import merge_tool_configs
+from ..lib.merge_utils import _normalize_module_entry
 
 
 if TYPE_CHECKING:
@@ -153,21 +154,37 @@ async def resolve_bundle_config(
     # and hooks alike.  Applied BEFORE the dedicated override sections
     # (config.providers[], modules.tools[], config.notifications.*) so that
     # those more-specific sections take precedence on overlapping keys.
+    #
+    # overrides.<id>.config is keyed by module IDENTITY, not by mount
+    # location -- so it must reach a module wherever it's declared, including
+    # inside a sub-agent's own frontmatter (config["agents"][<name>]["tools"]
+    # etc.), not just the root bundle's providers/tools/hooks lists. Without
+    # this, a tool an agent introduces that never appears in the root lists
+    # (e.g. a query tool declared only in an agent's tools: section) never
+    # receives its override and silently falls back to module defaults / env
+    # vars.
     config_overrides = app_settings.get_config_overrides()
     if config_overrides:
         for section_key in ("providers", "tools", "hooks"):
             section = bundle_config.get(section_key)
             if not section:
                 continue
-            for item in section:
-                if not isinstance(item, dict):
+            bundle_config[section_key] = _apply_config_overrides_to_section(
+                section, config_overrides
+            )
+
+        agents_section = bundle_config.get("agents")
+        if isinstance(agents_section, dict):
+            for agent_cfg in agents_section.values():
+                if not isinstance(agent_cfg, dict):
                     continue
-                module_id = item.get("module")
-                if module_id and module_id in config_overrides:
-                    override_cfg = config_overrides[module_id]
-                    if override_cfg:
-                        base_cfg = item.get("config", {}) or {}
-                        item["config"] = deep_merge(base_cfg, override_cfg)
+                for section_key in ("providers", "tools", "hooks"):
+                    agent_section = agent_cfg.get(section_key)
+                    if not agent_section:
+                        continue
+                    agent_cfg[section_key] = _apply_config_overrides_to_section(
+                        agent_section, config_overrides
+                    )
 
     # Apply provider overrides
     provider_overrides = app_settings.get_provider_overrides()
@@ -429,6 +446,61 @@ def _map_id_to_instance_id(
         ):
             provider = {**provider, "instance_id": provider["id"]}
         result.append(provider)
+    return result
+
+
+def _apply_config_overrides_to_section(
+    section: list[Any], config_overrides: dict[str, Any]
+) -> list[Any]:
+    """Apply overrides.<module-id>.config to every entry in a module list section.
+
+    Shared by the root ``providers``/``tools``/``hooks`` override loop in
+    :func:`resolve_bundle_config` and by the same application to each agent's
+    own ``providers``/``tools``/``hooks`` sections (``config["agents"][name]``).
+    ``overrides.<id>.config`` is keyed by module identity, not by mount
+    location, so it must reach a module wherever it's declared.
+
+    Entries may be bare strings (shorthand for ``{"module": <string>}``) or
+    dicts -- the same shapes :func:`merge_module_lists` already tolerates via
+    ``_normalize_module_entry``. For each entry:
+
+    - Normalize (read-only) to find its module id. Entries that don't
+      normalize to a dict with a ``module`` id are returned unchanged.
+    - If there's no matching override, the ORIGINAL entry is returned
+      unchanged -- bare strings stay bare, dicts are returned by the same
+      reference (no gratuitous copy), so untouched entries are byte-identical.
+    - If there is a matching override, a NEW dict entry is produced: the
+      existing config (if any) deep-merged with the override (override wins
+      on key conflicts), with all other entry keys (``source``, ``module``,
+      ...) preserved.
+
+    Args:
+        section: A module list (providers/tools/hooks), possibly containing
+            bare strings and/or dicts.
+        config_overrides: The ``overrides.<id>.config`` map from settings.
+
+    Returns:
+        A new list with overrides applied. The original ``section`` list and
+        its untouched entries are not mutated.
+    """
+    if not section or not config_overrides:
+        return section
+
+    result: list[Any] = []
+    for item in section:
+        normalized = _normalize_module_entry(item)
+        if normalized is None:
+            result.append(item)
+            continue
+        module_id = normalized.get("module")
+        override_cfg = config_overrides.get(module_id) if module_id else None
+        if not override_cfg:
+            result.append(item)
+            continue
+        base_cfg = normalized.get("config", {}) or {}
+        merged_entry = dict(normalized)
+        merged_entry["config"] = deep_merge(base_cfg, override_cfg)
+        result.append(merged_entry)
     return result
 
 

--- a/tests/test_agent_scoped_config_overrides.py
+++ b/tests/test_agent_scoped_config_overrides.py
@@ -1,0 +1,185 @@
+"""Tests for overrides.<module-id>.config propagation into agent-scoped modules.
+
+Root cause: overrides.<id>.config was only ever applied to the ROOT bundle's
+providers/tools/hooks lists (resolve_bundle_config()). A tool a sub-agent
+introduces only in its own frontmatter (config["agents"][<name>]["tools"])
+never received its override -- it was invisible to the mechanism because it
+never appears in the root lists.
+
+This module tests the shared pure helper `_apply_config_overrides_to_section`
+that fixes this, applied to both the root sections and each agent's own
+providers/tools/hooks sections.
+"""
+
+from amplifier_app_cli.agent_config import merge_configs
+from amplifier_app_cli.lib.merge_utils import deep_merge
+from amplifier_app_cli.runtime.config import _apply_config_overrides_to_section
+
+
+class TestAgentOnlyDictEntry:
+    """T1: agent-only dict-form tool entry (no config) + matching override."""
+
+    def test_override_applied_and_other_keys_preserved(self):
+        section = [
+            {
+                "module": "tool-context-intelligence-query",
+                "source": "git+https://example.com/repo@main#subdirectory=modules/x",
+            }
+        ]
+        overrides = {
+            "tool-context-intelligence-query": {
+                "sources": {
+                    "team-shared": {
+                        "url": "https://shared.example.com",
+                        "auth_mode": "entra",
+                    }
+                }
+            }
+        }
+
+        result = _apply_config_overrides_to_section(section, overrides)
+
+        assert len(result) == 1
+        entry = result[0]
+        assert entry["config"]["sources"]["team-shared"]["auth_mode"] == "entra"
+        # Other keys (source) must be preserved.
+        assert (
+            entry["source"]
+            == "git+https://example.com/repo@main#subdirectory=modules/x"
+        )
+        assert entry["module"] == "tool-context-intelligence-query"
+
+
+class TestBareStringEntry:
+    """T2: bare-string agent tool entry + override -> normalized to dict, override applied."""
+
+    def test_bare_string_normalized_and_override_applied(self):
+        section = ["tool-context-intelligence-query"]
+        overrides = {"tool-context-intelligence-query": {"timeout": 30}}
+
+        result = _apply_config_overrides_to_section(section, overrides)
+
+        assert len(result) == 1
+        entry = result[0]
+        assert isinstance(entry, dict)
+        assert entry["module"] == "tool-context-intelligence-query"
+        assert entry["config"] == {"timeout": 30}
+
+
+class TestPrecedence:
+    """T3: override wins on key conflicts, existing keys preserved."""
+
+    def test_override_wins_existing_keys_preserved(self):
+        section = [
+            {
+                "module": "tool-x",
+                "config": {"timeout": 5, "retries": 3},
+            }
+        ]
+        overrides = {"tool-x": {"timeout": 30}}
+
+        result = _apply_config_overrides_to_section(section, overrides)
+
+        assert result[0]["config"] == {"timeout": 30, "retries": 3}
+        # Sanity: matches manual deep_merge expectation.
+        assert result[0]["config"] == deep_merge(
+            {"timeout": 5, "retries": 3}, {"timeout": 30}
+        )
+
+
+class TestNoOp:
+    """T4: entries with no matching override are returned byte-identical."""
+
+    def test_bare_string_no_override_stays_bare(self):
+        section = ["tool-unrelated"]
+        result = _apply_config_overrides_to_section(section, {"tool-x": {"a": 1}})
+
+        assert result == ["tool-unrelated"]
+        assert result[0] is section[0]  # identity preserved, not just equality
+
+    def test_dict_no_override_stays_same_object(self):
+        entry = {"module": "tool-y", "config": {"a": 1}}
+        section = [entry]
+        result = _apply_config_overrides_to_section(section, {"tool-x": {"a": 1}})
+
+        assert result[0] is entry  # no gratuitous copy when nothing changes
+
+    def test_empty_overrides_returns_section_unchanged(self):
+        section = [{"module": "tool-z"}]
+        result = _apply_config_overrides_to_section(section, {})
+        assert result is section
+
+    def test_empty_section_returns_as_is(self):
+        assert _apply_config_overrides_to_section([], {"tool-x": {"a": 1}}) == []
+
+
+class TestIntegrationWithRealMergeConfigs:
+    """T5: full path -- root override application + real merge_configs() at spawn.
+
+    Simulates the exact David scenario: root tools = [], the query tool is
+    declared ONLY inside the graph-analyst agent's own frontmatter with no
+    config block, and overrides.tool-context-intelligence-query.config.sources
+    is set at the app level. After applying the override to both root AND
+    agent sections (the fix) and then spawning via the real merge_configs(),
+    the merged child tool entry must carry config.sources -- not fall through
+    to the tier-3 env-var fallback.
+    """
+
+    def test_agent_only_tool_receives_override_after_spawn_merge(self):
+        config_overrides = {
+            "tool-context-intelligence-query": {
+                "sources": {
+                    "team-shared": {
+                        "url": "${AMPLIFIER_CONTEXT_INTELLIGENCE_TEAM_SHARED_URL}",
+                        "auth_mode": "entra",
+                        "auth_resource": "${AMPLIFIER_CONTEXT_INTELLIGENCE_TEAM_SHARED_AUTH_RESOURCE}",
+                    }
+                }
+            }
+        }
+
+        # Mount plan shape as produced by resolve_bundle_config(): root tools
+        # empty, the query tool only declared inside the agent's own section.
+        mount_plan = {
+            "tools": [],
+            "agents": {
+                "graph-analyst": {
+                    "tools": [{"module": "tool-context-intelligence-query"}],
+                }
+            },
+        }
+
+        # --- Apply the fix: helper applied to root AND agent sections ---
+        agents_section = mount_plan.get("agents")
+        assert isinstance(agents_section, dict)
+        for agent_cfg in agents_section.values():
+            for section_key in ("providers", "tools", "hooks"):
+                section = agent_cfg.get(section_key)
+                if not section:
+                    continue
+                agent_cfg[section_key] = _apply_config_overrides_to_section(
+                    section, config_overrides
+                )
+
+        # --- Real spawn merge (session_spawner.py:265 equivalent) ---
+        parent_config = {"tools": mount_plan["tools"], "agents": mount_plan["agents"]}
+        agent_overlay = mount_plan["agents"]["graph-analyst"]
+
+        merged_child_config = merge_configs(parent_config, agent_overlay)
+
+        child_tools = merged_child_config["tools"]
+        matches = [
+            t
+            for t in child_tools
+            if isinstance(t, dict)
+            and t.get("module") == "tool-context-intelligence-query"
+        ]
+        assert len(matches) == 1, f"Expected exactly one query tool, got: {child_tools}"
+        tool_entry = matches[0]
+        assert "config" in tool_entry, (
+            "Agent-only tool must carry the override's config after spawn merge "
+            f"-- got: {tool_entry}"
+        )
+        assert tool_entry["config"]["sources"]["team-shared"]["auth_mode"] == "entra", (
+            f"sources.team-shared override must survive spawn merge -- got: {tool_entry}"
+        )


### PR DESCRIPTION
## Summary

App-level `overrides.<module-id>.config` was silently dropped when applied to modules a sub-agent declares only in its own composition. A tool declared only in an agent's frontmatter (e.g. `tool-context-intelligence-query` in `graph-analyst.md`) never received its override and fell through to env-var defaults, breaking config-driven initialization.

## Root cause

The override mechanism in `resolve_bundle_config()` was applied only to the ROOT bundle's `providers`/`tools`/`hooks` sections and never descended into `config["agents"][*]`. At spawn time, a tool present only in the agent's overlay was appended verbatim (the merge drop point) with no override applied.

## The fix

Extracted a pure helper `_apply_config_overrides_to_section(section, config_overrides)` that normalizes bare-string module entries, deep-merges overrides (so overrides win on key conflicts), and preserves agent-declared keys the override doesn't mention.

`resolve_bundle_config()` now applies this helper to:
- Root `("providers","tools","hooks")` sections (behavior unchanged)
- Each `config["agents"][*]" section (closes the gap)

Precedence: app override wins on overlapping keys; agent-declared keys are preserved (deep_merge, same semantics as the existing root path).

## Alternative considered (and rejected)

Extending `_sync_overrides_to_bundle` to stamp `bundle.agents` was evaluated — but verified as dead code: the app-cli spawn path (`session_spawner.spawn_sub_session` → `merge_configs`) reads child config derived from the shared `prepared.mount_plan` object (which the helper already mutates), not from the `Bundle` dataclass. The `Bundle.agents` path (`PreparedBundle.spawn`) is not used by app-cli.

## Verification

**Unit & regression:** 8 new tests pass (including an integration test using the real `merge_configs` spawn merge); 92 pre-existing override/merge tests still pass. The 14 full-suite failures are pre-existing on `main` at 5d7bff3 (confirmed byte-identical via git stash).

**End-to-end (Digital Twin Universe):**
- **Positive:** With local fixed app-cli, `sources.team-shared` override only (env tier-3 unset), graph-analyst sub-agent queries the team-shared server successfully → graph_query returns real rows, blob_read fetches real ~537KB blob ✓
- **Negative control:** Unpatched app-cli with identical config fails with "server URL not configured" — proves the override is load-bearing ✗

Complements PR #61 (skill_sync crash fix) for the same team-shared/Entra debugging scenario.
