### PR TITLE
fix: remove padding from code blocks to enable clean copy/paste

### DIFF
--- a/amplifier_app_cli/console.py
+++ b/amplifier_app_cli/console.py
@@ -4,9 +4,43 @@ from rich.console import Console
 from rich.console import ConsoleOptions
 from rich.console import RenderResult
 from rich.errors import MarkupError
+from rich.markdown import CodeBlock as RichCodeBlock
 from rich.markdown import Heading as RichHeading
 from rich.markdown import Markdown as RichMarkdown
+from rich.rule import Rule
+from rich.syntax import Syntax
 from rich.text import Text
+
+
+class CopyPasteCodeBlock(RichCodeBlock):
+    """Code block with no per-line whitespace padding, for clean copy/paste.
+
+    Rich's stock CodeBlock renders with ``Syntax(..., padding=1)``, which
+    writes a literal space character onto the left (and right) of every
+    line. That space is a real character in the terminal's screen buffer,
+    so a mouse-drag or triple-click copy captures it -- pasting code out of
+    a session then requires manually stripping a leading space from every
+    line.
+
+    This override keeps the block visually identifiable (background tint +
+    syntax highlighting, plus a thin rule above/below) without baking any
+    padding characters into the code lines themselves, so what you copy is
+    exactly the code -- nothing more.
+    """
+
+    def __rich_console__(
+        self, console: Console, options: ConsoleOptions
+    ) -> RenderResult:
+        code = str(self.text).rstrip()
+        yield Rule(style="dim", characters="\u2500")
+        yield Syntax(
+            code,
+            self.lexer_name,
+            theme=self.theme,
+            word_wrap=True,
+            padding=0,
+        )
+        yield Rule(style="dim", characters="\u2500")
 
 
 class LeftAlignedHeading(RichHeading):
@@ -49,6 +83,8 @@ class Markdown(RichMarkdown):
     elements = {
         **RichMarkdown.elements,
         "heading_open": LeftAlignedHeading,  # Use our custom heading
+        "fence": CopyPasteCodeBlock,  # ``` code blocks: no copy/paste padding
+        "code_block": CopyPasteCodeBlock,  # indented code blocks: same treatment
     }
 
 

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -99,6 +99,42 @@ CLEANUP_FINALLY_END: str = "cleanup:finally_end"
 _llm_error_filter = LLMErrorLogFilter()
 
 
+def _ensure_utf8_output() -> None:
+    """Force UTF-8 on stdout/stderr so terminal-rendered Unicode survives copy/paste.
+
+    Amplifier's Rich-rendered output (markdown, syntax highlighting, emoji
+    labels) contains multi-byte UTF-8 characters. If the terminal or the
+    OS console codepage isn't UTF-8 (common on Windows, where the legacy
+    console codepage defaults to something like CP437/CP1252), those bytes
+    get mis-decoded on copy/paste: e.g. an em dash (\u2014) or bullet (\u2022)
+    turns into garbled sequences like "\u00e2" or "\u00e2\u00a2" with the
+    continuation byte silently dropped as a non-printing control character.
+
+    This is a "fix the mechanism, not the symptom" guard: rather than
+    hoping every user's terminal is configured correctly, force our own
+    streams to UTF-8 and, on Windows, force the console's active codepage
+    to UTF-8 (65001) as well so what we emit is decoded the way we wrote
+    it -- everywhere.
+    """
+    import io
+
+    for stream in (sys.stdout, sys.stderr):
+        if isinstance(stream, io.TextIOWrapper):
+            try:
+                stream.reconfigure(encoding="utf-8", errors="replace")
+            except (ValueError, OSError):
+                pass  # Stream doesn't support reconfigure (e.g. some test doubles)
+
+    if sys.platform == "win32":
+        try:
+            import ctypes
+
+            ctypes.windll.kernel32.SetConsoleOutputCP(65001)  # type: ignore[attr-defined]
+            ctypes.windll.kernel32.SetConsoleCP(65001)  # type: ignore[attr-defined]
+        except (AttributeError, OSError):
+            pass  # Not a real Windows console (e.g. some CI/test environments)
+
+
 def _attach_llm_error_filter() -> None:
     """Attach the LLM error filter to the stderr StreamHandler at runtime.
 
@@ -3401,6 +3437,7 @@ register_session_commands(
 
 def main():
     """Main entry point."""
+    _ensure_utf8_output()
     _attach_llm_error_filter()
     cli()
 


### PR DESCRIPTION
## Problem

Code blocks rendered in interactive `amplifier` chat sessions carry a literal 1-space left margin on every line. Copying code out of a terminal session and pasting elsewhere requires manually stripping a leading space from every line.

**Example:**
```
 def demo():
     return "copy this"
```

(The leading space before `def` is a real character, not markdown formatting.)

## Root Cause

`amplifier_app_cli/console.py` defines a `Markdown` subclass of Rich's `Markdown` that overrides heading rendering (`LeftAlignedHeading`) but left code-block rendering (`fence`/`code_block` elements) on Rich's stock `CodeBlock`.

Rich's `CodeBlock.__rich_console__` renders via:
```python
Syntax(code, lexer, theme=theme, word_wrap=True, padding=1)
```

That `padding=1` writes a literal space character onto the left (and right, though terminals strip trailing whitespace on copy) of every code line. This padding is a real character in the terminal's screen buffer, so mouse-drag or triple-click copy operations capture it.

## Solution

Added `CopyPasteCodeBlock` class in `console.py` that:
- Overrides `CodeBlock.__rich_console__` with `padding=0` (no injected whitespace)
- Keeps the block visually identifiable via:
  - A dim horizontal rule (\u2500 characters) above and below
  - Syntax highlighting and background coloring (from Rich's `Syntax` renderer)
- Wired into `Markdown.elements` dict for both `fence` and `code_block` keys, mirroring how heading rendering is already overridden

Also added `_ensure_utf8_output()` defensive helper in `main.py`:
- Forces `sys.stdout`/`sys.stderr` to UTF-8 via `.reconfigure(encoding="utf-8", errors="replace")`
- On Windows, forces console codepage to 65001 (UTF-8) via `SetConsoleOutputCP`/`SetConsoleCP`
- This is defense-in-depth for terminal/locale misconfigurations; no active mojibake bugs were found in this CLI's rendering layer

## Verification

All verification is real, not asserted:

1. **Root cause confirmed:** Read the actual installed Rich source (`rich/markdown.py::CodeBlock`) to confirm the exact culprit: `padding=1` in `Syntax\(...)`

2. **Bytewise inspection:** Rendered real markdown through the patched `console.Markdown` class and inspected the raw ANSI output character-by-character:
   - Code lines have zero injected left-margin space
   - Only the code's own indentation remains (e.g., Python's 4-space indent is still there)
   - Dim horizontal borders and syntax highlighting confirmed present

3. **End-to-end DTU test:** Stood up a Digital Twin Universe running this exact local checkout
   - Verified via embedded commit SHA in DTU version string: the DTU was running the exact patched code, not a cached/published package
   - Ran real `amplifier run` producing a fenced code block through the patched code
   - Confirmed no injected padding in the terminal output

4. **User copy/paste validation:** End user independently copy-pasted real code blocks from the DTU session twice (in two separate conversation turns) and confirmed both times:
   - Code had correct indentation
   - No stray leading space on any line

5. **Code quality:**
   - `python_check` clean on `console.py` (0 issues)
   - `main.py` has 39 pre-existing pyright errors; this change does not introduce new errors (verified via diff of error lists before/after)
   - Type errors from `sys.stdout.reconfigure` fixed by narrowing with `isinstance(stream, io.TextIOWrapper)`

## Files Changed

- `amplifier_app_cli/console.py` — added `CopyPasteCodeBlock`, wired into `Markdown.elements`
- `amplifier_app_cli/main.py` — added `_ensure_utf8_output()`, called from `main()`

## Testing

No new tests added (the fix is in a rendering layer that requires visual verification in a real terminal). The fix is validated by:
- End-to-end interactive testing in DTU with real `amplifier run` commands
- User copy/paste validation from actual terminal sessions
- Byte-level inspection of rendered ANSI output confirming correct padding
- Existing test suite passes (verified in DTU)
