### PR TITLE
fix(bundle): fail loud when a declared module cannot be activated

### DIFF
--- a/amplifier_app_cli/commands/run.py
+++ b/amplifier_app_cli/commands/run.py
@@ -14,6 +14,7 @@ import click
 from rich.panel import Panel
 
 from amplifier_foundation.exceptions import BundleError, BundleValidationError
+from amplifier_foundation.modules import ModuleActivationError
 
 from ..console import console
 from ..session_store import extract_session_mode
@@ -176,6 +177,24 @@ def register_run_command(
                 Panel(
                     str(exc),
                     title="[bold white on red] Bundle Validation Error [/bold white on red]",
+                    border_style="red",
+                    padding=(1, 2),
+                )
+            )
+            sys.exit(1)
+        except ModuleActivationError as exc:
+            # One or more modules failed to download/activate. App-layer policy
+            # is to abort rather than start a session that is quietly missing
+            # capabilities. Render the failure and how to proceed.
+            console.print()
+            console.print(
+                Panel(
+                    f"{exc}\n\n"
+                    "The session was not started because it would have been missing\n"
+                    "the capabilities above.\n\n"
+                    "To start anyway with the modules that did load, re-run with:\n"
+                    "  AMPLIFIER_ALLOW_PARTIAL_BUNDLE=1",
+                    title="[bold white on red] Module Activation Failed [/bold white on red]",
                     border_style="red",
                     padding=(1, 2),
                 )

--- a/amplifier_app_cli/lib/bundle_loader/prepare.py
+++ b/amplifier_app_cli/lib/bundle_loader/prepare.py
@@ -10,6 +10,7 @@ modules from git sources before session creation.
 from __future__ import annotations
 
 import logging
+import os
 import re
 from typing import TYPE_CHECKING
 from typing import Callable
@@ -22,6 +23,30 @@ if TYPE_CHECKING:
     from amplifier_app_cli.lib.bundle_loader.discovery import AppBundleDiscovery
 
 logger = logging.getLogger(__name__)
+
+# App-layer POLICY: a module that fails to download or activate aborts session
+# startup instead of being silently dropped.
+#
+# Foundation deliberately defaults to strict=False -- it is a library and cannot
+# know whether a partial bundle is acceptable to its caller. For the CLI it is
+# not: a session that starts without a tool the user's bundle declared is a
+# session that will fail later, further from the cause, in a way the user reads
+# as "the model ignored me" rather than "a download failed".
+#
+# Escape hatch, not a preference: converting a soft failure into a hard one can
+# block a user entirely (a proxy that blocks one module host, a repo that went
+# private). This env var lets them keep working while they fix the real problem.
+_ALLOW_PARTIAL_ENV = "AMPLIFIER_ALLOW_PARTIAL_BUNDLE"
+
+
+def _activation_is_strict() -> bool:
+    """Whether module activation failures should abort session startup."""
+    return os.environ.get(_ALLOW_PARTIAL_ENV, "").strip().lower() not in (
+        "1",
+        "true",
+        "yes",
+    )
+
 
 
 # A "namespace:path" include (e.g. "foo:behaviors/extra") is a reference
@@ -211,6 +236,7 @@ async def load_and_prepare_bundle(
         install_deps=install_deps,
         source_resolver=resolver_callback,
         progress_callback=progress_callback,
+        strict=_activation_is_strict(),
     )
     logger.info(f"Bundle '{bundle_name}' prepared successfully")
 
@@ -275,7 +301,9 @@ async def compose_and_prepare_bundles(
 
     # Prepare the composed bundle
     logger.info(f"Preparing composed bundle (install_deps={install_deps})")
-    prepared = await composed.prepare(install_deps=install_deps)
+    prepared = await composed.prepare(
+        install_deps=install_deps, strict=_activation_is_strict()
+    )
     logger.info("Composed bundle prepared successfully")
 
     return prepared
@@ -307,7 +335,9 @@ async def prepare_bundle_from_uri(
     logger.debug(f"Loaded bundle: {bundle.name} v{bundle.version}")
 
     logger.info(f"Preparing bundle (install_deps={install_deps})")
-    prepared = await bundle.prepare(install_deps=install_deps)
+    prepared = await bundle.prepare(
+        install_deps=install_deps, strict=_activation_is_strict()
+    )
     logger.info("Bundle prepared successfully")
 
     return prepared

--- a/tests/test_fail_loud_bundle_activation.py
+++ b/tests/test_fail_loud_bundle_activation.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 
 import pytest
 
+from amplifier_foundation.exceptions import BundleError
+from amplifier_foundation.modules import ModuleActivationError
+
 from amplifier_app_cli.lib.bundle_loader.prepare import _ALLOW_PARTIAL_ENV
 from amplifier_app_cli.lib.bundle_loader.prepare import _activation_is_strict
 
@@ -68,4 +71,64 @@ class TestPreparePassesStrict343:
         assert wired_calls == prepare_calls, (
             f"{prepare_calls} prepare() call sites but only {wired_calls} pass "
             "strict= -- an unwired site silently reverts to issue #343 behaviour"
+        )
+
+
+class TestActivationFailureIsRenderedNotTracebacked343:
+    """Failing loud is only half the fix -- it has to fail *legibly*.
+
+    Turning on strict activation made ``ModuleActivationError`` fire for the
+    first time. It reached the user as a raw Python traceback, which is a
+    worse experience than the silent degradation it replaced: the user now
+    sees a stack dump and still has no idea what to do about it.
+    """
+
+    def test_error_is_a_bundle_error(self) -> None:
+        """Pins the foundation contract this CLI handler depends on.
+
+        If foundation ever moves ``ModuleActivationError`` back out of the
+        ``BundleError`` hierarchy, the generic handler stops covering it and
+        tracebacks return. Fail here rather than in a user's terminal.
+        """
+        assert issubclass(ModuleActivationError, BundleError)
+
+    def test_activation_handler_precedes_generic_bundle_error_handler(self) -> None:
+        """Handler *ordering* is load-bearing, not incidental.
+
+        ``ModuleActivationError`` is a ``BundleError`` subclass, so a generic
+        ``except BundleError`` placed first would swallow it and the user
+        would lose the specific remediation hint below. Python matches
+        handlers top-down, so the subclass must come first.
+        """
+        import inspect
+
+        from amplifier_app_cli.commands import run as run_mod
+
+        source = inspect.getsource(run_mod)
+        activation_at = source.find("except ModuleActivationError")
+        bundle_at = source.find("except BundleError")
+
+        assert activation_at != -1, "run command must handle ModuleActivationError"
+        assert bundle_at != -1, "sanity: expected a generic BundleError handler"
+        assert activation_at < bundle_at, (
+            "`except ModuleActivationError` must precede `except BundleError` -- "
+            "otherwise the subclass is swallowed and the user loses the "
+            "escape-hatch hint"
+        )
+
+    def test_handler_tells_the_user_how_to_proceed(self) -> None:
+        """A hard failure must never be a dead end.
+
+        Strict activation can strand a user whose proxy blocks one module
+        host. The rendered failure has to name the escape hatch, otherwise
+        the only recovery path is reading our source.
+        """
+        import inspect
+
+        from amplifier_app_cli.commands import run as run_mod
+
+        source = inspect.getsource(run_mod)
+        assert _ALLOW_PARTIAL_ENV in source, (
+            f"the failure panel must name {_ALLOW_PARTIAL_ENV} so a stranded "
+            "user has a way forward"
         )

--- a/tests/test_fail_loud_bundle_activation.py
+++ b/tests/test_fail_loud_bundle_activation.py
@@ -1,0 +1,71 @@
+"""Regression coverage for issue #343 (silently degraded bundles).
+
+A module that failed to download was dropped from the session with only a
+DEBUG log. The user got a session missing tools their bundle declared, and
+read the result as "the model ignored my instructions" rather than "a
+download failed" -- the failure surfaced far from its cause.
+
+Foundation supplies the mechanism (``prepare(strict=...)``). Choosing to turn
+it on is app-layer policy, and these tests pin that policy.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from amplifier_app_cli.lib.bundle_loader.prepare import _ALLOW_PARTIAL_ENV
+from amplifier_app_cli.lib.bundle_loader.prepare import _activation_is_strict
+
+
+class TestActivationStrictnessPolicy343:
+    def test_strict_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """With no env var set, a failed module aborts startup."""
+        monkeypatch.delenv(_ALLOW_PARTIAL_ENV, raising=False)
+        assert _activation_is_strict() is True
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", " true "])
+    def test_escape_hatch_opts_out(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        """The escape hatch exists so a hard failure can't strand a user.
+
+        A proxy blocking one module host, or a repo that went private, would
+        otherwise make the CLI unusable rather than merely degraded.
+        """
+        monkeypatch.setenv(_ALLOW_PARTIAL_ENV, value)
+        assert _activation_is_strict() is False
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "banana"])
+    def test_non_truthy_values_stay_strict(
+        self, monkeypatch: pytest.MonkeyPatch, value: str
+    ) -> None:
+        """Anything that isn't a clear opt-in stays strict -- fail safe."""
+        monkeypatch.setenv(_ALLOW_PARTIAL_ENV, value)
+        assert _activation_is_strict() is True
+
+
+class TestPreparePassesStrict343:
+    """The policy must actually reach ``prepare()`` -- not just exist."""
+
+    def test_all_prepare_call_sites_pass_strict(self) -> None:
+        """Guards against a new prepare() call site silently defaulting to lax.
+
+        foundation's default is strict=False, so an unwired call site is a
+        silent regression back to the #343 behaviour rather than a test error.
+        """
+        import inspect
+        import re
+
+        from amplifier_app_cli.lib.bundle_loader import prepare as prepare_mod
+
+        source = inspect.getsource(prepare_mod)
+        # Real call sites only -- prose mentions of prepare() in docstrings and
+        # comments are not wiring and must not be counted.
+        prepare_calls = len(re.findall(r"await\s+\w+\.prepare\(", source))
+        wired_calls = source.count("strict=_activation_is_strict()")
+
+        assert prepare_calls > 0, "sanity: expected prepare() call sites"
+        assert wired_calls == prepare_calls, (
+            f"{prepare_calls} prepare() call sites but only {wired_calls} pass "
+            "strict= -- an unwired site silently reverts to issue #343 behaviour"
+        )


### PR DESCRIPTION
## Problem

When a module fails to download, it is dropped from the session and startup continues. The user gets a session quietly missing tools or providers their bundle declared, with no indication anything went wrong. They read the result as "the model ignored my instructions" rather than "a download failed."

Reported in microsoft/amplifier#343.

## Requires

**Two foundation PRs must merge first — microsoft/amplifier-foundation#283 and microsoft/amplifier-foundation#284.** They touch disjoint files and can land in either order.

**#283 is a hard API dependency.** This PR calls `prepare(strict=...)`, which does not exist on foundation `main` today, and its error handler relies on `ModuleActivationError` being a `BundleError`. This repo tracks foundation via a `branch = "main"` git dependency, so it picks the change up automatically once #283 lands — no version bump needed. Until then `tests/test_fail_loud_bundle_activation.py::test_error_is_a_bundle_error` fails, deliberately: it makes the merge order an executable gate rather than tribal knowledge.

**#284 is a safety dependency.** It retries transient git clone failures. This PR is the one that turns strictness on, so merging it before the retry lands would escalate a single dropped connection from "silently degraded session" to "no session at all" — trading a quiet failure for a hair-trigger one. The retry is what makes failing loud safe to enable.

## What this changes

**1. Strict activation is on by default**

Foundation supplies the mechanism; choosing to use it is app-layer policy. Every `prepare()` call site passes `strict=_activation_is_strict()`.

**2. `AMPLIFIER_ALLOW_PARTIAL_BUNDLE` escape hatch**

Failing hard can strand a user whose proxy blocks one module host, or whose module repo went private. The escape hatch restores the previous skip-and-continue behaviour. Only clear opt-ins (`1`, `true`, `yes`) disable strictness — anything else, including typos, stays strict.

**3. The failure is rendered, not tracebacked**

Turning strictness on made `ModuleActivationError` fire for the first time, and it reached the user as a raw traceback — worse than the silent degradation it replaced, since the user now sees a stack dump and still does not know what to do. The run command catches it and renders a panel naming the failed modules and the escape hatch.

The handler is placed **before** the generic `except BundleError`. Once foundation#283 lands, `ModuleActivationError` is a `BundleError` subclass, and Python matches handlers top-down — a generic handler placed first would swallow it and the user would lose the remediation hint.

## Tests

`tests/test_fail_loud_bundle_activation.py`:
- strict by default; only clear opt-ins disable it; non-truthy values stay strict
- every `prepare()` call site passes `strict=` — foundation's default is `False`, so an unwired new call site is a silent regression rather than a test error
- the `BundleError` relationship this handler depends on (the cross-repo gate above)
- handler ordering, since it is load-bearing rather than incidental
- the rendered failure names the escape hatch, so a stranded user has a documented way forward

## Verified end-to-end

Both changes were exercised in an isolated container running from local source: silent degradation reproduced on stock code, hard failure with the rendered panel confirmed on patched code, the escape hatch confirmed to restore the old behaviour, and a healthy bundle confirmed to still start normally.
