### PR TITLE
fix(deps): bump amplifier-foundation pin to a snapshot that exports bridge_child_cost

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 [[package]]
 name = "amplifier-foundation"
 version = "1.0.0"
-source = { git = "https://github.com/microsoft/amplifier-foundation?branch=main#91dc9dc0bfc3a3890a190214aa584f903461ae91" }
+source = { git = "https://github.com/microsoft/amplifier-foundation?branch=main#dc010423d010da9a52e1b49808a1865666008c25" }
 dependencies = [
     { name = "amplifier-core" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Problem

`session_spawner.py` imports `from amplifier_foundation import bridge_child_cost`, but the `amplifier-foundation` commit pinned in `uv.lock` predates that symbol. A clean environment resolving strictly from the lock file fails to import on the session-spawn path.

Timeline:
- Locked foundation snapshot `91dc9dc` dates to 2026-03-17.
- `bridge_child_cost` was added to `amplifier-foundation` on 2026-05-08 — after the pinned snapshot.
- The import was added to this repo the same day, but the accompanying foundation pin bump was never made, so the lock has continued to resolve the pre-`bridge_child_cost` snapshot.

This is invisible to anyone who already has a newer `amplifier-foundation` in their working environment; it only surfaces on a clean install from the lock.

## Fix

Refresh the `amplifier-foundation` pin to current `main` (`dc010423`), which exports `bridge_child_cost`.

```
uv lock --upgrade-package amplifier-foundation
```

## Scope

Single line in `uv.lock`: the `amplifier-foundation` commit only. No other packages move; no source changes.