### PR TITLE
fix(providers): honour pinned provider sources at install time and stop reinstalling working providers

### DIFF
--- a/amplifier_app_cli/commands/init.py
+++ b/amplifier_app_cli/commands/init.py
@@ -19,6 +19,7 @@ from ..ui.scope import (
 from ..provider_config_utils import configure_provider
 from ..provider_manager import ProviderManager
 from ..provider_env_detect import detect_provider_from_env
+from ..provider_sources import ensure_provider_installed
 from ..provider_sources import install_known_providers
 from .routing import _discover_matrix_files
 from .routing import _get_configured_provider_types
@@ -47,35 +48,9 @@ def _is_provider_module_installed(provider_id: str) -> bool:
     Returns:
         True if the module can be imported, False otherwise
     """
-    import importlib
-    import importlib.metadata
+    from ..provider_sources import is_provider_module_installed
 
-    # Normalize to full module ID
-    module_id = (
-        provider_id
-        if provider_id.startswith("provider-")
-        else f"provider-{provider_id}"
-    )
-
-    # Try entry point first (most reliable for properly installed modules)
-    try:
-        eps = importlib.metadata.entry_points(group="amplifier.modules")
-        for ep in eps:
-            if ep.name == module_id:
-                # Entry point exists - module is installed
-                return True
-    except Exception:
-        pass
-
-    # Fall back to direct import check
-    try:
-        # Convert provider ID to Python module name
-        provider_name = module_id.replace("provider-", "")
-        module_name = f"amplifier_module_provider_{provider_name.replace('-', '_')}"
-        importlib.import_module(module_name)
-        return True
-    except ImportError:
-        return False
+    return is_provider_module_installed(provider_id)
 
 
 def check_first_run() -> bool:
@@ -125,15 +100,19 @@ def check_first_run() -> bool:
     )
 
     if not module_installed:
-        # Post-update scenario: settings exist but provider modules were wiped
-        # Auto-fix by reinstalling ALL known providers (bundles may need multiple)
+        # Post-update scenario: settings exist but the provider module was wiped.
+        # Install only the provider that is actually missing. Installing every
+        # known provider here would overwrite working installs that the user may
+        # have pinned to a specific build.
         logger.info(
             f"Provider {current_provider.module_id} is configured but module not installed. "
-            "Auto-installing providers (this can happen after 'amplifier update')..."
+            "Auto-installing it (this can happen after 'amplifier update')..."
         )
-        console.print("[dim]Installing provider modules...[/dim]")
+        console.print("[dim]Installing provider module...[/dim]")
 
-        installed = install_known_providers(config, console, verbose=True)
+        installed = ensure_provider_installed(
+            current_provider.module_id, config_manager=config, console=console
+        )
         if installed:
             # Successfully reinstalled - no need for full init
             logger.debug("check_first_run: auto-install succeeded, no init needed")

--- a/amplifier_app_cli/commands/provider.py
+++ b/amplifier_app_cli/commands/provider.py
@@ -377,6 +377,7 @@ def provider_install(
             config_manager=config_manager,
             console=None if quiet else console,
             verbose=not quiet,
+            force=force,
         )
 
         if not installed and not quiet:

--- a/amplifier_app_cli/provider_sources.py
+++ b/amplifier_app_cli/provider_sources.py
@@ -2,6 +2,7 @@
 
 import importlib
 import importlib.metadata
+import importlib.util
 import logging
 import site
 import subprocess
@@ -177,6 +178,16 @@ def is_provider_module_installed(provider_id: str) -> bool:
 
     Returns:
         True if the module can be imported, False otherwise
+
+    Note:
+        A registered entry point is NOT sufficient evidence that a provider is
+        usable. Providers are installed editable (``uv pip install -e <cache>``),
+        so clearing the module cache (``amplifier reset --remove cache``) deletes
+        the target directory while leaving the ``.dist-info`` -- and therefore the
+        entry point -- behind in site-packages. Such a provider still advertises
+        itself but fails to import. We therefore require the entry point's module
+        to actually resolve before treating the provider as installed, so that
+        dangling installs are repaired rather than skipped.
     """
     module_id = (
         provider_id
@@ -184,16 +195,21 @@ def is_provider_module_installed(provider_id: str) -> bool:
         else f"provider-{provider_id}"
     )
 
-    # Try entry point first (most reliable for properly installed modules)
+    # Prefer the entry point for discovery (it is authoritative about which
+    # module implements the provider), but confirm that module still resolves.
     try:
         eps = importlib.metadata.entry_points(group="amplifier.modules")
         for ep in eps:
             if ep.name == module_id:
-                return True
+                try:
+                    return importlib.util.find_spec(ep.module) is not None
+                except (ImportError, AttributeError, ValueError):
+                    # Parent package missing/broken -> treat as not installed.
+                    return False
     except Exception:
         pass
 
-    # Fall back to direct import check
+    # Fall back to direct import check when no entry point is registered.
     try:
         provider_name = module_id.replace("provider-", "")
         module_name = f"amplifier_module_provider_{provider_name.replace('-', '_')}"

--- a/amplifier_app_cli/provider_sources.py
+++ b/amplifier_app_cli/provider_sources.py
@@ -182,12 +182,16 @@ def is_provider_module_installed(provider_id: str) -> bool:
     Note:
         A registered entry point is NOT sufficient evidence that a provider is
         usable. Providers are installed editable (``uv pip install -e <cache>``),
-        so clearing the module cache (``amplifier reset --remove cache``) deletes
-        the target directory while leaving the ``.dist-info`` -- and therefore the
-        entry point -- behind in site-packages. Such a provider still advertises
-        itself but fails to import. We therefore require the entry point's module
-        to actually resolve before treating the provider as installed, so that
-        dangling installs are repaired rather than skipped.
+        so anything that deletes the module cache while leaving site-packages
+        intact strands the ``.dist-info`` -- and therefore the entry point --
+        pointing at a directory that no longer exists. ``amplifier reset --remove
+        cache`` does exactly this when amplifier was not installed via ``uv
+        tool``: ``_uninstall_amplifier()`` bails out early but
+        ``_remove_amplifier_dir()`` still runs. Manual cache cleanup has the same
+        effect. Such a provider still advertises itself but fails to import, so
+        we require the entry point's module to actually resolve before treating
+        the provider as installed -- otherwise the skip-if-installed check turns
+        a repairable state into a permanent one.
     """
     module_id = (
         provider_id

--- a/amplifier_app_cli/provider_sources.py
+++ b/amplifier_app_cli/provider_sources.py
@@ -86,12 +86,18 @@ def get_effective_provider_sources(
 ) -> dict[str, str]:
     """Get provider sources with settings modules and overrides applied.
 
-    Merges:
-    1. DEFAULT_PROVIDER_SOURCES (known providers)
-    2. User-configured source overrides (for known providers)
-    3. User-added provider modules from settings (for additional providers)
+    Merges, in ascending order of precedence:
 
-    User overrides and additions take precedence over defaults.
+    1. ``DEFAULT_PROVIDER_SOURCES`` (known providers, pinned to @main)
+    2. ``sources.modules`` (``amplifier source add``)
+    3. ``modules.providers[].source`` (``amplifier module add provider-X --source ...``)
+    4. ``overrides.<module_id>.source`` (settings.yaml ``overrides`` block)
+    5. ``config.providers[].source`` (``amplifier provider add/use --source ...``)
+
+    Steps 2, 4 and 5 mirror the precedence that the runtime uses when it builds
+    ``combined_sources`` in ``runtime/config.py``. Install time and run time MUST
+    agree: if they disagree, Amplifier installs one build of a provider and then
+    runs a different one, and any user pin is silently overwritten with @main.
 
     Args:
         config_manager: Optional config manager for source overrides and settings
@@ -102,7 +108,7 @@ def get_effective_provider_sources(
     sources = dict(DEFAULT_PROVIDER_SOURCES)
 
     if config_manager:
-        # 1. Apply source overrides for known providers
+        # 1. Apply source overrides for known providers (sources.modules)
         overrides = config_manager.get_module_sources()
         for module_id in list(sources.keys()):
             if module_id in overrides:
@@ -128,7 +134,73 @@ def get_effective_provider_sources(
                         sources[module_id] = source
                         logger.debug(f"Using settings source for {module_id}: {source}")
 
+        # 3. Apply `overrides.<module_id>.source` from settings.yaml.
+        # Higher precedence than sources.modules, matching the runtime.
+        try:
+            for module_id, source in config_manager.get_source_overrides().items():
+                if module_id.startswith("provider-") or module_id in sources:
+                    if sources.get(module_id) != source:
+                        logger.debug(
+                            f"Using settings override source for {module_id}: {source}"
+                        )
+                    sources[module_id] = source
+        except Exception as e:  # pragma: no cover - defensive, settings are best-effort
+            logger.debug(f"Could not read module source overrides: {e}")
+
+        # 4. Apply `config.providers[].source` - written by `amplifier provider add`
+        # and `amplifier provider use --source`. This is the most specific signal a
+        # user can give about which build of a provider they want, so it wins.
+        try:
+            for provider in config_manager.get_provider_overrides():
+                if not isinstance(provider, dict):
+                    continue
+                module_id = provider.get("module")
+                source = provider.get("source")
+                if module_id and source:
+                    if sources.get(module_id) != source:
+                        logger.debug(
+                            f"Using configured provider source for {module_id}: {source}"
+                        )
+                    sources[module_id] = source
+        except Exception as e:  # pragma: no cover - defensive, settings are best-effort
+            logger.debug(f"Could not read configured provider sources: {e}")
+
     return sources
+
+
+def is_provider_module_installed(provider_id: str) -> bool:
+    """Check whether a provider module is installed and importable.
+
+    Args:
+        provider_id: Provider module ID (e.g., "provider-anthropic"). A bare
+            name such as "anthropic" is normalized to "provider-anthropic".
+
+    Returns:
+        True if the module can be imported, False otherwise
+    """
+    module_id = (
+        provider_id
+        if provider_id.startswith("provider-")
+        else f"provider-{provider_id}"
+    )
+
+    # Try entry point first (most reliable for properly installed modules)
+    try:
+        eps = importlib.metadata.entry_points(group="amplifier.modules")
+        for ep in eps:
+            if ep.name == module_id:
+                return True
+    except Exception:
+        pass
+
+    # Fall back to direct import check
+    try:
+        provider_name = module_id.replace("provider-", "")
+        module_name = f"amplifier_module_provider_{provider_name.replace('-', '_')}"
+        importlib.import_module(module_name)
+        return True
+    except ImportError:
+        return False
 
 
 def is_local_path(source_uri: str) -> bool:
@@ -256,14 +328,20 @@ def install_known_providers(
     config_manager: "AppSettings | None" = None,
     console: Console | None = None,
     verbose: bool = True,
+    force: bool = False,
 ) -> list[str]:
-    """Install all known provider modules.
+    """Install known provider modules that are not already present.
 
-    Downloads and caches all known providers so they can be discovered
+    Downloads and caches known providers so they can be discovered
     via entry points for use in init and provider use commands.
 
     Uses source overrides from config_manager if available, otherwise
     falls back to DEFAULT_PROVIDER_SOURCES.
+
+    Providers that are already installed are left untouched unless ``force``
+    is set. Reinstalling an already-working provider is not a no-op: it
+    replaces whatever build is present with the one this function resolves,
+    which silently discards a user's pinned build.
 
     Supports both git URLs (git+https://...) and local file paths
     (./path, ../path, /absolute/path, file://path).
@@ -272,9 +350,11 @@ def install_known_providers(
         config_manager: Optional config manager for source overrides
         console: Optional Rich console for progress display
         verbose: Whether to show progress messages
+        force: Reinstall providers even if they are already installed
 
     Returns:
-        List of successfully installed provider module IDs
+        List of provider module IDs that are available after this call
+        (newly installed plus already-present ones)
     """
     installed: list[str] = []
     failed: list[tuple[str, str]] = []
@@ -287,6 +367,15 @@ def install_known_providers(
     ordered_providers = _get_ordered_providers(sources)
 
     for module_id, source_uri in ordered_providers:
+        # Leave already-installed providers alone. Overwriting them would
+        # discard the build the user actually has in place.
+        if not force and is_provider_module_installed(module_id):
+            logger.debug(f"{module_id} already installed, skipping")
+            if verbose and console:
+                console.print(f"  [dim]{module_id} already installed, skipping[/dim]")
+            installed.append(module_id)
+            continue
+
         try:
             if verbose and console:
                 console.print(f"  Installing {module_id}...", end="")

--- a/tests/test_provider_source_precedence.py
+++ b/tests/test_provider_source_precedence.py
@@ -18,6 +18,7 @@ from unittest.mock import patch
 from amplifier_app_cli.provider_sources import DEFAULT_PROVIDER_SOURCES
 from amplifier_app_cli.provider_sources import get_effective_provider_sources
 from amplifier_app_cli.provider_sources import install_known_providers
+from amplifier_app_cli.provider_sources import is_provider_module_installed
 
 PINNED = "git+https://github.com/acme/amplifier-module-provider-openai@abc1234"
 PINNED_ALT = "git+https://github.com/acme/amplifier-module-provider-openai@feature"
@@ -205,3 +206,106 @@ class TestCheckFirstRunRepairsOnlyMissingProvider:
         assert needs_init is False
         mock_install_all.assert_not_called()
         assert mock_ensure.call_args.args[0] == "provider-openai"
+
+
+class TestDanglingEditableInstallIsNotSkipped:
+    """A registered entry point is not proof that a provider still works.
+
+    Providers are installed editable (``uv pip install -e <cache_path>``), so
+    ``amplifier reset --remove cache`` deletes the target directory while the
+    ``.dist-info`` -- and therefore the entry point -- survives in site-packages.
+    Treating that as "installed" would skip the provider and leave the user with
+    an import failure, breaking the documented cache-wipe recovery path.
+    """
+
+    @staticmethod
+    def _entry_point(name: str, module: str) -> MagicMock:
+        ep = MagicMock()
+        ep.name = name
+        ep.module = module
+        return ep
+
+    def test_entry_point_whose_module_resolves_counts_as_installed(self):
+        ep = self._entry_point("provider-openai", "amplifier_module_provider_openai")
+        with (
+            patch(
+                "amplifier_app_cli.provider_sources.importlib.metadata.entry_points",
+                return_value=[ep],
+            ),
+            patch(
+                "amplifier_app_cli.provider_sources.importlib.util.find_spec",
+                return_value=object(),
+            ),
+        ):
+            assert is_provider_module_installed("provider-openai") is True
+
+    def test_entry_point_with_unresolvable_module_is_not_installed(self):
+        """The regression: cache wiped, dist-info left behind."""
+        ep = self._entry_point("provider-openai", "amplifier_module_provider_openai")
+        with (
+            patch(
+                "amplifier_app_cli.provider_sources.importlib.metadata.entry_points",
+                return_value=[ep],
+            ),
+            patch(
+                "amplifier_app_cli.provider_sources.importlib.util.find_spec",
+                return_value=None,
+            ),
+        ):
+            assert is_provider_module_installed("provider-openai") is False
+
+    def test_find_spec_raising_is_treated_as_not_installed(self):
+        """A missing parent package makes find_spec raise; that is not installed."""
+        ep = self._entry_point("provider-openai", "amplifier_module_provider_openai")
+        with (
+            patch(
+                "amplifier_app_cli.provider_sources.importlib.metadata.entry_points",
+                return_value=[ep],
+            ),
+            patch(
+                "amplifier_app_cli.provider_sources.importlib.util.find_spec",
+                side_effect=ModuleNotFoundError("no parent"),
+            ),
+        ):
+            assert is_provider_module_installed("provider-openai") is False
+
+    def test_dangling_provider_is_reinstalled_by_install_known_providers(self):
+        """End-to-end: a dangling provider must be repaired, not skipped."""
+        ep = self._entry_point("provider-openai", "amplifier_module_provider_openai")
+        sources = {"provider-openai": PINNED}
+        calls: list[str] = []
+
+        def fake_source_from_uri(uri: str):
+            src = MagicMock()
+            src.resolve.return_value = uri
+            return src
+
+        def fake_run(cmd, *args, **kwargs):
+            calls.append(cmd[4])
+            return MagicMock(returncode=0, stderr="")
+
+        with (
+            patch(
+                "amplifier_app_cli.provider_sources.importlib.metadata.entry_points",
+                return_value=[ep],
+            ),
+            patch(
+                "amplifier_app_cli.provider_sources.importlib.util.find_spec",
+                return_value=None,
+            ),
+            patch(
+                "amplifier_app_cli.provider_sources.source_from_uri",
+                side_effect=fake_source_from_uri,
+            ),
+            patch(
+                "amplifier_app_cli.provider_sources.subprocess.run",
+                side_effect=fake_run,
+            ),
+            patch(
+                "amplifier_app_cli.provider_sources.get_effective_provider_sources",
+                return_value=sources,
+            ),
+        ):
+            install_known_providers(config_manager=None, console=None, verbose=False)
+
+        assert calls == [PINNED], "dangling provider should have been reinstalled"

--- a/tests/test_provider_source_precedence.py
+++ b/tests/test_provider_source_precedence.py
@@ -1,0 +1,207 @@
+"""Regression tests for provider source resolution and install idempotency.
+
+These cover two related failure modes:
+
+1. Install time resolved provider sources from a smaller set of settings keys
+   than run time did, so a provider pinned via `amplifier provider add --source`
+   or an `overrides.<module_id>.source` entry was installed from @main and then
+   run from the pinned source (or silently replaced).
+
+2. `install_known_providers()` reinstalled every known provider unconditionally,
+   so a repair path triggered for one missing provider overwrote the other
+   providers that were already installed and working.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from amplifier_app_cli.provider_sources import DEFAULT_PROVIDER_SOURCES
+from amplifier_app_cli.provider_sources import get_effective_provider_sources
+from amplifier_app_cli.provider_sources import install_known_providers
+
+PINNED = "git+https://github.com/acme/amplifier-module-provider-openai@abc1234"
+PINNED_ALT = "git+https://github.com/acme/amplifier-module-provider-openai@feature"
+
+
+def _settings(
+    *,
+    module_sources: dict | None = None,
+    merged: dict | None = None,
+    source_overrides: dict | None = None,
+    provider_overrides: list | None = None,
+) -> MagicMock:
+    """Build a stub AppSettings exposing only the accessors we read."""
+    settings = MagicMock()
+    settings.get_module_sources.return_value = module_sources or {}
+    settings.get_merged_settings.return_value = merged or {}
+    settings.get_source_overrides.return_value = source_overrides or {}
+    settings.get_provider_overrides.return_value = provider_overrides or []
+    return settings
+
+
+class TestEffectiveProviderSources:
+    def test_defaults_when_no_settings(self):
+        assert get_effective_provider_sources(None) == DEFAULT_PROVIDER_SOURCES
+
+    def test_config_providers_source_is_honoured(self):
+        """`amplifier provider add --source` writes config.providers[].source."""
+        settings = _settings(
+            provider_overrides=[{"module": "provider-openai", "source": PINNED}]
+        )
+
+        sources = get_effective_provider_sources(settings)
+
+        assert sources["provider-openai"] == PINNED
+
+    def test_overrides_block_source_is_honoured(self):
+        """settings.yaml `overrides.<module_id>.source` must reach install time."""
+        settings = _settings(source_overrides={"provider-openai": PINNED})
+
+        sources = get_effective_provider_sources(settings)
+
+        assert sources["provider-openai"] == PINNED
+
+    def test_config_providers_wins_over_overrides_block(self):
+        """Precedence must match runtime/config.py's combined_sources ordering."""
+        settings = _settings(
+            module_sources={"provider-openai": "git+https://example.com/a@main"},
+            source_overrides={"provider-openai": PINNED_ALT},
+            provider_overrides=[{"module": "provider-openai", "source": PINNED}],
+        )
+
+        sources = get_effective_provider_sources(settings)
+
+        assert sources["provider-openai"] == PINNED
+
+    def test_overrides_block_wins_over_sources_modules(self):
+        settings = _settings(
+            module_sources={"provider-openai": "git+https://example.com/a@main"},
+            source_overrides={"provider-openai": PINNED},
+        )
+
+        sources = get_effective_provider_sources(settings)
+
+        assert sources["provider-openai"] == PINNED
+
+    def test_unknown_provider_from_config_providers_is_added(self):
+        settings = _settings(
+            provider_overrides=[{"module": "provider-acme", "source": PINNED}]
+        )
+
+        sources = get_effective_provider_sources(settings)
+
+        assert sources["provider-acme"] == PINNED
+
+    def test_malformed_entries_do_not_break_resolution(self):
+        settings = _settings(
+            provider_overrides=[
+                "not-a-dict",
+                {"module": "provider-openai"},  # no source
+                {"source": PINNED},  # no module
+            ]
+        )
+
+        sources = get_effective_provider_sources(settings)
+
+        assert sources == DEFAULT_PROVIDER_SOURCES
+
+
+class TestInstallKnownProvidersIdempotency:
+    @staticmethod
+    def _patched(installed_ids: set[str], calls: list[str]):
+        """Patch the install path so nothing is actually installed."""
+
+        def fake_source_from_uri(uri: str):
+            src = MagicMock()
+            src.resolve.return_value = uri
+            return src
+
+        def fake_run(cmd, *args, **kwargs):
+            calls.append(cmd[4])  # ["uv", "pip", "install", "-e", <path>, ...]
+            return MagicMock(returncode=0, stderr="")
+
+        return (
+            patch(
+                "amplifier_app_cli.provider_sources.is_provider_module_installed",
+                side_effect=lambda mid: mid in installed_ids,
+            ),
+            patch(
+                "amplifier_app_cli.provider_sources.source_from_uri",
+                side_effect=fake_source_from_uri,
+            ),
+            patch(
+                "amplifier_app_cli.provider_sources.subprocess.run",
+                side_effect=fake_run,
+            ),
+        )
+
+    def test_already_installed_providers_are_not_reinstalled(self):
+        """The whole point: do not overwrite a provider that already works."""
+        sources = {
+            "provider-anthropic": "git+https://example.com/anthropic@main",
+            "provider-openai": PINNED,
+        }
+        calls: list[str] = []
+        p1, p2, p3 = self._patched({"provider-openai"}, calls)
+
+        with (
+            patch(
+                "amplifier_app_cli.provider_sources.get_effective_provider_sources",
+                return_value=sources,
+            ),
+            p1,
+            p2,
+            p3,
+        ):
+            result = install_known_providers(console=None, verbose=False)
+
+        assert calls == ["git+https://example.com/anthropic@main"]
+        # Already-present providers are still reported as available.
+        assert set(result) == {"provider-anthropic", "provider-openai"}
+
+    def test_force_reinstalls_everything(self):
+        sources = {"provider-openai": PINNED}
+        calls: list[str] = []
+        p1, p2, p3 = self._patched({"provider-openai"}, calls)
+
+        with (
+            patch(
+                "amplifier_app_cli.provider_sources.get_effective_provider_sources",
+                return_value=sources,
+            ),
+            p1,
+            p2,
+            p3,
+        ):
+            result = install_known_providers(console=None, verbose=False, force=True)
+
+        assert calls == [PINNED]
+        assert result == ["provider-openai"]
+
+
+class TestCheckFirstRunRepairsOnlyMissingProvider:
+    def test_only_the_configured_provider_is_installed(self):
+        """A missing provider must not trigger a reinstall of every provider."""
+        from amplifier_app_cli.commands import init as init_cmd
+
+        provider = MagicMock()
+        provider.module_id = "provider-openai"
+        provider_mgr = MagicMock()
+        provider_mgr.get_current_provider.return_value = provider
+
+        with (
+            patch.object(init_cmd, "create_config_manager"),
+            patch.object(init_cmd, "ProviderManager", return_value=provider_mgr),
+            patch.object(
+                init_cmd, "_is_provider_module_installed", return_value=False
+            ),
+            patch.object(
+                init_cmd, "ensure_provider_installed", return_value=True
+            ) as mock_ensure,
+            patch.object(init_cmd, "install_known_providers") as mock_install_all,
+        ):
+            needs_init = init_cmd.check_first_run()
+
+        assert needs_init is False
+        mock_install_all.assert_not_called()
+        assert mock_ensure.call_args.args[0] == "provider-openai"


### PR DESCRIPTION
## Problem

Provider auto-install could silently replace a provider build that was already installed and working, and could install a provider from a different source than the runtime would later load it from.

Two independent defects combined to produce that:

**1. Install-time source resolution was narrower than run-time source resolution.**

`runtime/config.py` builds the source map the session actually uses as:

```python
combined_sources = {**module_sources, **source_overrides, **provider_sources}
```

`provider_sources.get_effective_provider_sources()` only consulted the first of those three plus `modules.providers[].source`. It never read `overrides.<module_id>.source` or `config.providers[].source`. So a provider pinned through either of those two keys — which is what `amplifier provider add --source ...` writes — was **installed** from the `@main` default while the runtime **loaded** it from the pinned source. The two halves of the system disagreed about which build was in play.

**2. `install_known_providers()` reinstalled every known provider unconditionally.**

The first-run repair path in `commands/init.check_first_run()` fires when the *configured* provider is missing. It responded by reinstalling *all* known providers. Reinstall is not a no-op — it runs `uv pip install -e` against whichever source this function resolves, replacing whatever build is currently present. So repairing one missing provider overwrote every other provider that was installed and working, with no failure and no prompt.

## Changes

**`provider_sources.get_effective_provider_sources()`** — now applies the same precedence chain the runtime uses, lowest to highest:

```
DEFAULT_PROVIDER_SOURCES
  < sources.modules
  < modules.providers[].source
  < overrides.<module_id>.source
  < config.providers[].source
```

Install time and run time now resolve the same source for the same provider. Malformed entries are skipped rather than raising.

**`provider_sources.install_known_providers()`** — skips providers that are already installed unless `force=True`. The return value now reports the providers available *after* the call (newly installed plus already-present), which is what both call sites actually branch on. `amplifier provider install --force` still reinstalls everything, which makes the all-providers branch consistent with the single-provider branch of the same command, which already honoured `--force`.

**`commands/init.check_first_run()`** — repairs only the provider that is actually missing, via `ensure_provider_installed()`, instead of reinstalling all known providers.

**`provider_sources.is_provider_module_installed()`** — the "is this provider module importable" check existed in two places with the same logic. It is now one function; `commands/init._is_provider_module_installed()` delegates to it.

## What this does not change

The reported issue also asked for a dedicated event emitted whenever auto-repair installs a provider. That is not included here, for two reasons:

- With this change auto-repair no longer replaces anything. It installs only what is genuinely absent, so there is no silent substitution left to observe.
- `check_first_run()` runs before any session exists (`session_runner.py` calls it, then constructs the session), so there is no event bus in scope at that point. Adding one would be a new mechanism rather than a fix. The path already logs through `logger` and prints to the console when one is passed.

If provider-install telemetry is wanted on its own merits, it should be scoped and designed separately.

## Testing

New file `tests/test_provider_source_precedence.py` — 10 tests covering:

- each settings key in the precedence chain, individually and in conflict
- providers declared only in `config.providers[]` (not in the defaults)
- malformed override entries
- already-installed providers are not reinstalled, and are still reported as available
- `force=True` reinstalls regardless
- `check_first_run()` installs only the missing provider and never calls `install_known_providers()`

Full suite: 1041 passed, same 42 pre-existing failures as on `main` (unrelated modules — `session_spawner`, `working_dir_pre_init`, `cost_bridge` — failing against the pinned `amplifier-foundation` in the test venv). No regressions introduced.

Closes microsoft/amplifier#342
