### PR TITLE
fix: remove continuation indent from interactive prompt to enable clean copy/paste

### DIFF
--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -2611,7 +2611,14 @@ def _create_prompt_session(get_active_mode: Callable | None = None) -> PromptSes
         history=history,
         key_bindings=kb,
         multiline=True,  # Enable multi-line display
-        prompt_continuation="  ",  # Two spaces for alignment (cleaner than "... ")
+        # Empty continuation prefix -- NOT "  " or "... ". A non-empty prefix
+        # is prepended to every wrapped/continuation line by prompt_toolkit,
+        # including lines that only *soft-wrapped* because they hit the
+        # terminal width (not just literal Ctrl-J newlines). That prefix is a
+        # real character in the terminal's screen buffer, so selecting and
+        # copying multi-line input picks it up on every wrapped line --
+        # including mid-word wraps -- requiring manual cleanup after paste.
+        prompt_continuation="",
         enable_history_search=True,  # Enables Ctrl-R
     )
 


### PR DESCRIPTION
## Problem

When a user enters a line in the interactive REPL that wraps at the terminal width (or uses Ctrl-J for an explicit multi-line entry), prompt_toolkit prepends a 2-space continuation prefix to every wrapped line — not just literal newlines, but soft-wraps where a line hits the terminal edge. That prefix is a real character in the terminal's screen buffer, so selecting and copying multi-line input picks it up on every wrapped line, including lines that wrapped mid-word, requiring manual cleanup after paste.

Example of the bug (terminal width 80 cols):
```
> this is a long line of text that should wrap around to the next line inside th
  is eighty column terminal so we can see the indentation behavior clearly right
   now
```

When selected and copied, the 2-space indent on each wrapped line is included as real whitespace.

## Root Cause

`amplifier_app_cli/main.py` `_create_prompt_session()` explicitly sets `prompt_continuation="  "` (two literal spaces) on the interactive REPL's `PromptSession`. The original code comment called this intentional: "Two spaces for alignment (cleaner than '... ')", but this design choice breaks copy/paste. prompt_toolkit prepends this string to every continuation line — including lines that only soft-wrapped because they hit the terminal width.

## Fix

Changed `prompt_continuation` from `"  "` to `""` (empty string) in `_create_prompt_session()`, with an explanatory comment documenting why non-empty values are unsafe for copy/paste.

**After fix:**
```
> this is a long line of text that should wrap around to the next line inside th
is eighty column terminal so we can see the indentation behavior clearly right n
ow
```

Wrapped lines now render flush left, and copy/paste includes no injected indentation.

## Verification

1. **Isolated PTY test**: Wrote a script mirroring the exact production `PromptSession` config (same `message`, `multiline=True`, key bindings for Ctrl-J/Enter). Drove it live inside a real PTY at 80 columns:
   - BEFORE (`prompt_continuation="  "`): terminal render showed wrapped continuation lines indented 2 spaces
   - AFTER (`prompt_continuation=""`): terminal render showed wrapped lines flush left at column 0, including mid-word wraps

2. **Syntax check**: `py_compile` clean on `main.py` (this is a one-line string-literal change + comment, no logic touched)

3. **DTU end-to-end verification**: Launched a Digital Twin Universe with the patched `amplifier` CLI installed from the local change (grepped the installed package to confirm `prompt_continuation=""` was present). User tested the actual interactive REPL with long input and confirmed wrapped lines rendered flush left.

## Files Changed

- `amplifier_app_cli/main.py`: changed `prompt_continuation="  "` to `prompt_continuation=""` in `_create_prompt_session()` with explanatory comment

## Related

This is the second half of the copy/paste fix series:
- First fix (#227): removed padding from displayed code blocks (Rich CodeBlock render)
- This fix: removes indent from interactive input continuation lines (PromptSession config)