### PR TITLE
feat(bundle): register 'anchors-amp-dev' (registration only, no default change)

### DIFF
--- a/amplifier_app_cli/lib/bundle_loader/discovery.py
+++ b/amplifier_app_cli/lib/bundle_loader/discovery.py
@@ -50,6 +50,11 @@ WELL_KNOWN_BUNDLES: dict[str, dict[str, str | bool]] = {
         "remote": "git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=bundles/anchors/bundle.md",
         "show_in_list": True,
     },
+    "anchors-amp-dev": {
+        "package": "",  # No Python package - bundle-only
+        "remote": "git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=bundles/anchors-amp-dev/bundle.md",
+        "show_in_list": True,
+    },
     "recipes": {
         "package": "",  # No Python package - bundle-only
         "remote": "git+https://github.com/microsoft/amplifier-bundle-recipes@main",

--- a/tests/test_anchors_amp_dev_registration.py
+++ b/tests/test_anchors_amp_dev_registration.py
@@ -1,0 +1,40 @@
+"""Regression tests: `anchors-amp-dev` is a registered, side-by-side bundle.
+
+`anchors-amp-dev` is registered so it can be selected by name, but registration
+must NOT change any default. It lives side by side with `amplifier-dev` and
+`anchors`; no user's global or project default is affected.
+"""
+import importlib
+
+from amplifier_app_cli.lib.bundle_loader.discovery import WELL_KNOWN_BUNDLES
+
+EXPECTED_REMOTE = (
+    "git+https://github.com/microsoft/amplifier-foundation@main"
+    "#subdirectory=bundles/anchors-amp-dev/bundle.md"
+)
+
+
+def test_anchors_amp_dev_is_registered():
+    assert "anchors-amp-dev" in WELL_KNOWN_BUNDLES
+    entry = WELL_KNOWN_BUNDLES["anchors-amp-dev"]
+    assert entry["remote"] == EXPECTED_REMOTE
+    assert entry["package"] == ""  # bundle-only, no Python package
+    assert entry["show_in_list"] is True
+
+
+def test_registration_does_not_change_default():
+    # The side-by-side guarantee: registering anchors-amp-dev must not flip the
+    # no-active-bundle default away from `anchors`.
+    tool_cmd = importlib.import_module("amplifier_app_cli.commands.tool")
+    from unittest.mock import patch
+
+    with patch.object(tool_cmd, "_get_active_bundle_name", return_value=None):
+        use_bundle, bundle_name, _ = tool_cmd._should_use_bundle()
+    assert use_bundle is True
+    assert bundle_name == "anchors"
+
+
+def test_amplifier_dev_still_registered_alongside():
+    # anchors-amp-dev does not replace amplifier-dev; both coexist.
+    assert "amplifier-dev" in WELL_KNOWN_BUNDLES
+    assert "anchors-amp-dev" in WELL_KNOWN_BUNDLES


### PR DESCRIPTION
## Summary

Registers **`anchors-amp-dev`** in WELL_KNOWN_BUNDLES — registration ONLY, no default changes. Users can explicitly select this bundle by name; existing defaults remain exactly as they are.

## What this changes

Adds one entry to `WELL_KNOWN_BUNDLES` in `amplifier_app_cli/lib/bundle_loader/discovery.py`:

```python
"anchors-amp-dev": {
    "remote": "git+https://github.com/microsoft/amplifier-foundation@main#subdirectory=bundles/anchors-amp-dev/bundle.md",
},
```

This makes the bundle selectable by name:

```
amplifier bundle use anchors-amp-dev
```

## Key difference from anchors (#208)

#208 (the anchors PR) changed the CLI default to `anchors`. This PR **does NOT** change any defaults. We are adding `anchors-amp-dev` alongside `amplifier-dev` and `anchors` — all three coexist, the default remains `anchors` (as established by #208).

## Testing

Regression tests pass (3/3):

```
tests/test_anchors_amp_dev_registration.py:
  ✓ Test anchors-amp-dev is registered in discovery
  ✓ Test default bundle is still 'anchors' (not changed by this PR)
  ✓ Test amplifier-dev coexists with anchors-amp-dev
```

## Dependency

Requires the companion **foundation PR #273** which adds `bundles/anchors-amp-dev/bundle.md`. That PR must merge first for this WELL_KNOWN_BUNDLES entry to resolve.

## Context

`anchors-amp-dev` is a mechanical promotion of the experiment `experiments/behavioral-anchor-amplifier-dev` into a registered bundle. It was evaluated as a drop-in replacement for `amplifier-dev` across ~140 DTU eval runs and reached a drop-in verdict. This PR registers it in the CLI; the foundation PR publishes the bundle files.
