### PR TITLE
feat: offload StdoutProxy write to executor thread to prevent main-loop freeze

### DIFF
--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -28,7 +28,6 @@ from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.history import InMemoryHistory
 from prompt_toolkit.key_binding import KeyBindings
-from prompt_toolkit.patch_stdout import patch_stdout
 from rich.panel import Panel
 
 from .commands.agents import agents as agents_group
@@ -56,6 +55,7 @@ from .console import console
 from .effective_config import get_effective_config_summary
 from .key_manager import KeyManager
 from .session_store import SessionStore
+from .stdout_offload import patch_stdout_offloaded as patch_stdout
 from .ui.dashboard_renderer import DashboardRenderer
 from .ui.dashboard_renderer import _redact_value as _dr_redact_value
 from .ui.item_renderer import ItemRenderer
@@ -2907,6 +2907,15 @@ async def interactive_chat(
             # mangled into literal "?[2m" text and rules/markdown smear across
             # the pinned prompt. raw=True uses write_raw() and passes ANSI
             # through intact (run_in_terminal still owns prompt erase/restore).
+            #
+            # patch_stdout (imported above as `.stdout_offload.patch_stdout_offloaded`)
+            # is a thread-offloaded drop-in for prompt_toolkit's own patch_stdout():
+            # the stock StdoutProxy hardcodes run_in_terminal(..., in_executor=False),
+            # so a big buffered write against a backpressured pty (busy/backgrounded
+            # tmux pane) blocks the OS write SYNCHRONOUSLY on the asyncio event-loop
+            # thread and wedges the entire loop solid -- including any in-process
+            # delegated sub-agents sharing this stdout (session_spawner.py). See
+            # stdout_offload.py for the full mechanism and a real-pty regression test.
             with patch_stdout(raw=True):
                 _reader_task = asyncio.create_task(_manager.run())
 
@@ -3032,7 +3041,11 @@ async def interactive_chat(
     try:
         while True:
             try:
-                # Get user input with history, editing, and paste support
+                # Get user input with history, editing, and paste support.
+                # patch_stdout here is the thread-offloaded
+                # patch_stdout_offloaded (see stdout_offload.py) -- same
+                # freeze risk applies to any background Rich writes that
+                # land while the user is composing input.
                 with patch_stdout():
                     user_input = await prompt_session.prompt_async()
 

--- a/amplifier_app_cli/stdout_offload.py
+++ b/amplifier_app_cli/stdout_offload.py
@@ -1,0 +1,205 @@
+"""Thread-offloaded replacement for ``prompt_toolkit.patch_stdout.patch_stdout``.
+
+CONFIRMED BUG (see docs/ISSUE_CASE_STUDIES.md-style investigation notes in the
+PR/issue this module fixes): ``prompt_toolkit.patch_stdout.StdoutProxy``'s
+internal ``_write_and_flush()`` method hardcodes::
+
+    run_in_terminal(write_and_flush, in_executor=False)
+
+(``prompt_toolkit/patch_stdout.py``, inside ``StdoutProxy._write_and_flush``).
+
+``in_executor=False`` means the actual OS-level terminal write (a real
+blocking ``write()`` + ``flush()`` syscall against ``sys.stdout``) is executed
+SYNCHRONOUSLY on the asyncio event-loop thread, via
+``loop.call_soon_threadsafe(write_and_flush_in_loop)``. If that syscall
+blocks -- which happens whenever the terminal consumer (a busy or
+backgrounded tmux pane, a slow SSH link, etc.) isn't draining its pty fast
+enough to keep up with a large buffered write -- the ENTIRE event loop
+freezes. Not just the write: every other task, timer, and callback
+scheduled on that loop (including unrelated ones, like a bash tool's own
+``asyncio.wait_for(...)`` timeout completion) cannot run AT ALL until the
+blocking write returns. This was proven via a real pty pair with a
+deliberately un-drained read side: the process froze solid and had to be
+killed externally.
+
+``prompt_toolkit`` does not expose any public way to opt a ``patch_stdout()``
+session into ``in_executor=True`` -- it is not a constructor parameter of
+``StdoutProxy`` or ``patch_stdout()``, only an internal implementation
+detail. The fix here is a scoped monkeypatch: for the duration of our
+``patch_stdout_offloaded()`` context, we replace the ``run_in_terminal``
+name that ``prompt_toolkit.patch_stdout`` module resolves at call time
+(imported there via ``from .application import ... run_in_terminal``) with
+a thin wrapper that forces ``in_executor=True``. This routes the actual
+write through prompt_toolkit's own ``run_in_executor_with_context()``
+thread-pool offload (the same mechanism prompt_toolkit itself uses for
+"long blocking functions" per its own docstring), so a stuck write blocks
+only that worker thread -- never the event loop. Everything else about
+``StdoutProxy`` (buffering, raw/ANSI handling, sleep-between-writes
+coalescing) is untouched; we don't duplicate or reimplement any of its
+write logic, so we don't drift from upstream changes to it.
+
+The monkeypatch is scoped to the context manager (installed on ``__enter__``,
+restored on ``__exit__``) rather than applied permanently at import time, so
+it cannot leak into unrelated uses of prompt_toolkit elsewhere in the
+process and is easy to reason about / test in isolation.
+
+Reentrancy: install/restore is guarded by a module-level depth counter (see
+``_install_depth`` below) so nested or overlapping ``patch_stdout_offloaded()``
+contexts -- even ones that exit out of order relative to their entry, e.g.
+two concurrent call sites both active at once -- always converge back to the
+TRUE original ``run_in_terminal`` once the last active context exits, rather
+than potentially leaving the wrapper permanently installed process-wide.
+"""
+
+from __future__ import annotations
+
+import inspect
+import threading
+from contextlib import contextmanager
+from typing import Any
+from typing import Callable
+from typing import Generator
+from typing import TypeVar
+
+import prompt_toolkit.patch_stdout as _pt_patch_stdout_module
+from prompt_toolkit.application import run_in_terminal as _pt_run_in_terminal
+from prompt_toolkit.patch_stdout import patch_stdout as _pt_patch_stdout
+
+_T = TypeVar("_T")
+
+__all__ = ["patch_stdout_offloaded"]
+
+# Reentrancy guard state (module-level, protected by `_install_lock`). Only
+# the outermost `__enter__` (depth 0 -> 1) captures the true original and
+# installs the wrapper; only the outermost `__exit__` (depth 1 -> 0) restores
+# it. This makes nested AND out-of-order-overlapping uses converge correctly.
+_install_lock = threading.Lock()
+_install_depth = 0
+_true_original_run_in_terminal: Callable[..., Any] | None = None
+
+
+def _run_in_terminal_forcing_executor(
+    func: Callable[[], _T],
+    render_cli_done: bool = False,
+    in_executor: bool = False,
+) -> Any:
+    """Wrapper around ``prompt_toolkit``'s ``run_in_terminal`` that forces
+    ``in_executor=True`` regardless of what the caller (StdoutProxy) passes.
+
+    ``in_executor`` is accepted (and ignored) purely to keep the exact call
+    signature ``StdoutProxy._write_and_flush``'s inner
+    ``write_and_flush_in_loop()`` uses -- ``run_in_terminal(write_and_flush,
+    in_executor=False)`` -- so this is a drop-in replacement at the name
+    ``prompt_toolkit.patch_stdout.run_in_terminal``.
+    """
+    del in_executor  # always overridden below -- that is the entire point of this fix
+    return _pt_run_in_terminal(func, render_cli_done=render_cli_done, in_executor=True)
+
+
+def _assert_run_in_terminal_is_patchable() -> None:
+    """Fail loud if ``prompt_toolkit.patch_stdout`` no longer exposes a
+    ``run_in_terminal`` name matching the shape this fix depends on.
+
+    This monkeypatch depends on an internal implementation detail: a plain
+    module-level name (not part of ``prompt_toolkit.patch_stdout.__all__``)
+    that a future ``prompt_toolkit`` release could rename, remove, or
+    restructure (e.g. inlining the import) with zero warning. If that
+    happens silently, this fix becomes a silent no-op -- reverting to the
+    exact event-loop-freeze bug it exists to close, with no test signal
+    until it's hit live again. So: verify the name exists and is callable
+    with the expected ``in_executor`` parameter our wrapper overrides, and
+    raise a clear, actionable error (naming the installed prompt_toolkit
+    version) if not, rather than silently degrading.
+    """
+    import prompt_toolkit
+
+    installed_version = prompt_toolkit.__version__
+
+    current = getattr(  # pyright: ignore[reportPrivateImportUsage]
+        _pt_patch_stdout_module, "run_in_terminal", None
+    )
+    if current is None:
+        raise RuntimeError(
+            "amplifier_app_cli.stdout_offload: prompt_toolkit.patch_stdout no "
+            f"longer exposes a 'run_in_terminal' name (prompt_toolkit=="
+            f"{installed_version}). This breaks the stdout-offload freeze fix: "
+            "the scoped monkeypatch in patch_stdout_offloaded() has nothing to "
+            "install, and StdoutProxy would silently fall back to its original "
+            "in_executor=False blocking write path (the exact event-loop-freeze "
+            "bug this fix closes). Update amplifier_app_cli/stdout_offload.py's "
+            "monkeypatch target to match the new prompt_toolkit internals, or "
+            "pin prompt_toolkit to a known-compatible version."
+        )
+
+    try:
+        signature = inspect.signature(current)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            "amplifier_app_cli.stdout_offload: prompt_toolkit.patch_stdout."
+            f"run_in_terminal (prompt_toolkit=={installed_version}) is no longer "
+            f"introspectable ({exc}). Cannot verify it matches the expected "
+            "call shape; update amplifier_app_cli/stdout_offload.py."
+        ) from exc
+
+    if "in_executor" not in signature.parameters:
+        raise RuntimeError(
+            "amplifier_app_cli.stdout_offload: prompt_toolkit.patch_stdout."
+            f"run_in_terminal (prompt_toolkit=={installed_version}) no longer "
+            f"accepts an 'in_executor' parameter (signature: {signature}). "
+            "The stdout-offload freeze fix depends on overriding that "
+            "parameter; without it, the monkeypatch would silently stop "
+            "forcing the offload. Update amplifier_app_cli/stdout_offload.py's "
+            "wrapper to match the new signature, or pin prompt_toolkit to a "
+            "known-compatible version."
+        )
+
+
+@contextmanager
+def patch_stdout_offloaded(raw: bool = False) -> Generator[None, None, None]:
+    """Drop-in replacement for ``prompt_toolkit.patch_stdout.patch_stdout(raw=...)``.
+
+    Identical observable behavior (writes appear above the pinned prompt,
+    ANSI passthrough when ``raw=True``), except the underlying
+    ``StdoutProxy``'s terminal writes are offloaded to a thread so a
+    blocked/backpressured write cannot freeze the asyncio event loop for the
+    whole session -- including any in-process delegated sub-agents sharing
+    this process's stdout (``session_spawner.py``).
+
+    Reentrant: nested or overlapping calls (even ones whose exits don't
+    mirror their entry order) are safe -- only the outermost active context
+    installs/restores the monkeypatch (see module-level ``_install_depth``).
+    """
+    global _install_depth, _true_original_run_in_terminal
+
+    # `run_in_terminal` is a plain module-level name inside prompt_toolkit's
+    # patch_stdout module (imported there via `from .application import ...
+    # run_in_terminal`), not part of its public `__all__` -- hence the
+    # getattr/setattr (with pyright suppressed) instead of attribute access,
+    # to be explicit that this is an intentional, scoped monkeypatch of an
+    # internal name rather than a typo against the public API.
+    with _install_lock:
+        if _install_depth == 0:
+            _assert_run_in_terminal_is_patchable()
+            _true_original_run_in_terminal = getattr(  # pyright: ignore[reportPrivateImportUsage]
+                _pt_patch_stdout_module, "run_in_terminal"
+            )
+            setattr(  # noqa: B010 - intentional scoped monkeypatch, see module docstring
+                _pt_patch_stdout_module,
+                "run_in_terminal",
+                _run_in_terminal_forcing_executor,
+            )
+        _install_depth += 1
+
+    try:
+        with _pt_patch_stdout(raw=raw):
+            yield
+    finally:
+        with _install_lock:
+            _install_depth -= 1
+            if _install_depth == 0:
+                setattr(  # noqa: B010
+                    _pt_patch_stdout_module,
+                    "run_in_terminal",
+                    _true_original_run_in_terminal,
+                )
+                _true_original_run_in_terminal = None

--- a/tests/test_stdout_offload_freeze_integration.py
+++ b/tests/test_stdout_offload_freeze_integration.py
@@ -1,0 +1,268 @@
+"""Integration tests: real pty pair (deliberately un-drained) proving the
+CONFIRMED event-loop-freeze mechanism in ``prompt_toolkit.patch_stdout`` and
+proving our fix (``amplifier_app_cli.stdout_offload.patch_stdout_offloaded``)
+genuinely isolates the block to a worker thread instead of the asyncio event
+loop.
+
+Background
+~~~~~~~~~~
+``prompt_toolkit.patch_stdout.StdoutProxy._write_and_flush()`` hardcodes::
+
+    run_in_terminal(write_and_flush, in_executor=False)
+
+(``prompt_toolkit/patch_stdout.py`` -- see ``amplifier_app_cli/stdout_offload.py``
+for the full mechanism writeup). ``in_executor=False`` means the actual
+OS-level terminal write executes SYNCHRONOUSLY on the asyncio event-loop
+thread. If that write blocks -- because the terminal consumer (a busy or
+backgrounded tmux pane, a slow SSH link) isn't draining its pty fast enough --
+the ENTIRE event loop freezes: no other task, timer, or callback can run at
+all until the write returns. This explained every prior "hangs until Enter"
+incident across a real production investigation, including two live sessions
+with concurrent delegation.
+
+Reproduction strategy
+~~~~~~~~~~~~~~~~~~~~~
+Each scenario forks a child process that:
+
+1. Opens a real pty pair and NEVER reads the master side (simulating a
+   busy/backgrounded pane under load -- the exact real-world condition).
+2. Builds a real ``prompt_toolkit.output.vt100.Vt100_Output`` writing to the
+   pty's slave side, and installs it as the ambient
+   ``prompt_toolkit.application.current`` AppSession's output.
+3. Installs a minimal stand-in "app" object (just ``.loop`` +
+   ``._is_running``) as the AppSession's active app, so
+   ``StdoutProxy._get_app_loop()`` returns a real loop (matching a genuine
+   interactive session) instead of ``None``.
+4. Runs a 50ms-interval "ticker" task recording wall-clock timestamps --
+   our probe for event-loop liveness.
+5. After a short warm-up (during which the ticker should already show
+   several ticks), writes ~4MB through ``sys.stdout`` (comfortably larger
+   than any kernel pty buffer) inside either the UNFIXED
+   ``prompt_toolkit.patch_stdout.patch_stdout(raw=True)`` or the FIXED
+   ``amplifier_app_cli.stdout_offload.patch_stdout_offloaded(raw=True)``.
+6. Observes for ~2.5 more seconds, then writes the ticker's recorded
+   timestamps to a result file and hard-exits via ``os._exit(0)`` (skipping
+   asyncio/atexit cleanup, since the huge write may still be permanently
+   stuck in a background thread -- we never drain the pty at all in this
+   test, on purpose, to keep the reproduction unambiguous).
+
+If the event loop freezes (unfixed path), the child never reaches step 6 at
+all -- the whole process hangs solid, exactly as confirmed in production, and
+the parent test must kill it via an external timeout. If the event loop
+stays responsive (fixed path), the child reaches step 6 promptly and the
+ticker shows continuous, small-gap progress throughout.
+
+Marked ``@pytest.mark.integration`` per this repo's convention for tests that
+fork a real process and allocate a real pty (deselected by default). Run
+explicitly with::
+
+    pytest -m integration tests/test_stdout_offload_freeze_integration.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# ~4MB comfortably overruns a kernel pty buffer (typically a few KB to
+# ~64KB), guaranteeing the underlying flush() blocks since nobody reads it.
+WRITE_SIZE_BYTES = 4 * 1024 * 1024
+WARMUP_S = 0.3
+OBSERVE_S = 2.5
+TICKER_INTERVAL_S = 0.05
+
+
+def _child_main(fixed: bool, result_path: str) -> None:
+    """Runs inside the forked child. See module docstring for the full
+    reproduction strategy. Ends by hard-exiting via ``os._exit()`` --
+    reached ONLY if the event loop never froze (see docstring point 6).
+    """
+    import asyncio
+
+    from prompt_toolkit.application.current import create_app_session
+    from prompt_toolkit.output.vt100 import Vt100_Output
+
+    # Real pty pair. Deliberately never read `target_master_fd` -- this is
+    # the "busy/backgrounded tmux pane" condition that never drains.
+    target_master_fd, target_slave_fd = os.openpty()
+    del target_master_fd  # intentionally never read from -- see docstring
+
+    target_slave_file = os.fdopen(target_slave_fd, "w", encoding="utf-8", closefd=True)
+    output = Vt100_Output.from_pty(target_slave_file)
+
+    class _FakeApp:
+        """Minimal stand-in for a running prompt_toolkit Application.
+
+        ``StdoutProxy._get_app_loop()`` only reads ``.loop``; the confirmed
+        mechanism depends on that being a real, non-None loop (matching a
+        genuine interactive session) so writes are dispatched via
+        ``loop.call_soon_threadsafe(...)`` instead of being written
+        directly on the background write-thread. ``._is_running = False``
+        deliberately takes ``run_in_terminal``'s ``in_terminal()`` fast
+        short-circuit path (no real Renderer/Layout needed) -- that path
+        is unaffected by the fix under test, which only changes the
+        ``in_executor`` flag passed to ``run_in_terminal``.
+        """
+
+        def __init__(self, loop: "asyncio.AbstractEventLoop") -> None:
+            self.loop = loop
+            self._is_running = False
+
+    ticks: list[float] = []
+
+    async def ticker() -> None:
+        while True:
+            ticks.append(time.monotonic())
+            await asyncio.sleep(TICKER_INTERVAL_S)
+
+    async def scenario() -> None:
+        with create_app_session(output=output) as app_session:
+            app_session.app = _FakeApp(asyncio.get_running_loop())  # type: ignore[assignment]
+
+            if fixed:
+                from amplifier_app_cli.stdout_offload import (
+                    patch_stdout_offloaded as patcher,
+                )
+            else:
+                from prompt_toolkit.patch_stdout import patch_stdout as patcher
+
+            with patcher(raw=True):
+                ticker_task = asyncio.create_task(ticker())
+                await asyncio.sleep(WARMUP_S)
+
+                big_payload = "x" * WRITE_SIZE_BYTES
+                sys.stdout.write(big_payload)
+                sys.stdout.flush()
+
+                await asyncio.sleep(OBSERVE_S)
+                ticker_task.cancel()
+
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    # NOTE: intentionally `run_until_complete`, not `asyncio.run()`. If the
+    # write was offloaded (fixed path), the executor future backing that
+    # write never resolves (we never drain the pty) -- `asyncio.run()`'s
+    # own shutdown machinery would hang trying to cancel/join that stray
+    # task. `run_until_complete` only waits on `scenario()` itself, which
+    # returns without awaiting that stray task.
+    loop.run_until_complete(scenario())
+
+    with open(result_path, "w", encoding="utf-8") as f:
+        json.dump(ticks, f)
+
+    # Hard-exit: skip asyncio/atexit cleanup entirely (see note above --
+    # a background thread may be permanently blocked on the un-drained pty).
+    os._exit(0)
+
+
+def _run_scenario(fixed: bool, timeout: float = 6.0) -> tuple[bool, list[float] | None]:
+    """Forks a child running ``_child_main``. Returns
+    ``(exited_on_its_own, ticks_or_None)``.
+    """
+    tag = "fixed" if fixed else "unfixed"
+    result_path = f"/tmp/test_stdout_offload_freeze_{tag}_{os.getpid()}.json"
+    if os.path.exists(result_path):
+        os.remove(result_path)
+
+    pid = os.fork()
+    if pid == 0:
+        sys.path.insert(0, str(REPO_ROOT))
+        try:
+            _child_main(fixed, result_path)
+        except BaseException:
+            os._exit(1)
+        os._exit(0)
+
+    deadline = time.time() + timeout
+    exited = False
+    while time.time() < deadline:
+        wpid, _status = os.waitpid(pid, os.WNOHANG)
+        if wpid == pid:
+            exited = True
+            break
+        time.sleep(0.05)
+
+    if not exited:
+        try:
+            os.kill(pid, signal.SIGKILL)
+            os.waitpid(pid, 0)
+        except ProcessLookupError:
+            pass
+
+    ticks: list[float] | None = None
+    if os.path.exists(result_path):
+        ticks = json.loads(Path(result_path).read_text(encoding="utf-8"))
+        os.remove(result_path)
+
+    return exited, ticks
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_unfixed_patch_stdout_wedges_event_loop_under_pty_backpressure():
+    """RED: reproduces the CONFIRMED production mechanism directly.
+
+    prompt_toolkit's stock ``patch_stdout(raw=True)`` hardcodes
+    ``in_executor=False``. Under un-drained pty backpressure, the blocking
+    OS write executes synchronously on the event-loop thread and wedges the
+    ENTIRE loop solid -- not merely delays it. The child process cannot
+    even reach its own result-writing code, matching the confirmed
+    production observation exactly ("the entire Python process froze
+    solid... had to be killed externally... total silence = total freeze").
+    """
+    exited, ticks = _run_scenario(fixed=False, timeout=6.0)
+
+    assert not exited, (
+        "Expected the unfixed prompt_toolkit patch_stdout() path to wedge "
+        "the event loop completely under un-drained pty backpressure -- "
+        "the child should require an external kill. If it exited on its "
+        "own, either the bug is already fixed upstream or the repro "
+        "conditions need review."
+    )
+    assert ticks is None, (
+        "Process should never have reached the result-writing code -- the "
+        "event loop was supposed to be completely wedged before that point."
+    )
+
+
+def test_fixed_patch_stdout_offloaded_stays_responsive_under_pty_backpressure():
+    """GREEN: with the fix (``patch_stdout_offloaded``), the identical
+    backpressure condition does NOT freeze the event loop -- concurrent
+    async work (the ticker task) keeps completing on schedule because the
+    actual blocking OS write is offloaded to a worker thread.
+    """
+    exited, ticks = _run_scenario(fixed=True, timeout=6.0)
+
+    assert exited, (
+        "Fixed path should exit on its own -- it should never need to be killed."
+    )
+    assert ticks is not None, (
+        "Fixed path should have written tick results before exiting."
+    )
+
+    expected_min_ticks = int((WARMUP_S + OBSERVE_S) / TICKER_INTERVAL_S * 0.5)
+    assert len(ticks) >= expected_min_ticks, (
+        f"Expected steady ticking throughout the ~{WARMUP_S + OBSERVE_S:.1f}s "
+        f"run (>= {expected_min_ticks} ticks), got {len(ticks)}: {ticks}"
+    )
+
+    gaps = [b - a for a, b in zip(ticks, ticks[1:])]
+    max_gap = max(gaps)
+    assert max_gap < 0.5, (
+        f"Ticker task stalled for {max_gap:.2f}s while the large write was "
+        "in flight -- the event loop was not responsive; offload is not "
+        f"working. All gaps: {gaps}"
+    )

--- a/tests/test_stdout_offload_gaps.py
+++ b/tests/test_stdout_offload_gaps.py
@@ -1,0 +1,204 @@
+"""Regression tests closing three gaps identified by independent review of
+the stdout-offload freeze fix (``amplifier_app_cli/stdout_offload.py``):
+
+1. Reentrancy/nesting safety of the scoped ``run_in_terminal`` monkeypatch.
+2. The write-time exception path (offloaded write raises mid-executor-call).
+3. A loud, fail-fast guard against a future ``prompt_toolkit`` restructuring
+   ``run_in_terminal`` out from under this monkeypatch (silent breakage).
+
+These are unit tests (no pty, no fork, no ``@pytest.mark.integration``) --
+they exercise ``patch_stdout_offloaded()``'s own monkeypatch machinery
+directly, which is fast and does not require the freeze-reproduction
+apparatus in ``test_stdout_offload_freeze_integration.py``.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+from typing import Callable
+
+import prompt_toolkit.patch_stdout as _pt_patch_stdout_module
+import pytest
+
+from amplifier_app_cli.stdout_offload import _run_in_terminal_forcing_executor
+from amplifier_app_cli.stdout_offload import patch_stdout_offloaded
+
+
+def _current_run_in_terminal() -> Callable[..., Any]:
+    """``run_in_terminal`` is a plain module-level name inside prompt_toolkit's
+    ``patch_stdout`` module, not part of its public ``__all__`` -- hence the
+    getattr (pyright suppressed) instead of attribute access, matching
+    ``stdout_offload.py``'s own convention for touching this internal name.
+    """
+    return getattr(  # pyright: ignore[reportPrivateImportUsage]
+        _pt_patch_stdout_module, "run_in_terminal"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gap 1: reentrancy/nesting safety
+# ---------------------------------------------------------------------------
+
+
+def test_nested_patch_stdout_offloaded_restores_true_original_after_outer_exit():
+    """Two properly-nested ``with patch_stdout_offloaded():`` blocks (the
+    inner fully inside the outer, exiting LIFO) must leave the TRUE original
+    ``run_in_terminal`` installed once the OUTER context exits -- not the
+    inner's captured wrapper.
+    """
+    true_original = _current_run_in_terminal()
+
+    with patch_stdout_offloaded():
+        with patch_stdout_offloaded():
+            pass
+        # Inner has exited; outer is still active, so the monkeypatch must
+        # still be installed (this is correct/expected, not a bug).
+        assert _current_run_in_terminal() is not true_original
+
+    assert _current_run_in_terminal() is true_original, (
+        "After the OUTER patch_stdout_offloaded() context exited, the true "
+        "original run_in_terminal must be restored."
+    )
+
+
+def test_overlapping_non_lifo_patch_stdout_offloaded_restores_true_original():
+    """Simulates the genuinely hazardous case the review flagged: two
+    'concurrent call sites both active at once' whose exits do NOT mirror
+    their entries (not expressible via nested ``with`` blocks, since those
+    always unwind LIFO). Context A enters, then context B enters while A is
+    still active, then A exits *first* (out of order) while B is still
+    active, then B exits last.
+
+    Without a reentrancy guard: A captures the true original T and installs
+    wrapper W. B captures W (already installed) as "its" original and
+    re-installs W (no-op). A's early exit restores T -- prematurely, while B
+    is still supposed to be active. B's later exit then restores what B
+    captured (W), leaving W installed FOREVER after both contexts have
+    exited. This test proves whether that actually happens.
+    """
+    true_original = _current_run_in_terminal()
+
+    ctx_a = patch_stdout_offloaded()
+    ctx_a.__enter__()
+    ctx_b = patch_stdout_offloaded()
+    ctx_b.__enter__()
+
+    # Out-of-order exit: A first, even though B is still "active".
+    ctx_a.__exit__(None, None, None)
+    ctx_b.__exit__(None, None, None)
+
+    assert _current_run_in_terminal() is true_original, (
+        "After both overlapping (non-LIFO) contexts have exited, the true "
+        "original run_in_terminal must be restored -- not left monkeypatched "
+        "process-wide forever."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gap 2: write-time exception path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_in_terminal_forcing_executor_propagates_write_exception():
+    """If the offloaded write itself raises (simulating a broken pipe /
+    disconnected pty mid-write), the exception must propagate back to
+    whoever awaits the wrapper -- not be silently swallowed.
+    """
+
+    class _SimulatedBrokenPipe(OSError):
+        pass
+
+    def _raising_write() -> None:
+        raise _SimulatedBrokenPipe("simulated broken pipe mid-write")
+
+    with pytest.raises(_SimulatedBrokenPipe):
+        await _run_in_terminal_forcing_executor(_raising_write)
+
+
+@pytest.mark.asyncio
+async def test_patch_stdout_offloaded_restores_original_when_body_raises():
+    """The ``finally: setattr(...)`` restore in ``patch_stdout_offloaded``'s
+    ``__exit__`` must still execute -- and correctly restore the true
+    original ``run_in_terminal`` -- even when the code running inside the
+    context (which is what observes/awaits a failing offloaded write) raises.
+    """
+    true_original = _current_run_in_terminal()
+
+    class _SimulatedBrokenPipe(OSError):
+        pass
+
+    with pytest.raises(_SimulatedBrokenPipe):
+        with patch_stdout_offloaded():
+            assert _current_run_in_terminal() is not true_original
+            raise _SimulatedBrokenPipe("simulated broken pipe mid-write")
+
+    assert _current_run_in_terminal() is true_original, (
+        "run_in_terminal must be restored to the true original even when the "
+        "context body raised."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gap 3: version-guard against silent breakage
+# ---------------------------------------------------------------------------
+
+
+def test_patch_stdout_offloaded_fails_loudly_if_run_in_terminal_attribute_absent(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Simulates a future ``prompt_toolkit`` release restructuring
+    ``patch_stdout`` so it no longer exposes a module-level ``run_in_terminal``
+    name. The fix must FAIL LOUD with a clear, actionable error naming the
+    installed prompt_toolkit version -- not silently degrade back to the
+    original unpatched (freeze-prone) behavior.
+    """
+    monkeypatch.delattr(_pt_patch_stdout_module, "run_in_terminal", raising=True)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        with patch_stdout_offloaded():
+            pass  # pragma: no cover - must not be reached
+
+    message = str(exc_info.value)
+    assert "run_in_terminal" in message
+    import prompt_toolkit
+
+    assert prompt_toolkit.__version__ in message, (
+        "Error message must name the installed prompt_toolkit version so a "
+        "future maintainer can immediately see what changed."
+    )
+
+
+def test_patch_stdout_offloaded_fails_loudly_if_run_in_terminal_shape_changes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Simulates ``run_in_terminal`` still existing as a name, but no longer
+    matching the expected callable shape (e.g. renamed/removed the
+    ``in_executor`` parameter our wrapper relies on overriding). Must also
+    fail loud rather than silently installing a wrapper that no longer does
+    anything meaningful.
+    """
+
+    def _reshaped_run_in_terminal(func, render_cli_done: bool = False):
+        # No `in_executor` parameter -- simulates an incompatible upstream
+        # signature change.
+        return func()
+
+    monkeypatch.setattr(
+        _pt_patch_stdout_module, "run_in_terminal", _reshaped_run_in_terminal
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        with patch_stdout_offloaded():
+            pass  # pragma: no cover - must not be reached
+
+    assert "in_executor" in str(exc_info.value)
+
+
+def test_run_in_terminal_forcing_executor_signature_matches_expected_shape():
+    """Sanity check tying our own wrapper's signature to what the guard
+    checks for, so the guard and the wrapper can't silently drift apart.
+    """
+    sig = inspect.signature(_run_in_terminal_forcing_executor)
+    assert "in_executor" in sig.parameters


### PR DESCRIPTION
## Summary

This PR fixes a fundamental event-loop freeze bug where console output under backpressure stalls the entire CLI for minutes at a time, resolving the instant a keystroke is pressed.

**Root cause:** prompt_toolkit's `StdoutProxy` (used by `patch_stdout()`) hardcodes `run_in_terminal(write_and_flush, in_executor=False)`. When the terminal is backpressured (slow/backgrounded read side), every console write blocks the entire asyncio event loop **synchronously** on the main thread. With concurrent delegated sub-agents producing parallel output, the main thread freezes solid, blocking unrelated async work like bash tool timeout callbacks. The bug manifests as 'CLI hangs silently for minutes to hours', resolving the instant Enter is pressed.

**Why it matters:** This is distinct from (and more fundamental than) the KeyboardInterrupt/click.confirm bug fixed in PR #229 (which was real and necessary but NOT the cause of any reported incident — no Ctrl-C was ever involved). This freeze has been independently confirmed in LIVE production incidents via /proc inspection (`wchan=wait_woken` main thread blocked, released within ~3s of keystroke).

## The Fix

New module `amplifier_app_cli/stdout_offload.py` provides `patch_stdout_offloaded()` — a reentrancy-safe monkeypatch that forces `in_executor=True` on prompt_toolkit's internal `run_in_terminal` call. The actual OS write now executes on a worker thread and **cannot freeze the main event loop**.

Used as a drop-in replacement for `patch_stdout` at both call sites in `main.py`:
- Turn wrapper (entire turn execution)
- REPL input prompt

## Hardening (from independent review)

After a six-lens critique (intent-keeper, cranky-old-sam, crusty-old-engineer, restless-old-brian, user-advocate, tester-breaker), three concrete gaps were identified and closed with TDD:

1. **Reentrancy/overlapping-context safety:** Module-level depth counter + lock ensures the true original `run_in_terminal` is correctly restored even under overlapping (non-LIFO) context manager usage, not just simple nesting.

2. **Write-time exception propagation:** Confirmed and tested that an exception during the offloaded write correctly propagates to the caller and the monkeypatch is still restored via `finally` block.

3. **Version-drift guard:** `_assert_run_in_terminal_is_patchable()` runs on every entry and fails LOUD with a clear, actionable error (names the installed prompt_toolkit version) if its internal shape ever changes, rather than silently reverting to the exact freeze bug this fix closes.

## Verification Evidence

**Isolated pty-backpressure repro** (real pty pair, undrained read side, 4MB write):
- Unfixed path: freezes solid (internal asyncio.wait_for timeout never fires, needs external kill)
- Fixed path: stays responsive (50+ liveness ticks, max gap <0.5s during same write)

**Two independent LIVE production incidents:**
- Real stuck Amplifier CLI sessions (not synthetic)
- Both reproduced exact `wchan=wait_woken` main-thread-blocked signature
- Both independently confirmed via direct /proc inspection to release within ~3 seconds of sending a keystroke — matching reported symptom exactly

**Test coverage:**
- All 7 new gap-hardening tests pass
- Most safety-critical test (reentrancy guard): RED→GREEN cycle verified personally (guard surgically disabled via sed, test FAILED with real assertion error, guard restored, test PASSED) — not just trusting reporter
- Full existing amplifier-app-cli suite: 14 failed / 1075 passed / 13 deselected / 1 xfailed (same pre-existing failures confirmed identical via `git stash` both before and after)
- python_check on new/changed files: clean (0 errors, 0 warnings)

## Scope Note

This is a **separate, follow-on fix from PR #229**. Different root causes (main-loop freeze vs KeyboardInterrupt handling), same investigation. PR #229 addressed a real but unrelated bug. This fix addresses the actual cause of the reported 'hangs for minutes' symptom.

Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>