### PR TITLE
feat: add /goal slash command for autonomous goal-driven continuation

### DIFF
--- a/amplifier_app_cli/goal_progress_hook.py
+++ b/amplifier_app_cli/goal_progress_hook.py
@@ -1,0 +1,91 @@
+"""Console rendering for the /goal auto-continue loop's progress events.
+
+The auto-continue loop itself lives in the orchestrator (loop-streaming's
+StreamingOrchestrator.execute()) rather than the app layer -- see
+docs/designs/goal-command.md. The orchestrator emits an
+``orchestrator:goal_progress`` event instead of writing to stdout directly,
+because bare print() from an orchestrator corrupts protocol channels for
+other hosts (amplifier-agent's stdout JSON-RPC, amplifierd/amplifier-chat's
+journald-only stdout). This hook is the CLI-specific renderer: it subscribes
+to that event and prints the exact strings the CLI previously printed
+itself, to the CLI's rich ``console``.
+
+Registered once per session (both interactive_chat and execute_single),
+mirroring the incremental_save.py pattern.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .console import console
+
+
+class GoalProgressHook:
+    """Renders ``orchestrator:goal_progress`` events to the CLI console.
+
+    Contract:
+    - Listens for: orchestrator:goal_progress events
+    - Side effects: writes formatted progress lines to the CLI's rich console
+    - Never raises: an unrecognized/malformed payload is rendered as-is
+      rather than crashing the session (hook failures must not block
+      execution)
+
+    Usage:
+        hook = GoalProgressHook()
+        hooks.register("orchestrator:goal_progress", hook.on_goal_progress,
+                        name="goal_progress")
+    """
+
+    async def on_goal_progress(self, event: str, data: dict[str, Any]) -> None:
+        """Render one goal-progress event using the pre-existing strings.
+
+        Mirrors exactly what the orchestrator used to print() itself
+        (docs/designs/goal-command.md) before that was moved to an event
+        emission for protocol-channel safety.
+        """
+        state = data.get("state")
+        reason = data.get("reason")
+        turn = data.get("turn")
+        cap = data.get("cap")
+
+        if state == "continuing":
+            turn_label = f"{turn}/{cap}" if cap else f"{turn}"
+            console.print(f"\u27f3 goal: turn {turn_label} \u2014 {reason}")
+        elif state == "achieved":
+            console.print(f"\u2713 goal achieved: {reason}")
+        elif state == "cap_hit":
+            console.print(f"\u26a0 goal: hit turn cap ({cap}) \u2014 stopping.")
+        elif state == "cancelled":
+            console.print(f"\u2717 goal: cancelled \u2014 {reason}")
+        elif state == "error":
+            console.print(f"\u2717 goal: evaluator failed \u2014 {reason}")
+        else:
+            # Unrecognized state: don't silently drop it, but don't guess at
+            # formatting either -- surface the raw payload.
+            console.print(f"[dim]goal progress: {data}[/dim]")
+
+
+def register_goal_progress_hook(session: Any) -> GoalProgressHook | None:
+    """Register the goal-progress console renderer on ``session``.
+
+    Convenience function mirroring incremental_save.py's
+    register_incremental_save -- creates the hook and registers it with the
+    session's hooks registry. Safe to call unconditionally: a no-op when
+    hooks aren't available.
+
+    Args:
+        session: The AmplifierSession to register on
+
+    Returns:
+        The created hook instance, or None if hooks not available
+    """
+    hooks = session.coordinator.get("hooks")
+    if not hooks or not hasattr(hooks, "register"):
+        return None
+
+    hook = GoalProgressHook()
+    hooks.register(
+        "orchestrator:goal_progress", hook.on_goal_progress, name="goal_progress"
+    )
+    return hook

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
 from amplifier_core import AmplifierSession
 from amplifier_core import ModuleValidationError  # pyright: ignore[reportAttributeAccessIssue]
 from amplifier_core.llm_errors import LLMError
+from amplifier_core.message_models import ChatRequest
+from amplifier_core.message_models import Message
 from amplifier_foundation import sanitize_message
 from prompt_toolkit import PromptSession
 from prompt_toolkit.formatted_text import HTML
@@ -363,6 +365,54 @@ def _parse_config_flags(
     return remaining, compact, detailed, trees, fmt
 
 
+# SPIKE (docs/designs/goal-command.md, TASK 1 -- --max-turns plumbing):
+# shared parser used by BOTH /goal entry points (interactive CommandProcessor
+# and headless execute_single) so the flag syntax and failure behavior can't
+# drift between the two. Fails loud -- raises ValueError -- rather than ever
+# silently falling back to unlimited.
+_GOAL_MAX_TURNS_FLAG = "--max-turns"
+
+
+def _parse_goal_max_turns(args: str) -> tuple[int | None, str]:
+    """Parse an optional leading ``--max-turns N`` flag off /goal args.
+
+    Returns (cap, remainder): cap is None when no flag is present
+    (unlimited -- current default); remainder is the goal condition text
+    with the flag and its value stripped off the front.
+
+    Raises ValueError -- never silently treats a bad value as unlimited --
+    when the flag is present but its value is missing, non-integer, or not
+    a positive integer.
+    """
+    stripped = args.strip()
+    if not stripped.startswith(_GOAL_MAX_TURNS_FLAG):
+        return None, stripped
+
+    rest = stripped[len(_GOAL_MAX_TURNS_FLAG) :].strip()
+    parts = rest.split(maxsplit=1)
+    if not parts:
+        raise ValueError(
+            f"{_GOAL_MAX_TURNS_FLAG} requires a positive integer value, e.g. "
+            f"'/goal {_GOAL_MAX_TURNS_FLAG} 5 <condition>'"
+        )
+
+    value_str = parts[0]
+    remainder = parts[1] if len(parts) > 1 else ""
+    try:
+        value = int(value_str)
+    except ValueError:
+        raise ValueError(
+            f"Invalid {_GOAL_MAX_TURNS_FLAG} value: {value_str!r} -- "
+            "must be a positive integer."
+        ) from None
+    if value <= 0:
+        raise ValueError(
+            f"Invalid {_GOAL_MAX_TURNS_FLAG} value: {value} -- "
+            "must be a positive integer."
+        )
+    return value, remainder.strip()
+
+
 class CommandProcessor:
     """Process slash commands and special directives."""
 
@@ -409,6 +459,10 @@ class CommandProcessor:
             "action": "load_skill",
             "description": "Load a skill (e.g., /skill simplify)",
         },
+        "/goal": {
+            "action": "handle_goal",
+            "description": "Set a goal condition and auto-continue until satisfied: /goal <condition> (or /goal clear)",
+        },
     }
 
     # Dynamic shortcuts for modes (populated from mode definitions)
@@ -418,6 +472,16 @@ class CommandProcessor:
     # Patterns used to detect sensitive config keys that should be redacted.
     # Kept for backward compatibility; the canonical copy lives in dashboard_renderer.
     _SENSITIVE_KEY_PATTERNS = ("key", "token", "secret", "password", "api_key")
+
+    # /goal: aliases that clear an active goal, and the hard (Python-enforced,
+    # not model-judged) turn cap. Spike default per docs/designs/goal-command.md.
+    _GOAL_CLEAR_ALIASES = ("clear", "stop", "off", "reset", "none", "cancel")
+    # SPIKE (docs/designs/goal-command.md, parity decision): cap is now
+    # optional. None means unlimited -- matching Claude Code's default (no
+    # enforced bound; "stop after N turns" goes in the condition text). A
+    # positive int is still a hard, Python-enforced mechanical cap, honored by
+    # the orchestrator's goal loop.
+    _GOAL_TURN_CAP = None
 
     def _render_config_tree(
         self, console: Any, cfg: dict, indent: str, *, dim: bool = False
@@ -457,6 +521,8 @@ class CommandProcessor:
             self.session.coordinator.session_state = {}
         if "active_mode" not in self.session.coordinator.session_state:
             self.session.coordinator.session_state["active_mode"] = None
+        if "goal" not in self.session.coordinator.session_state:
+            self.session.coordinator.session_state["goal"] = None
         # Populate mode shortcuts from discovery (if available)
         self._populate_mode_shortcuts()
         # Populate skill shortcuts from discovery (if available)
@@ -504,6 +570,23 @@ class CommandProcessor:
                     skill_parts = args.strip().split(maxsplit=1)
                     data["skill_name"] = skill_parts[0] if skill_parts else ""
                     data["arguments"] = skill_parts[1] if len(skill_parts) > 1 else ""
+                elif cmd_info["action"] == "handle_goal" and args.strip():
+                    # Setting a condition (not a clear alias) runs it as a turn
+                    # immediately, mirroring the /mode trailing-prompt mechanism.
+                    if args.strip().lower() not in self._GOAL_CLEAR_ALIASES:
+                        # TASK 1 (--max-turns): parse off an optional leading
+                        # cap flag so the trailing prompt is the condition
+                        # ALONE, not "--max-turns 5 <condition>" verbatim. On
+                        # malformed input, do not queue a trailing prompt --
+                        # _handle_goal re-parses the same (unmodified)
+                        # data["args"] below and reports the error loudly.
+                        try:
+                            _, _goal_remainder = _parse_goal_max_turns(args)
+                        except ValueError:
+                            pass
+                        else:
+                            if _goal_remainder:
+                                data["trailing_prompt"] = _goal_remainder
                 return cmd_info["action"], data
 
             # Check for mode shortcuts (e.g., /plan -> /mode plan)
@@ -596,6 +679,9 @@ class CommandProcessor:
 
         if action == "handle_mode":
             return await self._handle_mode(data.get("args", ""))
+
+        if action == "handle_goal":
+            return await self._handle_goal(data.get("args", ""))
 
         if action == "list_modes":
             return await self._list_modes()
@@ -1079,6 +1165,67 @@ class CommandProcessor:
         context = self.session.coordinator.get("context")
         if context and hasattr(context, "clear"):
             await context.clear()
+        # /clear also clears any active goal (parity with Claude Code's /goal).
+        self.session.coordinator.session_state["goal"] = None
+
+    async def _handle_goal(self, args: str) -> str:
+        """Handle /goal command: set, clear, or show status of an active goal.
+
+        Spike scope (docs/designs/goal-command.md): a goal is a plain string
+        condition. Setting one stores it in session_state; the REPL loop (see
+        interactive_chat's `_execute_with_interrupt_and_goal`) is responsible
+        for running the actual auto-continue evaluation loop -- this method
+        only owns the state transition and status text.
+        """
+        args = args.strip()
+        session_state = self.session.coordinator.session_state
+        goal = session_state.get("goal")
+
+        if not args:
+            if not goal:
+                return "No goal active. Usage: /goal <condition>"
+            cap = goal.get("cap")
+            turns_label = (
+                f"{goal['turns_used']}/{cap}"
+                if cap
+                else f"{goal['turns_used']} (unlimited)"
+            )
+            lines = [
+                f"Goal: {goal['condition']}",
+                f"Turns used: {turns_label}",
+                f"Last evaluator reason: {goal.get('last_reason') or '(none yet)'}",
+            ]
+            return "\n".join(lines)
+
+        if args.lower() in self._GOAL_CLEAR_ALIASES:
+            if goal:
+                session_state["goal"] = None
+                return f"Goal cleared: {goal['condition']}"
+            return "No goal active."
+
+        # TASK 1 (--max-turns): parse an optional leading cap flag off the
+        # front of args. Fail loud on malformed input -- do not set a goal,
+        # do not silently fall back to unlimited.
+        try:
+            cap, condition = _parse_goal_max_turns(args)
+        except ValueError as e:
+            return f"Goal not set: {e}"
+
+        if not condition:
+            return (
+                f"Goal not set: missing condition text after "
+                f"{_GOAL_MAX_TURNS_FLAG} N. Usage: /goal "
+                f"[{_GOAL_MAX_TURNS_FLAG} N] <condition>"
+            )
+
+        session_state["goal"] = {
+            "condition": condition,
+            "turns_used": 0,
+            "last_reason": None,
+            "cap": cap,
+        }
+        cap_suffix = f" (max {cap} turns)" if cap else ""
+        return f"Goal set: {condition}{cap_suffix}"
 
     async def _rename_session(self, new_name: str) -> str:
         """Rename the current session."""
@@ -3026,6 +3173,194 @@ async def interactive_chat(
             ):
                 _streaming_hooks_instance.set_composing_source(None)
 
+    # === /goal support (spike, docs/designs/goal-command.md) ===
+    #
+    # Turn-boundary evaluator + auto-continue loop. `_execute_with_interrupt`
+    # is NOT modified -- this wraps it. When no goal is active this wrapper is
+    # a single pass-through call, so it's safe to use at every REPL call site.
+
+    _GOAL_EVALUATOR_SYSTEM_PROMPT = (
+        "You are a strict, tool-less evaluator. You will be shown a GOAL "
+        "CONDITION and a transcript of an assistant's work so far in a "
+        "coding/agent session. Decide whether the GOAL CONDITION has been "
+        "satisfied by that work.\n\n"
+        "Respond with EXACTLY two lines and nothing else:\n"
+        "Line 1: the single word YES or NO (verbatim, nothing else)\n"
+        "Line 2: one sentence explaining why\n"
+    )
+
+    # Best-effort cheap-model hints per provider-name substring. Spike-level
+    # heuristic only: if the mounted provider's registered name doesn't match
+    # a known family, the evaluator falls back to that provider's own default
+    # model (not necessarily cheap -- see report caveats).
+    _GOAL_CHEAP_MODEL_HINTS = {
+        "anthropic": "claude-haiku-4-5",
+        "openai": "gpt-5-mini",
+        "azure-openai": "gpt-5-mini",
+        "azure_openai": "gpt-5-mini",
+    }
+
+    _GOAL_MAX_TRANSCRIPT_MESSAGES = 40
+
+    def _flatten_message_for_evaluator(msg: dict) -> str:
+        """Render one stored (dict) message as plain text for the evaluator."""
+        role = msg.get("role", "unknown")
+        content = msg.get("content", "")
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            parts = []
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                btype = block.get("type")
+                if btype == "text":
+                    parts.append(block.get("text", ""))
+                elif btype == "tool_call":
+                    parts.append(f"[called tool: {block.get('name', '?')}]")
+                elif btype == "tool_result":
+                    parts.append("[tool result omitted]")
+                # thinking/redacted_thinking/reasoning blocks are intentionally
+                # skipped -- the evaluator only judges what was surfaced.
+            text = "\n".join(p for p in parts if p)
+        else:
+            text = str(content)
+        return f"{role}: {text}" if text else ""
+
+    async def _evaluate_goal(condition: str) -> tuple[bool, str]:
+        """Ask a cheap, tool-less model whether `condition` is satisfied.
+
+        Returns (satisfied, reason). Raises on any failure -- no fallbacks;
+        the caller stops the goal loop loudly on any exception here.
+        """
+        context = session.coordinator.get("context")
+        if not context or not hasattr(context, "get_messages"):
+            raise RuntimeError("no context manager available to read the conversation")
+        all_messages = await context.get_messages()
+
+        truncated = False
+        messages = all_messages
+        if len(messages) > _GOAL_MAX_TRANSCRIPT_MESSAGES:
+            messages = messages[-_GOAL_MAX_TRANSCRIPT_MESSAGES:]
+            truncated = True
+            console.print(
+                f"[dim]\u27f3 goal: truncating evaluator context to the last "
+                f"{_GOAL_MAX_TRANSCRIPT_MESSAGES} of {len(all_messages)} messages[/dim]"
+            )
+
+        transcript_text = "\n\n".join(
+            t for t in (_flatten_message_for_evaluator(m) for m in messages) if t
+        )
+
+        providers = session.coordinator.get("providers") or {}
+        if not providers:
+            raise RuntimeError("no provider mounted for evaluation")
+        provider_name, provider = next(iter(providers.items()))
+
+        model_override = None
+        for hint_key, hint_model in _GOAL_CHEAP_MODEL_HINTS.items():
+            if hint_key in provider_name.lower():
+                model_override = hint_model
+                break
+
+        user_prompt = (
+            f"GOAL CONDITION:\n{condition}\n\n"
+            f"CONVERSATION SO FAR"
+            f"{' (truncated, most recent messages shown)' if truncated else ''}:\n"
+            f"{transcript_text}\n\n"
+            "Has the GOAL CONDITION been satisfied? Respond in the required "
+            "two-line format."
+        )
+
+        eval_messages = [
+            Message(role="system", content=_GOAL_EVALUATOR_SYSTEM_PROMPT),
+            Message(role="user", content=user_prompt),
+        ]
+        chat_request = ChatRequest(
+            messages=eval_messages, tools=None, model=model_override
+        )
+
+        response = await provider.complete(chat_request)
+
+        response_text = ""
+        for block in response.content:
+            if getattr(block, "type", None) == "text":
+                response_text += getattr(block, "text", "")
+
+        lines = [
+            line.strip() for line in response_text.strip().splitlines() if line.strip()
+        ]
+        if not lines:
+            raise ValueError("evaluator returned an empty response")
+
+        verdict = lines[0].strip().upper()
+        if verdict not in ("YES", "NO"):
+            raise ValueError(f"unparseable evaluator verdict: {lines[0]!r}")
+
+        reason = lines[1] if len(lines) > 1 else "(evaluator gave no reason)"
+        return verdict == "YES", reason
+
+    async def _execute_with_interrupt_and_goal(prompt_text: str) -> bool:
+        """Run a turn, then -- if a goal is active -- pursue it: evaluate,
+        and if not satisfied, automatically run another turn using the
+        evaluator's reason as the next prompt. No human keystroke involved.
+
+        Bounded by a hard, Python-enforced turn cap (session_state["goal"]["cap"]).
+        A cancelled turn (Ctrl-C) stops goal pursuit immediately. An evaluator
+        failure stops goal pursuit immediately and reports the error -- it
+        never silently continues or silently declares success.
+        """
+        completed = await _execute_with_interrupt(prompt_text)
+
+        while True:
+            goal = session.coordinator.session_state.get("goal")
+            if not goal:
+                return completed
+
+            if not completed:
+                session.coordinator.session_state["goal"] = None
+                console.print(
+                    f"[yellow]\u2717 goal: cancelled \u2014 condition was:[/yellow] "
+                    f"{goal['condition']}"
+                )
+                return completed
+
+            goal["turns_used"] += 1
+
+            if goal["turns_used"] >= goal["cap"]:
+                session.coordinator.session_state["goal"] = None
+                console.print(
+                    f"[bold yellow]\u26a0 goal: hit turn cap "
+                    f"({goal['cap']}) \u2014 stopping.[/bold yellow]"
+                )
+                return completed
+
+            try:
+                satisfied, reason = await _evaluate_goal(goal["condition"])
+            except Exception as e:
+                session.coordinator.session_state["goal"] = None
+                console.print(
+                    f"[bold red]\u2717 goal: evaluator failed \u2014 {e}[/bold red]"
+                )
+                return completed
+
+            goal["last_reason"] = reason
+
+            if satisfied:
+                session.coordinator.session_state["goal"] = None
+                console.print(
+                    f"[bold green]\u2713 goal achieved:[/bold green] {reason}"
+                )
+                return completed
+
+            console.print(
+                f"[cyan]\u27f3 goal:[/cyan] turn {goal['turns_used']}/{goal['cap']} "
+                f"\u2014 {reason}"
+            )
+            console.print("\n[dim]Processing... (Ctrl+C to cancel)[/dim]")
+            next_prompt = await process_runtime_mentions(session, reason)
+            completed = await _execute_with_interrupt(next_prompt)
+
     # Execute initial prompt if provided
     if initial_prompt:
         console.print(
@@ -3035,6 +3370,12 @@ async def interactive_chat(
 
         # Process runtime @mentions in initial prompt
         initial_prompt = await process_runtime_mentions(session, initial_prompt)
+        # SPIKE (docs/designs/goal-command.md): the goal auto-continue loop now
+        # lives in the orchestrator (loop-streaming's execute()), so the REPL
+        # calls the plain wrapper -- not `_execute_with_interrupt_and_goal`,
+        # which would double the loop (app-layer AND orchestrator both
+        # auto-continuing). `_execute_with_interrupt_and_goal` is left in place,
+        # unused, for side-by-side comparison of the two implementations.
         await _execute_with_interrupt(initial_prompt)
 
     # === REPL LOOP ===
@@ -3063,6 +3404,8 @@ async def interactive_chat(
                         _expanded_text = await process_runtime_mentions(
                             session, data["text"]
                         )
+                        # SPIKE: goal auto-continue now lives in the orchestrator;
+                        # see the note at the initial_prompt call site above.
                         await _execute_with_interrupt(_expanded_text)
 
                     else:
@@ -3078,6 +3421,8 @@ async def interactive_chat(
                                     "\n[dim]Processing... (Ctrl+C to cancel)[/dim]"
                                 )
                                 text = await process_runtime_mentions(session, text)
+                                # SPIKE: goal auto-continue now lives in the
+                                # orchestrator; see the note above.
                                 await _execute_with_interrupt(text)
                             else:
                                 console.print(f"[cyan]{text}[/cyan]")
@@ -3097,6 +3442,8 @@ async def interactive_chat(
                             trailing_prompt = await process_runtime_mentions(
                                 session, trailing_prompt
                             )
+                            # SPIKE: goal auto-continue now lives in the
+                            # orchestrator; see the note above.
                             await _execute_with_interrupt(trailing_prompt)
 
             except EOFError:
@@ -3248,10 +3595,103 @@ async def execute_single(
         # Process runtime @mentions in user input
         prompt = await process_runtime_mentions(session, prompt)
 
+        # === /goal support in headless mode (spike, docs/designs/goal-command.md) ===
+        # The auto-continue loop itself now lives in the orchestrator (see
+        # loop-streaming's execute()), so headless mode only needs to set
+        # session_state["goal"] before the single session.execute() call --
+        # the orchestrator does the rest, including printing progress via
+        # plain print() (this process has no rich console driving stdout
+        # from inside the orchestrator).
+        if prompt.strip().lower().startswith("/goal "):
+            goal_args = prompt.strip()[len("/goal ") :].strip()
+            if goal_args:
+                # TASK 1 (--max-turns): same shared parser as the interactive
+                # /goal handler -- identical flag syntax, identical fail-loud
+                # behavior on a bad value. Never silently falls back to
+                # unlimited.
+                try:
+                    goal_cap, goal_condition = _parse_goal_max_turns(goal_args)
+                except ValueError as e:
+                    if output_format in ["json", "json-trace"]:
+                        if original_stdout is not None:
+                            sys.stdout = original_stdout
+                        error_output = {
+                            "status": "error",
+                            "error": str(e),
+                            "error_type": "GoalArgumentError",
+                            "session_id": session.session_id,
+                            "timestamp": datetime.now(UTC).isoformat(),
+                        }
+                        print(json.dumps(error_output, indent=2))
+                    else:
+                        console.print(f"[red]Goal not set:[/red] {e}")
+                    sys.exit(1)
+
+                if not goal_condition:
+                    msg = (
+                        f"Goal not set: missing condition text after "
+                        f"{_GOAL_MAX_TURNS_FLAG} N. Usage: /goal "
+                        f"[{_GOAL_MAX_TURNS_FLAG} N] <condition>"
+                    )
+                    if output_format in ["json", "json-trace"]:
+                        if original_stdout is not None:
+                            sys.stdout = original_stdout
+                        error_output = {
+                            "status": "error",
+                            "error": msg,
+                            "error_type": "GoalArgumentError",
+                            "session_id": session.session_id,
+                            "timestamp": datetime.now(UTC).isoformat(),
+                        }
+                        print(json.dumps(error_output, indent=2))
+                    else:
+                        console.print(f"[red]{msg}[/red]")
+                    sys.exit(1)
+
+                session.coordinator.session_state["goal"] = {
+                    "condition": goal_condition,
+                    "turns_used": 0,
+                    "last_reason": None,
+                    "cap": goal_cap,
+                }
+                cap_suffix = f" (max {goal_cap} turns)" if goal_cap else ""
+                console.print(f"Goal set: {goal_condition}{cap_suffix}")
+                prompt = goal_condition
+
         if verbose:
             console.print(f"[dim]Executing: {prompt}[/dim]")
 
-        response = await session.execute(prompt)
+        # TASK 2 (SIGINT cancellation, docs/designs/goal-command.md 0b "Not
+        # proven at orchestrator level" -- Ctrl-C mid-goal): headless had NO
+        # SIGINT handler on this path at all, so Ctrl-C just killed the
+        # process instead of setting coordinator.cancellation, which the
+        # orchestrator's goal loop already checks every turn (see
+        # loop-goal's execute(), `coordinator.cancellation.is_cancelled`).
+        # Mirrors the interactive pattern in `_execute_with_interrupt`'s
+        # sigint_handler (~:2875) and its signal.signal install/restore
+        # (~:2909 install, ~:3085 restore) -- that function itself is left
+        # untouched; this is a second, independent install for the headless
+        # single-shot path, which has no per-turn wrapper to piggyback on.
+        session.coordinator.cancellation.reset()
+
+        def _goal_sigint_handler(signum, frame):
+            """First Ctrl-C: graceful (stop after current turn). Second: immediate."""
+            cancellation = session.coordinator.cancellation
+            if cancellation.is_cancelled:
+                cancellation.request_immediate()
+                console.print("\n[bold red]Cancelling immediately...[/bold red]")
+            else:
+                cancellation.request_graceful()
+                console.print(
+                    "\n[yellow]Stopping goal run after the current turn... "
+                    "(Ctrl+C again to force)[/yellow]"
+                )
+
+        _original_sigint_handler = signal.signal(signal.SIGINT, _goal_sigint_handler)
+        try:
+            response = await session.execute(prompt)
+        finally:
+            signal.signal(signal.SIGINT, _original_sigint_handler)
 
         # Get metadata for output
         actual_session_id = session.session_id

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -2830,6 +2830,14 @@ async def interactive_chat(
 
     register_incremental_save(session, store, actual_session_id, bundle_name, config)
 
+    # Register /goal auto-continue progress renderer (docs/designs/goal-command.md).
+    # The orchestrator emits orchestrator:goal_progress instead of printing
+    # directly (bare print() from an orchestrator corrupts other hosts'
+    # protocol channels); this hook is the CLI's renderer for it.
+    from .goal_progress_hook import register_goal_progress_hook
+
+    register_goal_progress_hook(session)
+
     # Show banner only for NEW sessions (resume shows banner via history display in commands/session.py)
     if not session_config.is_resume:
         config_summary = get_effective_config_summary(config, bundle_name)
@@ -3591,6 +3599,16 @@ async def execute_single(
                     priority=1000,
                     name="trace_collector_post",
                 )
+
+        # Register /goal auto-continue progress renderer (docs/designs/goal-command.md).
+        # Headless mode has no rich console driving stdout from inside the
+        # orchestrator, so the orchestrator emits orchestrator:goal_progress
+        # instead of printing directly; this hook renders it here. Registered
+        # unconditionally (not gated on trace_collector/output_format) since
+        # goal output must work regardless of output format.
+        from .goal_progress_hook import register_goal_progress_hook
+
+        register_goal_progress_hook(session)
 
         # Process runtime @mentions in user input
         prompt = await process_runtime_mentions(session, prompt)

--- a/docs/GOAL_COMMAND.md
+++ b/docs/GOAL_COMMAND.md
@@ -126,6 +126,23 @@ An invalid value fails immediately and sets no goal:
 **Writing "or stop after 20 turns" into the condition text is not a bound** — that is a
 sentence for a model to interpret. Use the flag.
 
+### What the cap does NOT bound
+
+`--max-turns` bounds **goal continuations** — the number of times the goal loop starts a new
+turn. It does **not** bound work happening *inside* a single turn.
+
+An agent can make an unlimited number of tool calls within one turn; the turn ends only when
+the model stops requesting tools. If an agent gets stuck polling something that never
+completes, it never ends its turn, the goal evaluator never runs, and **the cap never fires.**
+
+This was verified: an agent given a job-status script that always exited 0 and never reached
+100% polled it 59+ times inside a single turn with `--max-turns 8` set. The cap was never
+reached because no turn ever ended.
+
+`/goal` is a **completion gate**, not a runaway guard. It catches an agent that stops too
+early. It cannot catch one that never stops. For unattended runs, bound the process
+externally (a wall-clock `timeout`, a CI job limit) in addition to `--max-turns`.
+
 ---
 
 ## What the evaluator can and cannot see

--- a/docs/GOAL_COMMAND.md
+++ b/docs/GOAL_COMMAND.md
@@ -1,0 +1,164 @@
+# `/goal` — autonomous continuation
+
+`/goal` sets a completion condition. After each turn, a separate evaluator model reads the
+condition plus the conversation and answers *"is this done?"*. If not, another turn starts
+automatically with the evaluator's reason as guidance. If yes, the goal clears.
+
+Auto mode removes per-*tool* prompts. `/goal` removes per-*turn* prompts.
+
+```
+/goal <condition>                    # set a goal and start working
+/goal --max-turns 20 <condition>     # same, with a hard turn cap
+/goal                                # show current condition, turns used, last reason
+/goal clear                          # clear it (aliases: stop, off, reset, none, cancel)
+```
+
+Works in interactive mode and headless:
+
+```bash
+amplifier run --mode single "/goal all tests in tests/ pass with pytest exiting 0"
+```
+
+`/clear` also clears an active goal. Ctrl-C stops a goal run: once for graceful, twice for
+immediate.
+
+---
+
+## Writing a condition that works
+
+**This is the part that determines whether `/goal` saves you time or wastes your money.**
+The evaluator is strict by design — it will not call an ambiguous condition satisfied. A
+vague condition produces one of two failures:
+
+- The loop keeps running against work that is already finished, burning turns on ambiguity.
+- The evaluator has nothing concrete to check, and accepts a shallow claim as success.
+
+Both are avoidable by writing the condition well.
+
+### A good condition has three parts
+
+| Part | Why | Example |
+|---|---|---|
+| **A measurable end state** | The evaluator needs something checkable | "every call site compiles" |
+| **The check that proves it** | Removes ambiguity about *how* done is demonstrated | "`pytest -q` exits 0 with ≥20 tests passing" |
+| **Constraints that must hold** | Negative constraints are what drift first | "no third-party web framework; stdlib only" |
+
+Put all three in. Order doesn't matter.
+
+### Worked example
+
+**Weak:**
+```
+/goal make the API good
+```
+Nothing measurable, no check, no constraints. The evaluator will either loop indefinitely or
+accept the first plausible-sounding claim.
+
+**Strong:**
+```
+/goal Build a URL shortener REST API at ./shortener using ONLY the Python standard
+library (no Flask, FastAPI, or Django). SQLite persistence. Endpoints: POST /shorten,
+GET /<code> (302), GET /stats/<code>, DELETE /<code>. Duplicate alias returns 409,
+invalid URL returns 400, unknown code returns 404. Done when `python3 -m pytest -q`
+run from ./shortener exits 0 with at least 20 tests passing.
+```
+
+Measurable end state, an explicit check, and explicit negative constraints.
+
+### Name the check exactly
+
+If the condition says "tests pass," the evaluator has to guess what that means — which
+command, run from where, with what interpreter. It will ask for clarification by *running
+more turns*.
+
+Write the literal command:
+
+```
+Done when `cd ./shortener && python3 -m pytest -q` exits 0.
+```
+
+> **Real example.** A run where the exact pytest command was accidentally omitted from the
+> condition finished its actual work on turn 1 — 28 tests passing — but the evaluator
+> correctly refused to accept an ambiguous condition and pushed back twice more before
+> converging. The work was done; the wording cost two extra turns. Naming the command
+> prevents this.
+
+### State constraints as explicit MUST NOTs
+
+Negative constraints ("maintain backward compatibility", "don't touch the migration
+scripts") are the first thing to get lost over a long run. Put them in the condition, keep
+them short, and make them discrete:
+
+```
+CONSTRAINT: do not modify any file outside src/. CONSTRAINT: do not add dependencies.
+```
+
+### One goal at a time
+
+`/goal redesign auth, add OAuth, write tests, and update the docs` is four goals. The
+evaluator has to judge all of them at once and will keep finding one that isn't finished.
+Split compound objectives into sequential goals.
+
+---
+
+## Bounding the run
+
+By default there is **no turn cap** — the loop runs until the evaluator is satisfied. For
+unattended or CI runs, set a mechanical bound:
+
+```
+/goal --max-turns 20 <condition>
+```
+
+This is enforced in Python, not judged by a model. When it trips:
+
+```
+⚠ goal: hit turn cap (20) — stopping.
+```
+
+An invalid value fails immediately and sets no goal:
+
+```
+/goal --max-turns abc do something
+→ Goal not set: Invalid --max-turns value: 'abc' -- must be a positive integer.
+```
+
+**Writing "or stop after 20 turns" into the condition text is not a bound** — that is a
+sentence for a model to interpret. Use the flag.
+
+---
+
+## What the evaluator can and cannot see
+
+The evaluator reads **the conversation**. It has **no tools** — it does not run commands or
+read files independently.
+
+This has one important consequence: **work that is never surfaced into the conversation is
+invisible to it.** If the agent runs the test suite but never prints the result, the
+evaluator cannot confirm it passed. Conditions that ask the agent to *show* its verification
+("you must actually run the tests and show the real output") work better than conditions
+that only describe the end state.
+
+It also means the evaluator can be satisfied by a *claim* rather than a fact. `/goal` is not
+a substitute for verifying important work yourself.
+
+---
+
+## Status and progress
+
+`/goal` with no arguments shows the condition, turns used (against the cap if set), and the
+evaluator's most recent reason.
+
+That reason is the entire progress signal. There is deliberately no percentage, no milestone
+list, and no burn-down — a synthesized progress number would be a guess presented as a
+measurement.
+
+---
+
+## Cost
+
+Each turn adds one evaluator call on the small/fast model, which is minor next to the main
+turn. The real cost driver is the number of turns, which is driven by how well the condition
+is written. A well-specified condition converges; a vague one does not.
+
+Use `--max-turns` for anything unattended.


### PR DESCRIPTION
"## Summary\n\nAdds the `/goal` slash command — parity with Claude Code (v2.1.139+) and OpenAI Codex CLI. Developers already familiar with this command from other tools can now use it in Amplifier with the same semantics.\n\n## What it does\n\n- `/goal <condition>` — sets a completion condition and immediately starts a turn. After each turn, a separate evaluator model (no tools) judges \"done? yes/no + reason\". If not done, another turn starts automatically with the reason as guidance. If done, the goal clears.\n- `/goal --max-turns N <condition>` — same, with a hard, Python-enforced turn cap. Invalid values (non-integer, 0, negatives) fail loud: error printed, no goal set, no turn runs.\n- `/goal` (bare) — shows condition, turns used (against cap if set), and evaluator's most recent reason.\n- `/goal clear` — clears it. Aliases: `stop`, `off`, `reset`, `none`, `cancel`. `/clear` also clears an active goal.\n\n## Headless support\n\nWorks in interactive mode and headless:\n\n```bash\namplifier run --mode single \"/goal all tests in tests/ pass with pytest exiting 0\"\n```\n\nThe entire loop runs in one invocation. SIGINT handling has been added to the headless path: first Ctrl-C requests graceful cancellation, second requests immediate.\n\n## Implementation & orchestrator dependency\n\nThis PR *sets* `session.coordinator.session_state[\"goal\"]` only. The auto-continue loop itself lives in the orchestrator — **this PR depends on microsoft/amplifier-module-loop-streaming#30**. Without that orchestrator change, `/goal` sets state but no auto-continuation occurs.\n\nThis split is deliberate: putting the loop in the orchestrator makes it work headless, in the REPL, and in every other app that mounts it, rather than needing one implementation per app.\n\n## CLI-side goal-progress renderer (NEW)\n\n**Problem**: The orchestrator PR (microsoft/amplifier-module-loop-streaming#30) removes all `print()` calls from the module, because bare print() from an orchestrator corrupts protocol channels for other hosts — `amplifier-agent` uses stdout as a JSON-RPC channel, `amplifierd`/`amplifier-chat`/`amplifier-voice` are daemons/web apps where prints land in journald invisible to the client, and `amplifier-resolver-sdk` defensively redirects stdout→stderr to protect the JSON protocol.\n\n**Solution**: The orchestrator now emits `orchestrator:goal_progress` events instead. This PR adds a new CLI-side hook (`goal_progress_hook.py`) that subscribes to these events and renders to the CLI's rich console, preserving the exact user-visible progress strings (`⟳ goal: turn N/CAP — reason`, `✓ goal achieved: ...`, `⚠ goal: hit turn cap (N) — stopping.`, `✗ goal: cancelled — ...`, `✗ goal: evaluator failed — ...`).\n\nThe hook is registered unconditionally in both `interactive_chat` and `execute_single`, following the same pattern as `incremental_save.py`, so goal output works consistently across all CLI modes.\n\n## Mechanical `--max-turns` cap\n\nThe `--max-turns` flag is the opt-in bound — mechanically enforced by Python, not model-judged. Default is no turn cap, matching Claude Code.\n\n- Bad values (`abc`, `0`, `-5`) fail loud: `ValueError` is raised, no goal is set, no turn runs.\n- Good values (`1`, `5`, `100`) are accepted and enforced by the orchestrator loop.\n- The shared parser `_parse_goal_max_turns()` is used by both interactive (CommandProcessor) and headless (execute_single) entry points, ensuring flag syntax and failure behavior cannot drift between them.\n\n### What the cap does NOT bound\n\n`--max-turns` bounds **goal continuations** — the number of times the goal loop starts a new turn. It does **not** bound work happening *inside* a single turn.\n\nAn agent can make an unlimited number of tool calls within one turn; the turn ends only when the model stops requesting tools. If an agent gets stuck polling something that never completes, it never ends its turn, the goal evaluator never runs, and **the cap never fires.**\n\nThis was verified: an agent given a job-status script that always exited 0 and never reached 100% polled it 59+ times inside a single turn with `--max-turns 8` set. The cap was never reached because no turn ever ended.\n\n`/goal` is a **completion gate**, not a runaway guard. It catches an agent that stops too early. It cannot catch one that never stops. For unattended runs, bound the process externally (a wall-clock `timeout`, a CI job limit) in addition to `--max-turns`.\n\n## New documentation\n\n`docs/GOAL_COMMAND.md` covers usage, but importantly **how to write a condition that converges**. A vague or ambiguous condition is the dominant cost driver:\n\n- One run finished the actual work on turn 1 (28 tests passing) but the condition accidentally omitted the literal pytest command, so the evaluator correctly refused to accept it and pushed back twice more.\n- The doc prescribes: a measurable end state, the literal check command, and explicit MUST-NOT constraints.\n\n## Validation (independently verified)\n\nThe feature was proven to do its actual job — catching premature completion:\n\n- **Staged-review trap**: Agent implemented 1 of 6 required functions and returned. Evaluator caught it — *\"only the `slugify` function has been implemented so far; the other 5 functions remain as stubs\"* — pushed back; agent completed all 6. Reviewer independently verified all 6 present and working.\n- **Hidden-remainder trap**: Spec required 12 functions plus a per-function changelog policy. Agent did all obvious work and returned. Evaluator caught a genuinely subtle deviation — *\"the CHANGELOG.md contains all 12 function entries... but they are all under a single dated entry rather than having a distinct dated entry for every one of the 12 functions as required\"* — pushed back; agent fixed it. Reviewer independently verified 12 functions, 12 distinct dates, all 12 named.\n\nBoth pushback reasons were specific and actionable, and both drove to a verified-correct final state. Zero evaluator failures across every validation run.\n\nPrior validation:\n- Headless and interactive both proven end-to-end (3 auto-continuations → `✓ goal achieved`).\n- Regression: with no goal set, behavior is unchanged.\n- `--max-turns` trips exactly at the cap; bad values fail loud with no goal set.\n- SIGINT mid-run → goal cleared, loop stopped, clean exit.\n- In a Digital Twin Universe, an agent built a stdlib-only URL shortener REST API; the reviewer independently ran `pytest` (**28 passed, exit 0**) and curled every endpoint (302/404/400/409 correct).\n- A separate \"never use any import statement\" run held that constraint too (`grep -c import` → 0, 39 tests passing).\n\n## Pre-existing issue (flagged for separate PR)\n\nDuring validation, a pre-existing bug was discovered: with `amplifier-core` 1.3.0 as locked, **every** turn fails with `TypeError: Object of type Decimal is not JSON serializable`, reproducible on a plain prompt with no goal involved. This is unrelated to this feature and deliberately **not** fixed here. It should be addressed in a separate issue/PR.\n\n---\n\nGenerated with [Amplifier](https://github.com/microsoft/amplifier)\n"
