### PR TITLE
fix(providers): repair all configured provider modules, not just the active one

### DIFF
--- a/amplifier_app_cli/commands/init.py
+++ b/amplifier_app_cli/commands/init.py
@@ -19,7 +19,6 @@ from ..ui.scope import (
 from ..provider_config_utils import configure_provider
 from ..provider_manager import ProviderManager
 from ..provider_env_detect import detect_provider_from_env
-from ..provider_sources import ensure_provider_installed
 from ..provider_sources import install_known_providers
 from .routing import _discover_matrix_files
 from .routing import _get_configured_provider_types
@@ -53,6 +52,48 @@ def _is_provider_module_installed(provider_id: str) -> bool:
     return is_provider_module_installed(provider_id)
 
 
+def _configured_provider_modules(
+    config: AppSettings, active_module_id: str
+) -> list[str]:
+    """Ordered unique provider module IDs configured in settings.
+
+    The active provider is always first: it is configured by definition, and
+    check_first_run()'s return value is driven by it.
+
+    Reads `config.providers` via the same accessor the rest of the install path
+    uses (`provider_sources.get_effective_provider_sources()` reads it too), so
+    install time and this check agree on what "configured" means. Malformed
+    entries are skipped rather than raised on - a hand-edited settings.yaml
+    must never prevent Amplifier from booting.
+
+    Args:
+        config: Config manager (AppSettings) to read configured providers from
+        active_module_id: Module ID of the currently active provider
+
+    Returns:
+        Ordered list of unique provider module IDs, active provider first
+    """
+    modules = [active_module_id]
+
+    try:
+        configured = config.get_provider_overrides()
+    except Exception as e:  # pragma: no cover - defensive, settings are best-effort
+        logger.debug(f"Could not read configured providers: {e}")
+        return modules
+
+    if not isinstance(configured, list):
+        return modules
+
+    for entry in configured:
+        if not isinstance(entry, dict):
+            continue
+        module_id = entry.get("module")
+        if module_id and module_id not in modules:
+            modules.append(module_id)
+
+    return modules
+
+
 def check_first_run() -> bool:
     """Check if this appears to be first run (no provider configured).
 
@@ -70,10 +111,22 @@ def check_first_run() -> bool:
     2. No surprise defaults that may not match bundle requirements
     3. Clear error path when nothing is configured
 
-    If a provider is configured but its module is missing (post-update scenario where
+    If ANY configured provider's module is missing (post-update scenario where
     `amplifier update` wiped the venv), this function will automatically reinstall
     all known provider modules without user interaction. We install ALL providers
     (not just the configured one) because bundles may include multiple providers.
+
+    The repair is gated on every configured module, not just the active one:
+    `amplifier update` and `amplifier reset` install no providers themselves, so
+    this is the single funnel for update, reset, and fresh install. Gating on the
+    active provider alone would leave a hole - if the active provider happens to
+    be installed but another configured provider is missing (a transient install
+    failure, a hand-edited settings.yaml, a single-provider `amplifier provider
+    install`), no boot would ever repair it.
+
+    Return value stays driven by the ACTIVE provider only: True means "push the
+    user into the add-a-provider prompt", which a non-active provider failing to
+    install must never trigger.
     """
     config = create_config_manager()
     provider_mgr = ProviderManager(config)
@@ -92,41 +145,62 @@ def check_first_run() -> bool:
         )
         return True
 
-    # Provider is configured - check if its module is actually installed
-    module_installed = _is_provider_module_installed(current_provider.module_id)
+    # Provider is configured - check whether EVERY configured module is installed.
+    # This is a find_spec per configured module: no subprocess, no network.
+    configured_modules = _configured_provider_modules(
+        config, current_provider.module_id
+    )
+    missing = [m for m in configured_modules if not _is_provider_module_installed(m)]
     logger.debug(
         f"check_first_run: provider={current_provider.module_id}, "
-        f"module_installed={module_installed}"
+        f"configured_modules={configured_modules}, missing={missing}"
     )
 
-    if not module_installed:
-        # Post-update scenario: settings exist but the provider module was wiped.
-        # Install only the provider that is actually missing. Installing every
-        # known provider here would overwrite working installs that the user may
-        # have pinned to a specific build.
+    if missing:
+        # Post-update scenario: settings exist but provider modules were wiped.
+        # `amplifier update`/`amplifier reset` wipe the whole tool venv, not just
+        # the active provider's module, so we must reinstall ALL known provider
+        # modules here, not just the configured one -- otherwise every other
+        # provider instance the user has configured silently fails to mount.
+        # This is safe: install_known_providers(force=False) skips any provider
+        # that is already installed, so it never overwrites a working/pinned
+        # install -- it only repairs what's genuinely missing.
         logger.info(
-            f"Provider {current_provider.module_id} is configured but module not installed. "
-            "Auto-installing it (this can happen after 'amplifier update')..."
+            f"Configured provider modules not installed: {', '.join(missing)}. "
+            "Auto-installing all known providers (this can happen after 'amplifier update')..."
         )
-        console.print("[dim]Installing provider module...[/dim]")
+        console.print("[dim]Installing provider modules...[/dim]")
 
-        installed = ensure_provider_installed(
-            current_provider.module_id, config_manager=config, console=console
-        )
-        if installed:
-            # Successfully reinstalled - no need for full init
+        installed = install_known_providers(config, console, verbose=True)
+
+        # A configured provider whose module is neither a known provider nor
+        # carries a `source:` cannot be repaired here. Say so and move on --
+        # blocking would trap the user in the init prompt on every boot.
+        still_missing = [m for m in missing if m not in installed]
+        if still_missing:
+            logger.warning(
+                "Could not install configured provider module(s): "
+                f"{', '.join(still_missing)}. Instances using them will not load."
+            )
+            console.print(
+                f"[yellow]Could not install: {', '.join(still_missing)}. "
+                "Instances using them will not load.[/yellow]"
+            )
+
+        if current_provider.module_id in installed:
+            # Active provider is usable - session can start.
             logger.debug("check_first_run: auto-install succeeded, no init needed")
             console.print()
             return False
         else:
-            # Auto-fix failed - fall back to provider add prompt
+            # Auto-fix failed for the ACTIVE provider - fall back to add prompt.
             logger.warning(
                 "Failed to auto-install providers after detecting missing modules. "
                 "Will prompt user to add a provider."
             )
             return True
 
-    # Provider configured and module installed - no init needed
+    # Provider configured and all configured modules installed - no init needed
     logger.debug(
         f"check_first_run: provider {current_provider.module_id} configured and installed, "
         "no init needed"

--- a/amplifier_app_cli/commands/init.py
+++ b/amplifier_app_cli/commands/init.py
@@ -187,7 +187,23 @@ def check_first_run() -> bool:
                 "Instances using them will not load.[/yellow]"
             )
 
-        if current_provider.module_id in installed:
+        # Both terms are load-bearing; do not "simplify" either away.
+        # `in installed` is the cheap short-circuit for the common path.
+        # `_is_provider_module_installed()` is the semantic truth: a provider
+        # installed locally for development (`uv pip install -e ...`, no
+        # `source:` in settings) is importable and usable, but is never
+        # iterated by install_known_providers() and so never appears in
+        # `installed`. Checking only the list would tell such a user "No
+        # provider configured!" about a provider that works. Conversely,
+        # checking only importability would be fragile: install_known_providers()
+        # does a manual cache-refresh dance (invalidate_caches / addsitedir /
+        # list(distributions)) precisely because subprocess installs are not
+        # immediately visible to the running process -- if that refresh is ever
+        # imperfect, a direct-only check would produce a false init prompt on
+        # the common path.
+        if current_provider.module_id in installed or _is_provider_module_installed(
+            current_provider.module_id
+        ):
             # Active provider is usable - session can start.
             logger.debug("check_first_run: auto-install succeeded, no init needed")
             console.print()

--- a/amplifier_app_cli/commands/init.py
+++ b/amplifier_app_cli/commands/init.py
@@ -187,23 +187,19 @@ def check_first_run() -> bool:
                 "Instances using them will not load.[/yellow]"
             )
 
-        # Both terms are load-bearing; do not "simplify" either away.
-        # `in installed` is the cheap short-circuit for the common path.
-        # `_is_provider_module_installed()` is the semantic truth: a provider
+        # Ask whether the module is importable -- do not trust the repair's
+        # self-report. install_known_providers() appends a module to `installed`
+        # on subprocess rc == 0 alone, without ever importing it, so an install
+        # that exits 0 but yields an unusable module (broken dependency, entry
+        # point naming a module absent from the built package, stranded
+        # .dist-info) is still reported as installed. Same principle as
+        # is_provider_module_installed()'s docstring: a registered entry point
+        # is NOT sufficient evidence that a provider is usable. Membership in
+        # `installed` is weaker still. It is also not a superset -- a provider
         # installed locally for development (`uv pip install -e ...`, no
-        # `source:` in settings) is importable and usable, but is never
-        # iterated by install_known_providers() and so never appears in
-        # `installed`. Checking only the list would tell such a user "No
-        # provider configured!" about a provider that works. Conversely,
-        # checking only importability would be fragile: install_known_providers()
-        # does a manual cache-refresh dance (invalidate_caches / addsitedir /
-        # list(distributions)) precisely because subprocess installs are not
-        # immediately visible to the running process -- if that refresh is ever
-        # imperfect, a direct-only check would produce a false init prompt on
-        # the common path.
-        if current_provider.module_id in installed or _is_provider_module_installed(
-            current_provider.module_id
-        ):
+        # `source:` in settings) is never iterated by install_known_providers()
+        # and so never appears there, despite working fine.
+        if _is_provider_module_installed(current_provider.module_id):
             # Active provider is usable - session can start.
             logger.debug("check_first_run: auto-install succeeded, no init needed")
             console.print()

--- a/tests/test_check_first_run_installs_all_providers.py
+++ b/tests/test_check_first_run_installs_all_providers.py
@@ -52,18 +52,27 @@ class TestCheckFirstRunRepairsAllKnownProviders:
         provider_mgr = MagicMock()
         provider_mgr.get_current_provider.return_value = provider
 
+        present: set[str] = set()  # wiped venv; repair makes these importable
+
         with (
             patch.object(init_cmd, "create_config_manager"),
             patch.object(init_cmd, "ProviderManager", return_value=provider_mgr),
-            patch.object(init_cmd, "_is_provider_module_installed", return_value=False),
+            patch.object(
+                init_cmd,
+                "_is_provider_module_installed",
+                side_effect=lambda m: m in present,
+            ),
             patch.object(
                 init_cmd,
                 "install_known_providers",
-                return_value=[
-                    "provider-anthropic",
-                    "provider-openai",
-                    "provider-chat-completions",
-                ],
+                side_effect=_stateful_install(
+                    present,
+                    [
+                        "provider-anthropic",
+                        "provider-openai",
+                        "provider-chat-completions",
+                    ],
+                ),
             ) as mock_install_all,
         ):
             needs_init = init_cmd.check_first_run()
@@ -91,6 +100,8 @@ class TestCheckFirstRunRepairsAllKnownProviders:
         }
 
         attempted: list[str] = []
+        present: set[str] = set()  # wiped venv; a successful install fills this
+        module_for_uri = {uri: module for module, uri in sources.items()}
 
         def fake_source_from_uri(uri: str):
             src = MagicMock()
@@ -98,20 +109,28 @@ class TestCheckFirstRunRepairsAllKnownProviders:
             return src
 
         def fake_run(cmd, *args, **kwargs):
-            attempted.append(cmd[4])  # ["uv", "pip", "install", "-e", <path>, ...]
+            uri = cmd[4]  # ["uv", "pip", "install", "-e", <path>, ...]
+            attempted.append(uri)
+            # Installing a module makes it importable -- model that, so the
+            # post-repair check sees the world the install actually produced.
+            present.add(module_for_uri[uri])
             return MagicMock(returncode=0, stderr="")
 
         with (
             patch.object(init_cmd, "create_config_manager"),
             patch.object(init_cmd, "ProviderManager", return_value=provider_mgr),
-            patch.object(init_cmd, "_is_provider_module_installed", return_value=False),
+            patch.object(
+                init_cmd,
+                "_is_provider_module_installed",
+                side_effect=lambda m: m in present,
+            ),
             patch(
                 "amplifier_app_cli.provider_sources.get_effective_provider_sources",
                 return_value=sources,
             ),
             patch(
                 "amplifier_app_cli.provider_sources.is_provider_module_installed",
-                return_value=False,
+                side_effect=lambda m: m in present,
             ),
             patch(
                 "amplifier_app_cli.provider_sources.source_from_uri",
@@ -187,6 +206,25 @@ class TestCheckFirstRunRepairsAllKnownProviders:
         assert attempted == [sources["provider-anthropic"]], (
             "already-installed provider-openai must not be reinstalled/overwritten"
         )
+
+
+def _stateful_install(present: set, installs: list) -> "object":
+    """install_known_providers() stub that makes what it installs importable.
+
+    Installing a provider changes its importability, so a repair stub must
+    update the state the installed-check reads. Pairing a constant
+    `_is_provider_module_installed -> False` mock with a repair that reports
+    success encodes a world where installation never actually works -- the
+    repair path could never be observed to succeed, and the test would only
+    pass while check_first_run() trusted the repair's self-report instead of
+    verifying importability.
+    """
+
+    def _install(*args, **kwargs):
+        present.update(installs)
+        return list(installs)
+
+    return _install
 
 
 def _config_with_providers(entries: list) -> MagicMock:
@@ -314,18 +352,24 @@ class TestCheckFirstRunGatesOnAllConfiguredModules:
             ]
         )
 
+        present: set[str] = set()  # wiped venv; repair makes these importable
+
         with (
             patch.object(init_cmd, "create_config_manager", return_value=config),
             patch.object(
                 init_cmd, "ProviderManager", return_value=_provider_mgr("provider-anthropic")
             ),
             patch.object(
-                init_cmd, "_is_provider_module_installed", return_value=False
+                init_cmd,
+                "_is_provider_module_installed",
+                side_effect=lambda m: m in present,
             ),
             patch.object(
                 init_cmd,
                 "install_known_providers",
-                return_value=["provider-anthropic", "provider-openai"],
+                side_effect=_stateful_install(
+                    present, ["provider-anthropic", "provider-openai"]
+                ),
             ) as mock_install,
         ):
             needs_init = init_cmd.check_first_run()
@@ -426,6 +470,49 @@ class TestCheckFirstRunGatesOnAllConfiguredModules:
         assert needs_init is False, (
             "a locally installed active provider is usable even though it never "
             "appears in install_known_providers()'s return list"
+        )
+
+    def test_active_reported_installed_but_not_importable_must_not_start_session(self):
+        """`installed` is a self-report, not evidence the module works.
+
+        install_known_providers() appends a module to its return list on
+        subprocess `rc == 0` alone -- it never confirms importability. An
+        install can exit 0 and still yield an unusable module: a broken
+        dependency, an entry point naming a module absent from the built
+        package, a stranded `.dist-info`. Such a module lands in `installed`
+        while is_provider_module_installed() correctly reports False.
+
+        Trusting the self-report would boot a session with a dead active
+        provider. This is the same principle is_provider_module_installed()'s
+        own docstring states: a registered entry point is NOT sufficient
+        evidence that a provider is usable.
+        """
+        from amplifier_app_cli.commands import init as init_cmd
+
+        config = _config_with_providers(
+            [{"module": "provider-anthropic"}, {"module": "provider-openai"}]
+        )
+
+        with (
+            patch.object(init_cmd, "create_config_manager", return_value=config),
+            patch.object(
+                init_cmd,
+                "ProviderManager",
+                return_value=_provider_mgr("provider-anthropic"),
+            ),
+            # Repair claims success for both, but the module is still not importable.
+            patch.object(init_cmd, "_is_provider_module_installed", return_value=False),
+            patch.object(
+                init_cmd,
+                "install_known_providers",
+                return_value=["provider-anthropic", "provider-openai"],
+            ),
+        ):
+            needs_init = init_cmd.check_first_run()
+
+        assert needs_init is True, (
+            "a provider that reports installed but cannot be imported must not "
+            "be treated as usable"
         )
 
     def test_no_provider_configured_still_needs_init(self):

--- a/tests/test_check_first_run_installs_all_providers.py
+++ b/tests/test_check_first_run_installs_all_providers.py
@@ -381,6 +381,53 @@ class TestCheckFirstRunGatesOnAllConfiguredModules:
             "the warning must name the module that could not be installed"
         )
 
+    def test_locally_developed_active_provider_is_not_forced_into_init(self):
+        """A locally editable-installed active provider must not force init.
+
+        `install_known_providers()` only ever iterates
+        `get_effective_provider_sources()` -- the known providers plus anything
+        carrying an explicit `source:`. A provider module installed locally for
+        development (`uv pip install -e ...`, no `source:` in settings) is
+        importable and perfectly usable, but never appears in the returned
+        `installed` list.
+
+        So membership in `installed` is NOT the same question as "is the active
+        provider usable". Gating solely on `in installed` means: active provider
+        is local-dev AND some other configured provider is missing -> the repair
+        block runs -> the active module is absent from `installed` -> we return
+        True and tell the user "No provider configured!" about a provider that
+        is configured and working. Non-interactively, auto_init_from_env() then
+        writes provider config they never asked for.
+        """
+        from amplifier_app_cli.commands import init as init_cmd
+
+        config = _config_with_providers(
+            [
+                {"module": "provider-localdev"},  # active, installed, NOT in sources
+                {"module": "provider-openai"},  # missing, IS in sources
+            ]
+        )
+        present = {"provider-localdev"}
+
+        with (
+            patch.object(init_cmd, "create_config_manager", return_value=config),
+            patch.object(
+                init_cmd, "ProviderManager", return_value=_provider_mgr("provider-localdev")
+            ),
+            patch.object(
+                init_cmd, "_is_provider_module_installed", side_effect=lambda m: m in present
+            ),
+            patch.object(
+                init_cmd, "install_known_providers", return_value=["provider-openai"]
+            ),
+        ):
+            needs_init = init_cmd.check_first_run()
+
+        assert needs_init is False, (
+            "a locally installed active provider is usable even though it never "
+            "appears in install_known_providers()'s return list"
+        )
+
     def test_no_provider_configured_still_needs_init(self):
         """Unchanged existing behavior -- must not regress."""
         from amplifier_app_cli.commands import init as init_cmd

--- a/tests/test_check_first_run_installs_all_providers.py
+++ b/tests/test_check_first_run_installs_all_providers.py
@@ -1,0 +1,396 @@
+"""Regression test: check_first_run() must repair ALL missing provider modules.
+
+PR #238 narrowed the missing-module repair branch in ``check_first_run()`` from
+``install_known_providers()`` (attempts every known provider, skip-if-installed)
+to ``ensure_provider_installed()`` (installs only the currently *active*
+provider module). The stated reason was to avoid overwriting providers the
+user may have pinned to a specific build.
+
+That concern is already handled by the skip-if-installed guard that the same
+PR added inside ``install_known_providers()`` (see
+``TestInstallKnownProvidersIdempotency`` in test_provider_source_precedence.py):
+with ``force=False`` (the default), already-installed providers are left
+untouched. The call-site narrowing was therefore redundant defense -- and it
+introduced a real regression.
+
+The failure mode this branch exists to repair -- `amplifier update` or
+`amplifier reset` wiping the tool venv -- removes ALL provider modules, not
+just the active one. A user with multiple provider instances configured
+(e.g. anthropic + openai + chat-completions) only got their active provider
+reinstalled; every other declared provider silently failed to mount on next
+boot, producing errors like:
+
+    Partial provider failure: 4/10 loaded. Missing: {'openai': 1, ...}
+
+This test pins the correct behavior: the repair path must attempt every
+known/declared provider module, not just the active one.
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestCheckFirstRunRepairsAllKnownProviders:
+    def test_check_first_run_calls_install_known_providers_not_single(self):
+        """The repair branch must drive install_known_providers() (all known
+        providers, skip-if-installed) rather than a single-module install.
+
+        `init.py` must not even import `ensure_provider_installed` for this
+        call site any more -- asserting that import is gone is itself part
+        of the regression guard, since its presence is what let the narrowed
+        call site regress silently in the first place.
+        """
+        from amplifier_app_cli.commands import init as init_cmd
+
+        assert not hasattr(init_cmd, "ensure_provider_installed"), (
+            "check_first_run()'s repair path must use install_known_providers() "
+            "exclusively; a lingering ensure_provider_installed import is how "
+            "the single-module regression crept back in"
+        )
+
+        provider = MagicMock()
+        provider.module_id = "provider-anthropic"
+        provider_mgr = MagicMock()
+        provider_mgr.get_current_provider.return_value = provider
+
+        with (
+            patch.object(init_cmd, "create_config_manager"),
+            patch.object(init_cmd, "ProviderManager", return_value=provider_mgr),
+            patch.object(init_cmd, "_is_provider_module_installed", return_value=False),
+            patch.object(
+                init_cmd,
+                "install_known_providers",
+                return_value=[
+                    "provider-anthropic",
+                    "provider-openai",
+                    "provider-chat-completions",
+                ],
+            ) as mock_install_all,
+        ):
+            needs_init = init_cmd.check_first_run()
+
+        assert needs_init is False
+        mock_install_all.assert_called_once()
+
+    def test_end_to_end_every_declared_provider_module_is_attempted(self):
+        """Pin the actual outcome, not just the call: with settings declaring
+        THREE distinct provider modules and a wiped venv (nothing installed),
+        every one of them must be attempted for install -- not just the
+        currently active provider.
+        """
+        from amplifier_app_cli.commands import init as init_cmd
+
+        provider = MagicMock()
+        provider.module_id = "provider-anthropic"
+        provider_mgr = MagicMock()
+        provider_mgr.get_current_provider.return_value = provider
+
+        sources = {
+            "provider-anthropic": "git+https://example.com/anthropic@main",
+            "provider-openai": "git+https://example.com/openai@main",
+            "provider-chat-completions": "git+https://example.com/chat-completions@main",
+        }
+
+        attempted: list[str] = []
+
+        def fake_source_from_uri(uri: str):
+            src = MagicMock()
+            src.resolve.return_value = uri
+            return src
+
+        def fake_run(cmd, *args, **kwargs):
+            attempted.append(cmd[4])  # ["uv", "pip", "install", "-e", <path>, ...]
+            return MagicMock(returncode=0, stderr="")
+
+        with (
+            patch.object(init_cmd, "create_config_manager"),
+            patch.object(init_cmd, "ProviderManager", return_value=provider_mgr),
+            patch.object(init_cmd, "_is_provider_module_installed", return_value=False),
+            patch(
+                "amplifier_app_cli.provider_sources.get_effective_provider_sources",
+                return_value=sources,
+            ),
+            patch(
+                "amplifier_app_cli.provider_sources.is_provider_module_installed",
+                return_value=False,
+            ),
+            patch(
+                "amplifier_app_cli.provider_sources.source_from_uri",
+                side_effect=fake_source_from_uri,
+            ),
+            patch(
+                "amplifier_app_cli.provider_sources.subprocess.run",
+                side_effect=fake_run,
+            ),
+        ):
+            needs_init = init_cmd.check_first_run()
+
+        assert needs_init is False
+        assert set(attempted) == set(sources.values()), (
+            "every declared provider module must be attempted for install, "
+            "not just the currently active one"
+        )
+
+    def test_already_installed_providers_are_still_not_overwritten(self):
+        """The revert must not reintroduce the OTHER regression #238 fixed:
+        install_known_providers()'s skip-if-installed guard (force=False) is
+        what makes it safe to call unconditionally from check_first_run().
+        A provider that is already installed must not be reinstalled/overwritten.
+        """
+        from amplifier_app_cli.commands import init as init_cmd
+
+        provider = MagicMock()
+        provider.module_id = "provider-anthropic"
+        provider_mgr = MagicMock()
+        provider_mgr.get_current_provider.return_value = provider
+
+        sources = {
+            "provider-anthropic": "git+https://example.com/anthropic@main",
+            "provider-openai": "git+https://example.com/openai@main",
+        }
+
+        attempted: list[str] = []
+
+        def fake_source_from_uri(uri: str):
+            src = MagicMock()
+            src.resolve.return_value = uri
+            return src
+
+        def fake_run(cmd, *args, **kwargs):
+            attempted.append(cmd[4])
+            return MagicMock(returncode=0, stderr="")
+
+        with (
+            patch.object(init_cmd, "create_config_manager"),
+            patch.object(init_cmd, "ProviderManager", return_value=provider_mgr),
+            # The active provider's module is missing (triggers the repair path)...
+            patch.object(init_cmd, "_is_provider_module_installed", return_value=False),
+            patch(
+                "amplifier_app_cli.provider_sources.get_effective_provider_sources",
+                return_value=sources,
+            ),
+            # ...but provider-openai is already installed and must be left alone.
+            patch(
+                "amplifier_app_cli.provider_sources.is_provider_module_installed",
+                side_effect=lambda mid: mid == "provider-openai",
+            ),
+            patch(
+                "amplifier_app_cli.provider_sources.source_from_uri",
+                side_effect=fake_source_from_uri,
+            ),
+            patch(
+                "amplifier_app_cli.provider_sources.subprocess.run",
+                side_effect=fake_run,
+            ),
+        ):
+            init_cmd.check_first_run()
+
+        assert attempted == [sources["provider-anthropic"]], (
+            "already-installed provider-openai must not be reinstalled/overwritten"
+        )
+
+
+def _config_with_providers(entries: list) -> MagicMock:
+    """Stub config manager exposing `config.providers` entries."""
+    config = MagicMock()
+    config.get_provider_overrides.return_value = entries
+    return config
+
+
+def _provider_mgr(active_module_id: str | None) -> MagicMock:
+    """Stub ProviderManager whose active provider is `active_module_id`."""
+    mgr = MagicMock()
+    if active_module_id is None:
+        mgr.get_current_provider.return_value = None
+    else:
+        provider = MagicMock()
+        provider.module_id = active_module_id
+        mgr.get_current_provider.return_value = provider
+    return mgr
+
+
+class TestCheckFirstRunGatesOnAllConfiguredModules:
+    """The repair gate must consider EVERY configured provider module.
+
+    Gating the repair on the ACTIVE provider alone leaves a hole: if the active
+    provider happens to be installed but another configured provider is missing,
+    check_first_run() returns early and repairs nothing. That state is reachable
+    in practice --
+
+    * install_known_providers() catches per-provider exceptions and continues,
+      so one transient git/network failure leaves that provider missing forever
+      (the active one succeeded, so no later boot ever retries),
+    * the user hand-edits settings.yaml to add a provider,
+    * `amplifier provider install <name>` installs a single provider.
+
+    `amplifier update` and `amplifier reset` install no providers themselves --
+    both rely on the next boot's check_first_run() -- so this single gate is the
+    funnel for update, reset, and fresh install alike.
+
+    Return semantics stay driven by the ACTIVE provider only: "needs init" (True)
+    means "push the user into the add-a-provider prompt", which a non-active
+    provider failing to install must never trigger.
+    """
+
+    def test_missing_non_active_module_triggers_repair(self):
+        """The hole: active installed, another configured module missing."""
+        from amplifier_app_cli.commands import init as init_cmd
+
+        config = _config_with_providers(
+            [
+                {"module": "provider-anthropic", "id": "anthropic"},
+                {"module": "provider-openai", "id": "openai"},
+                {"module": "provider-gemini", "id": "gemini"},
+            ]
+        )
+        # Active (anthropic) is fine; openai is the gap.
+        present = {"provider-anthropic", "provider-gemini"}
+
+        with (
+            patch.object(init_cmd, "create_config_manager", return_value=config),
+            patch.object(
+                init_cmd, "ProviderManager", return_value=_provider_mgr("provider-anthropic")
+            ),
+            patch.object(
+                init_cmd,
+                "_is_provider_module_installed",
+                side_effect=lambda m: m in present,
+            ),
+            patch.object(
+                init_cmd,
+                "install_known_providers",
+                return_value=[
+                    "provider-anthropic",
+                    "provider-openai",
+                    "provider-gemini",
+                ],
+            ) as mock_install,
+        ):
+            needs_init = init_cmd.check_first_run()
+
+        mock_install.assert_called_once()
+        assert needs_init is False
+
+    def test_all_configured_modules_installed_skips_repair(self):
+        """Happy path: nothing missing -> no repair, no reinstall churn."""
+        from amplifier_app_cli.commands import init as init_cmd
+
+        config = _config_with_providers(
+            [
+                {"module": "provider-anthropic"},
+                {"module": "provider-openai"},
+                {"module": "provider-chat-completions"},
+            ]
+        )
+
+        with (
+            patch.object(init_cmd, "create_config_manager", return_value=config),
+            patch.object(
+                init_cmd, "ProviderManager", return_value=_provider_mgr("provider-anthropic")
+            ),
+            patch.object(
+                init_cmd, "_is_provider_module_installed", return_value=True
+            ) as mock_check,
+            patch.object(init_cmd, "install_known_providers") as mock_install,
+        ):
+            needs_init = init_cmd.check_first_run()
+
+        mock_install.assert_not_called()
+        assert needs_init is False
+        # Every configured module is checked -- and nothing more expensive runs.
+        assert {c.args[0] for c in mock_check.call_args_list} == {
+            "provider-anthropic",
+            "provider-openai",
+            "provider-chat-completions",
+        }
+
+    def test_full_wipe_triggers_repair(self):
+        """The original bug: venv wiped, nothing installed at all."""
+        from amplifier_app_cli.commands import init as init_cmd
+
+        config = _config_with_providers(
+            [
+                {"module": "provider-anthropic"},
+                {"module": "provider-openai"},
+            ]
+        )
+
+        with (
+            patch.object(init_cmd, "create_config_manager", return_value=config),
+            patch.object(
+                init_cmd, "ProviderManager", return_value=_provider_mgr("provider-anthropic")
+            ),
+            patch.object(
+                init_cmd, "_is_provider_module_installed", return_value=False
+            ),
+            patch.object(
+                init_cmd,
+                "install_known_providers",
+                return_value=["provider-anthropic", "provider-openai"],
+            ) as mock_install,
+        ):
+            needs_init = init_cmd.check_first_run()
+
+        mock_install.assert_called_once()
+        assert needs_init is False
+
+    def test_unfixable_leftover_warns_but_does_not_block(self, caplog):
+        """A module repair cannot install must warn -- not force init.
+
+        A provider whose module is neither in DEFAULT_PROVIDER_SOURCES nor
+        carries a `source:` is unfixable here. Returning True for that would
+        shove the user into the add-a-provider prompt on every single boot,
+        forever, even though their active provider works fine.
+        """
+        import logging
+
+        from amplifier_app_cli.commands import init as init_cmd
+
+        config = _config_with_providers(
+            [
+                {"module": "provider-anthropic"},
+                {"module": "provider-acme-custom"},
+            ]
+        )
+        present = {"provider-anthropic"}
+
+        with (
+            patch.object(init_cmd, "create_config_manager", return_value=config),
+            patch.object(
+                init_cmd, "ProviderManager", return_value=_provider_mgr("provider-anthropic")
+            ),
+            patch.object(
+                init_cmd,
+                "_is_provider_module_installed",
+                side_effect=lambda m: m in present,
+            ),
+            # Repair cannot supply provider-acme-custom.
+            patch.object(
+                init_cmd,
+                "install_known_providers",
+                return_value=["provider-anthropic"],
+            ) as mock_install,
+            caplog.at_level(logging.WARNING, logger="amplifier_app_cli.commands.init"),
+        ):
+            needs_init = init_cmd.check_first_run()
+
+        mock_install.assert_called_once()
+        assert needs_init is False, (
+            "an unfixable non-active provider must not force the init prompt"
+        )
+        assert "provider-acme-custom" in caplog.text, (
+            "the warning must name the module that could not be installed"
+        )
+
+    def test_no_provider_configured_still_needs_init(self):
+        """Unchanged existing behavior -- must not regress."""
+        from amplifier_app_cli.commands import init as init_cmd
+
+        with (
+            patch.object(init_cmd, "create_config_manager", return_value=MagicMock()),
+            patch.object(init_cmd, "ProviderManager", return_value=_provider_mgr(None)),
+            patch.object(init_cmd, "install_known_providers") as mock_install,
+        ):
+            needs_init = init_cmd.check_first_run()
+
+        assert needs_init is True
+        mock_install.assert_not_called()

--- a/tests/test_provider_source_precedence.py
+++ b/tests/test_provider_source_precedence.py
@@ -180,9 +180,20 @@ class TestInstallKnownProvidersIdempotency:
         assert result == ["provider-openai"]
 
 
-class TestCheckFirstRunRepairsOnlyMissingProvider:
-    def test_only_the_configured_provider_is_installed(self):
-        """A missing provider must not trigger a reinstall of every provider."""
+class TestCheckFirstRunRepairsAllKnownProviders:
+    """A missing provider module must trigger a repair of ALL known providers.
+
+    `amplifier update`/`amplifier reset` wipe the whole tool venv, not just the
+    currently active provider's module. A user with multiple provider instances
+    configured (e.g. anthropic + openai + chat-completions) needs every one of
+    them reinstalled, not just the active one -- see
+    tests/test_check_first_run_installs_all_providers.py for the full regression
+    coverage. This is safe because install_known_providers(force=False) skips
+    any provider that is already installed (TestInstallKnownProvidersIdempotency
+    above), so it never overwrites a working/pinned install.
+    """
+
+    def test_install_known_providers_is_used_for_repair(self):
         from amplifier_app_cli.commands import init as init_cmd
 
         provider = MagicMock()
@@ -193,19 +204,17 @@ class TestCheckFirstRunRepairsOnlyMissingProvider:
         with (
             patch.object(init_cmd, "create_config_manager"),
             patch.object(init_cmd, "ProviderManager", return_value=provider_mgr),
+            patch.object(init_cmd, "_is_provider_module_installed", return_value=False),
             patch.object(
-                init_cmd, "_is_provider_module_installed", return_value=False
-            ),
-            patch.object(
-                init_cmd, "ensure_provider_installed", return_value=True
-            ) as mock_ensure,
-            patch.object(init_cmd, "install_known_providers") as mock_install_all,
+                init_cmd,
+                "install_known_providers",
+                return_value=["provider-anthropic", "provider-openai"],
+            ) as mock_install_all,
         ):
             needs_init = init_cmd.check_first_run()
 
         assert needs_init is False
-        mock_install_all.assert_not_called()
-        assert mock_ensure.call_args.args[0] == "provider-openai"
+        mock_install_all.assert_called_once()
 
 
 class TestDanglingEditableInstallIsNotSkipped:

--- a/tests/test_provider_source_precedence.py
+++ b/tests/test_provider_source_precedence.py
@@ -201,14 +201,25 @@ class TestCheckFirstRunRepairsAllKnownProviders:
         provider_mgr = MagicMock()
         provider_mgr.get_current_provider.return_value = provider
 
+        # Stateful: installing a provider makes it importable. A constant-False
+        # installed-check paired with a repair that reports success would encode
+        # a world where installation never works.
+        present: set[str] = set()
+
+        def fake_install(*args, **kwargs):
+            present.update(["provider-anthropic", "provider-openai"])
+            return ["provider-anthropic", "provider-openai"]
+
         with (
             patch.object(init_cmd, "create_config_manager"),
             patch.object(init_cmd, "ProviderManager", return_value=provider_mgr),
-            patch.object(init_cmd, "_is_provider_module_installed", return_value=False),
             patch.object(
                 init_cmd,
-                "install_known_providers",
-                return_value=["provider-anthropic", "provider-openai"],
+                "_is_provider_module_installed",
+                side_effect=lambda m: m in present,
+            ),
+            patch.object(
+                init_cmd, "install_known_providers", side_effect=fake_install
             ) as mock_install_all,
         ):
             needs_init = init_cmd.check_first_run()


### PR DESCRIPTION
## Problem

After `amplifier update` or `amplifier reset`, only one provider module ends up installed. Every other configured provider silently fails to mount:

```
Installing provider module...
Installing provider-anthropic... ✓
...
Partial provider failure: 4/10 loaded. Missing: {'openai': 1, 'gemini': 1,
'github-copilot': 1, 'qwen-3.6': 1, 'azure-openai': 1, 'ornith': 1}.
```

The session continues in a degraded state with only a log warning. Install state correlated 1:1 with mount failures — the one installed module's 4 instances mounted, the 5 uninstalled modules' 6 instances did not.

## Root cause

Two defects in `check_first_run()`, which is the **only** provider-repair path in the CLI. `update.py` and `reset.py` contain zero references to providers — both recreate the tool venv (`uv tool install --upgrade --reinstall`, and `uninstall` + `install` respectively), wiping all editable-installed provider modules, then rely entirely on the next boot's `check_first_run()`.

**1. Regression from #238 (ad69c69).** The repair call was narrowed:

```python
-        installed = install_known_providers(config, console, verbose=True)
+        installed = ensure_provider_installed(current_provider.module_id, ...)
```

Repairing one provider cannot fix a wipe that removed all of them.

**2. Pre-existing latent bug.** The repair was gated on the active provider only — present in `ad69c69^` as well:

```python
module_installed = _is_provider_module_installed(current_provider.module_id)
if not module_installed:
    ...
```

If the active provider happened to be installed but another configured provider was missing, no boot ever repaired it. Reachable via a transient install failure (`install_known_providers` catches per-provider exceptions and continues), a hand-edited `settings.yaml`, or `amplifier provider install <one-name>`.

## Fix

Gate the repair on **every** configured provider module, and repair with `install_known_providers()`:

```python
configured_modules = _configured_provider_modules(config, current_provider.module_id)
missing = [m for m in configured_modules if not _is_provider_module_installed(m)]
if missing:
    installed = install_known_providers(config, console, verbose=True)
```

Return value stays driven by the **active** provider only — a non-active provider failing to install must never push the user into the add-a-provider prompt. Modules that cannot be repaired (neither a known provider nor carrying a `source:`) now emit a named warning rather than failing silently.

|  | Gate | Repair | Broken cases |
|---|---|---|---|
| pre-#238 | active only | all known | active present + others missing |
| #238 (current main) | active only | active only | ↑ plus full venv wipe |
| **this PR** | **all configured** | **all known** | none of the above |

## This preserves #238 — it is not a revert

#238 fixed four things. This PR touches one of them.

| # | What #238 fixed | Where | Touched here? |
|---|---|---|---|
| 1 | Pinned `source:` takes precedence over built-in defaults | `get_effective_provider_sources()` | No |
| 2 | Already-installed providers skipped, not rebuilt every run | `install_known_providers()` guard | No |
| 3 | Entry point must actually resolve (repairs dangling editable installs) | `is_provider_module_installed()` | No |
| 4 | `check_first_run()` repairs only the one missing provider | `check_first_run()` | **Replaced** |

Items 1–3 are what close #342. Item 4 was defended in #238's commit message as protecting pinned installs — but item 2, added in the same PR, already does that. `install_known_providers(force=False)` skips anything already installed, so it never overwrites a pinned build. The narrowing was redundant, and it is what caused the regression.

**Evidence:** #238's own test file `tests/test_provider_source_precedence.py` shipped 5 classes / 14 tests. Exactly one class changed here — the one pinning item 4. The other 13 pass unchanged:

```
TestEffectiveProviderSources ............ 7 PASSED   (item 1)
TestInstallKnownProvidersIdempotency .... 2 PASSED   (item 2)
TestDanglingEditableInstallIsNotSkipped . 4 PASSED   (item 3)
TestCheckFirstRunRepairsAllKnownProviders 1 PASSED   (item 4, reworked)
14 passed
```

Reverting #238 instead would reintroduce #342 (pinned sources overwritten with `@main`, every provider rebuilt each run), lose dangling-editable-install detection, and still carry the pre-existing active-only gate bug.

## Test plan

- [x] 5 new tests in `tests/test_check_first_run_installs_all_providers.py`, written first; 3 failed against pre-fix code, including one reproducing the active-installed/others-missing hole
- [x] Targeted suite: **22 passed**
- [x] Full suite: **15 failed, 1174 passed** vs `main` baseline **15 failed, 1166 passed** — identical failure list (all pre-existing, unrelated files); +8 = the new tests
- [x] `ruff check` on all touched files: clean
- [x] E2E, isolated venv + temp `HOME`, 4 provider modules configured, none installed → all 8 known providers installed, all 4 configured modules resolve, `check_first_run() -> False`
- [x] E2E, active installed + `provider-openai` removed → repair triggered, 7 reported `already installed, skipping`, only `provider-openai` installed. Confirms #238's skip-guard still protects pinned builds under real conditions.
- [x] Boot cost measured: ~6–7 ms for 4 configured modules on the happy path (`find_spec` only; no subprocess, no network), still short-circuits to `return False`

## Rollout

Existing users get this with one `amplifier update` — the update replaces app-cli, and the next launch runs the new gate and restores everything. Users currently sitting in the degraded state are repaired the same way. Fresh installs were never affected. First launch after updating will spend ~30–60s installing providers from git; this is one-time and only when something is genuinely missing.