### PR TITLE
fix: improve goal command UX - fix terminal wrapping and reduce echoed output

### DIFF
--- a/amplifier_app_cli/goal_progress_hook.py
+++ b/amplifier_app_cli/goal_progress_hook.py
@@ -11,11 +11,21 @@ formatted progress lines to the CLI's rich ``console``.
 
 Registered once per session (both interactive_chat and execute_single),
 mirroring the incremental_save.py pattern.
+
+Rendering uses real Rich renderables (Rule / Table.grid / Padding) rather
+than hand-assembled strings with manual dividers and indentation -- Rich
+knows the terminal width and wraps long lines while preserving hanging
+indents; a plain f-string with a leading "  " loses that indent the moment
+a line wraps back to column 0.
 """
 
 from __future__ import annotations
 
 from typing import Any
+
+from rich.padding import Padding
+from rich.rule import Rule
+from rich.table import Table
 
 from .console import console
 
@@ -45,7 +55,27 @@ _TERMINAL_STYLES: dict[str, str] = {
     "stalled": "bold red",
 }
 
-_BLOCK_RULE = "\u2500" * 3
+# States where the run actually struggled -- collapsed reason history earns
+# its space here because it shows *whether the evaluator kept repeating
+# itself*. "achieved" doesn't need it (it succeeded); "cancelled" doesn't
+# need it (the user stopped it, not the loop).
+_STRUGGLE_STATES = frozenset({"stalled", "cap_hit"})
+
+# Which field wins when both `reason` (the final turn's evaluator verdict)
+# and `summary` (a fast-model narrative of the whole run) are present. They
+# overlap heavily -- never show both. For a successful run, the narrative of
+# *what got done* is more useful than the terse final "yes it's done."
+# For every other terminal state the run did NOT succeed, so the concrete,
+# current blocker (reason) is more actionable than a broad narrative.
+_PREFER_SUMMARY_STATES = frozenset({"achieved"})
+
+# Cap on rendered reason-history entries (after collapsing consecutive
+# duplicates) so a long-stalled run doesn't dump a wall of near-identical
+# lines.
+_MAX_HISTORY_ENTRIES = 5
+
+_INDENT_1 = (0, 0, 0, 2)
+_INDENT_2 = (0, 0, 0, 4)
 
 
 class GoalProgressHook:
@@ -53,7 +83,8 @@ class GoalProgressHook:
 
     Contract:
     - Listens for: orchestrator:goal_progress events
-    - Side effects: writes formatted progress lines to the CLI's rich console
+    - Side effects: writes formatted progress lines/renderables to the CLI's
+      rich console
     - Never raises: an unrecognized/malformed payload is rendered as-is
       rather than crashing the session (hook failures must not block
       execution)
@@ -93,10 +124,11 @@ class GoalProgressHook:
     def _render_terminal(self, state: str, data: dict[str, Any]) -> None:
         """Render the end-of-run block for a terminal goal state.
 
-        Always includes: the outcome, how many times the turn was sent back
-        to the assistant (continuations), and the fast-model summary when
-        present. Never suppressed when summary is None -- the structured
-        facts (count, outcome, last reason) still render.
+        The amount of detail scales with how interesting the outcome is:
+        an immediate, uncontested success gets one line; a run that
+        struggled (stalled, hit its cap) gets the full picture, including
+        collapsed reason history. `reason` and `summary` are never both
+        shown -- see ``_PREFER_SUMMARY_STATES``.
         """
         label = _TERMINAL_LABELS[state]
         style = _TERMINAL_STYLES[state]
@@ -107,32 +139,107 @@ class GoalProgressHook:
         stall_detail = data.get("stall_detail")
         continuations = data.get("continuations")
 
-        if continuations is None:
-            continuations_label = "unknown number of continuations"
-        else:
-            plural = "" if continuations == 1 else "s"
-            continuations_label = f"{continuations} continuation{plural}"
-        if cap:
-            continuations_label += f" (cap: {cap})"
+        # Trivial success: the user watched it happen in one pass. There is
+        # nothing else worth saying -- one line, done.
+        if state == "achieved" and continuations == 0:
+            console.print(
+                f"[{style}]\u2713 {label}[/{style}] \u2014 no continuations needed"
+            )
+            return
 
-        console.print(f"[{style}]{_BLOCK_RULE} {label} {_BLOCK_RULE}[/{style}]")
-        console.print(f"  sent back to assistant: {continuations_label}")
+        console.print(
+            Rule(title=f"[{style}]{label}[/{style}]", style=style, align="left")
+        )
 
-        if reason:
-            console.print(f"  last reason: {reason}")
+        facts = Table.grid(padding=(0, 1))
+        facts.add_column(no_wrap=True, style="dim")
+        facts.add_column(overflow="fold")
+        facts.add_row(
+            "sent back to assistant:", _continuations_label(continuations, cap)
+        )
+        console.print(facts)
 
         if state == "stalled" and stall_detail:
-            console.print(f"[bold red]  stalled on:[/bold red] {stall_detail}")
+            console.print(
+                Padding(f"[bold red]stalled on:[/bold red] {stall_detail}", _INDENT_1)
+            )
 
-        if len(reasons) > 1:
-            console.print("  reason history:")
-            for r in reasons:
-                console.print(f"    - {r}")
+        narrative_label, narrative_text = _pick_narrative(
+            reason, summary, prefer_summary=state in _PREFER_SUMMARY_STATES
+        )
+        if narrative_text:
+            console.print(
+                Padding(f"[dim]{narrative_label}:[/dim] {narrative_text}", _INDENT_1)
+            )
 
-        if summary:
-            console.print(f"  summary: {summary}")
+        if state in _STRUGGLE_STATES:
+            # The most recent reason is already shown above (as `reason` or
+            # `summary`) -- history covers everything before it, so nothing
+            # is repeated.
+            history = _collapse_consecutive(reasons[:-1])
+            if history:
+                console.print(Padding("[dim]reason history:[/dim]", _INDENT_1))
+                shown = history[-_MAX_HISTORY_ENTRIES:]
+                omitted = len(history) - len(shown)
+                if omitted > 0:
+                    console.print(
+                        Padding(
+                            f"[dim]\u2026 ({omitted} earlier, omitted)[/dim]", _INDENT_2
+                        )
+                    )
+                for text, count in shown:
+                    suffix = f" (\u00d7{count})" if count > 1 else ""
+                    console.print(Padding(f"- {text}{suffix}", _INDENT_2))
+
+
+def _continuations_label(continuations: int | None, cap: int | None) -> str:
+    """Format the 'sent back to assistant' fact line's value."""
+    if continuations is None:
+        label = "unknown number of continuations"
+    else:
+        plural = "" if continuations == 1 else "s"
+        label = f"{continuations} continuation{plural}"
+    if cap:
+        label += f" (cap: {cap})"
+    return label
+
+
+def _pick_narrative(
+    reason: str | None, summary: str | None, *, prefer_summary: bool
+) -> tuple[str, str]:
+    """Choose exactly one of `reason` / `summary` to render, never both.
+
+    They overlap heavily in practice (the same outcome described twice, at
+    length); showing one is the fix. Returns (label, text), or ("", "") if
+    neither is present.
+    """
+    order = (
+        (("summary", summary), ("reason", reason))
+        if prefer_summary
+        else (("reason", reason), ("summary", summary))
+    )
+    for label, text in order:
+        if text:
+            return label, text
+    return "", ""
+
+
+def _collapse_consecutive(reasons: list[str]) -> list[tuple[str, int]]:
+    """Collapse consecutive duplicate reasons into (text, count) pairs.
+
+    The orchestrator is being updated to collapse consecutive duplicates
+    itself before emitting `reasons`, but this hook collapses defensively
+    too -- an older orchestrator (or any future one) may still send a run of
+    5-8 near-identical entries, and that's noise, not signal.
+    """
+    collapsed: list[tuple[str, int]] = []
+    for text in reasons:
+        if collapsed and collapsed[-1][0] == text:
+            prev_text, prev_count = collapsed[-1]
+            collapsed[-1] = (prev_text, prev_count + 1)
         else:
-            console.print("  [dim](no summary available)[/dim]")
+            collapsed.append((text, 1))
+    return collapsed
 
 
 def register_goal_progress_hook(session: Any) -> GoalProgressHook | None:

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -7,11 +7,9 @@ import os
 import signal
 import sys
 from collections.abc import Callable
-from datetime import UTC
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -19,53 +17,48 @@ from amplifier_app_cli.utils.help_formatter import AmplifierGroup
 
 if TYPE_CHECKING:
     from amplifier_foundation.bundle import PreparedBundle
-from amplifier_core import AmplifierSession
-from amplifier_core import ModuleValidationError  # pyright: ignore[reportAttributeAccessIssue]
+from amplifier_core import (
+    AmplifierSession,
+    ModuleValidationError,  # pyright: ignore[reportAttributeAccessIssue]
+)
 from amplifier_core.llm_errors import LLMError
 from amplifier_foundation import sanitize_message
 from prompt_toolkit import PromptSession
 from prompt_toolkit.formatted_text import HTML
-from prompt_toolkit.history import FileHistory
-from prompt_toolkit.history import InMemoryHistory
+from prompt_toolkit.history import FileHistory, InMemoryHistory
 from prompt_toolkit.key_binding import KeyBindings
 from rich.panel import Panel
 
 from .commands.agents import agents as agents_group
 from .commands.allowed_dirs import allowed_dirs as allowed_dirs_group
-from .commands.denied_dirs import denied_dirs as denied_dirs_group
 from .commands.bundle import bundle as bundle_group
-from .commands.init import check_first_run
-from .commands.init import init_cmd
-from .commands.init import prompt_first_run_init
+from .commands.denied_dirs import denied_dirs as denied_dirs_group
+from .commands.init import check_first_run, init_cmd, prompt_first_run_init
 from .commands.module import module as module_group
 from .commands.notify import notify as notify_group
 from .commands.provider import provider as provider_group
-from .commands.routing import routing_group
 from .commands.reset import reset as reset_cmd
+from .commands.routing import routing_group
 from .commands.run import register_run_command
 from .commands.session import register_session_commands
 from .commands.source import source as source_group
-from .session_runner import create_initialized_session
-from .session_runner import SessionConfig
 from .commands.tool import tool as tool_group
 from .commands.update import update as update_cmd
 from .commands.version import version as version_cmd
-from .console import Markdown
-from .console import console
+from .console import Markdown, console
 from .effective_config import get_effective_config_summary
 from .key_manager import KeyManager
+from .session_runner import SessionConfig, create_initialized_session
 from .session_store import SessionStore
 from .stdout_offload import patch_stdout_offloaded as patch_stdout
 from .ui.dashboard_renderer import DashboardRenderer
 from .ui.dashboard_renderer import _redact_value as _dr_redact_value
+from .ui.error_display import display_llm_error, display_validation_error
 from .ui.item_renderer import ItemRenderer
-from .ui.view_policy import resolve_view
-from .ui.error_display import display_llm_error
-from .ui.error_display import display_validation_error
 from .ui.log_filter import LLMErrorLogFilter
+from .ui.view_policy import resolve_view
 from .utils.error_format import escape_markup
-from .utils.version import get_core_version
-from .utils.version import get_version
+from .utils.version import get_core_version, get_version
 
 logger = logging.getLogger(__name__)
 
@@ -970,8 +963,7 @@ class CommandProcessor:
 
             # Description gets the remaining space: total - indent(4) - name - gap(3)
             desc_max = terminal_cols - 4 - name_col - 3
-            if desc_max < 10:
-                desc_max = 10  # minimum visible width
+            desc_max = max(desc_max, 10)  # minimum visible width
 
             for name, description, advertised in source_modes:
                 hidden_sfx = " (hidden)" if not advertised else ""
@@ -1236,8 +1228,11 @@ class CommandProcessor:
             "no_tool_turns": 0,
             "escalated": False,
         }
+        # Don't echo the condition back -- the user just typed it and can
+        # already see it. Surface only what they couldn't already see:
+        # whether a turn cap is in effect.
         cap_suffix = f" (max {cap} turns)" if cap else " (unlimited turns)"
-        return f"Goal set: {condition}{cap_suffix}"
+        return f"Goal set{cap_suffix}."
 
     async def _rename_session(self, new_name: str) -> str:
         """Rename the current session."""
@@ -1248,7 +1243,8 @@ class CommandProcessor:
         session_id = self.session.coordinator.session_id
 
         try:
-            from datetime import datetime, UTC
+            from datetime import UTC, datetime
+
             from .session_store import SessionStore
 
             store = SessionStore()
@@ -1282,8 +1278,8 @@ class CommandProcessor:
         # Check if session fork utilities are available
         try:
             from amplifier_foundation.session import (
-                fork_session,
                 count_turns,
+                fork_session,
                 get_turn_summary,
             )
         except ImportError:
@@ -3503,7 +3499,11 @@ async def execute_single(
                 cap_suffix = (
                     f" (max {goal_cap} turns)" if goal_cap else " (unlimited turns)"
                 )
-                console.print(f"Goal set: {goal_condition}{cap_suffix}")
+                # Don't echo the condition back -- the user just typed it and
+                # can already see it (mirrors the interactive _handle_goal
+                # confirmation, so both paths stay consistent -- see
+                # docs/GOAL_COMMAND.md).
+                console.print(f"Goal set{cap_suffix}.")
                 prompt = goal_condition
 
         if verbose:

--- a/docs/GOAL_COMMAND.md
+++ b/docs/GOAL_COMMAND.md
@@ -122,9 +122,9 @@ fenced — set one explicitly:
 This is enforced in Python, not judged by a model. When it trips:
 
 ```
-──── GOAL STOPPED — turn cap hit (NOT confirmed complete) ────
-  sent back to assistant: 5 continuations (cap: 5)
-  last reason: ...
+GOAL STOPPED — turn cap hit (NOT confirmed complete) ──────────────
+sent back to assistant: 5 continuations (cap: 5)
+  reason: ...
 ```
 
 A cap hit means the run stopped **without the evaluator confirming the goal was met** — it
@@ -158,10 +158,10 @@ detected the agent making zero progress — repeated turns with no tool calls an
 unchanging blocker — and gave up rather than burning turns against nothing:
 
 ```
-──── GOAL FAILED — stalled (no progress detected) ────
-  sent back to assistant: 3 continuations
-  last reason: ...
+GOAL FAILED — stalled (no progress detected) ──────────────
+sent back to assistant: 3 continuations
   stalled on: agent repeated the same blocked claim 3 turns in a row without making a tool call
+  reason: ...
   reason history:
     - ...
 ```

--- a/docs/decisions/ADR-0005-goal-unlimited-by-default.md
+++ b/docs/decisions/ADR-0005-goal-unlimited-by-default.md
@@ -75,8 +75,8 @@ supports that fully; it is simply not forced onto every invocation by default.
   agentic auto-continue tools that also default to no bound.
 - Because the default is now the common case, the CLI does **not** print a loud warning on
   every unlimited run -- that would be noise on the normal path and would train users to
-  ignore warnings. The confirmation line (`Goal set: <condition> (unlimited turns)`) states
-  the fact plainly without alarm.
+  ignore warnings. The confirmation line (`Goal set (unlimited turns).`) states the fact
+  plainly without alarm, and without echoing the condition text the user just typed.
 - Anyone wanting a mechanical fence must opt in with `--max-turns N`. This is documented in
   `docs/GOAL_COMMAND.md`.
 

--- a/tests/test_goal_command.py
+++ b/tests/test_goal_command.py
@@ -67,12 +67,23 @@ class TestHandleGoalSet:
         assert "unlimited turns" in result
 
     @pytest.mark.asyncio
+    async def test_set_confirmation_does_not_echo_condition(self):
+        """The user just typed the condition -- printing it back is pure
+        duplication. The confirmation should surface only what they
+        couldn't already see: whether a turn cap is in effect."""
+        cp = _make_command_processor()
+        result = await cp._handle_goal("a very long condition the user already typed")
+        assert "a very long condition the user already typed" not in result
+        assert "Goal set" in result
+
+    @pytest.mark.asyncio
     async def test_custom_cap_applied(self):
         cp = _make_command_processor()
         result = await cp._handle_goal(f"{_GOAL_MAX_TURNS_FLAG} 3 do the thing")
         goal = cp.session.coordinator.session_state["goal"]
         assert goal["cap"] == 3
         assert "max 3 turns" in result
+        assert "do the thing" not in result
 
     @pytest.mark.asyncio
     async def test_explicit_zero_is_equivalent_to_default_unlimited(self):

--- a/tests/test_goal_progress_hook.py
+++ b/tests/test_goal_progress_hook.py
@@ -1,15 +1,23 @@
 """Tests for GoalProgressHook's rendering of orchestrator:goal_progress events.
 
-No existing test pattern covers hook console-rendering in this repo, so this
-file uses a lightweight approach: monkeypatch the module's ``console.print``
-to capture emitted lines and assert on their content, rather than snapshotting
-Rich's rendered output.
+The hook prints real Rich renderables (Rule, Table, Padding) rather than
+hand-assembled strings, so capturing ``str(arg)`` on each ``console.print``
+call isn't enough -- a Table's ``__str__`` doesn't include its cell text.
+Instead, this fixture points the module's shared ``console`` at a real
+``rich.console.Console`` writing to an in-memory buffer, so every renderable
+is actually rendered (with word-wrap etc.) exactly as it would be in the
+terminal. Tests then assert on the *information* that must be present in
+that rendered text (state labels, counts, reasons) -- not on decorative
+characters (dividers, colors, exact spacing) -- so they survive future
+cosmetic changes.
 """
 
+import io
 import sys
 from pathlib import Path
 
 import pytest
+from rich.console import Console
 
 sys.path.insert(0, str(Path(__file__).parent))
 
@@ -18,19 +26,17 @@ from amplifier_app_cli.goal_progress_hook import GoalProgressHook
 
 @pytest.fixture
 def hook(monkeypatch):
-    """A GoalProgressHook with console.print captured into a list."""
-    printed: list[str] = []
-    monkeypatch.setattr(
-        "amplifier_app_cli.goal_progress_hook.console.print",
-        lambda *args, **kwargs: printed.append(" ".join(str(a) for a in args)),
-    )
+    """A GoalProgressHook rendering to a real (buffered) Rich console."""
+    buffer = io.StringIO()
+    test_console = Console(file=buffer, width=100, force_terminal=False)
+    monkeypatch.setattr("amplifier_app_cli.goal_progress_hook.console", test_console)
     h = GoalProgressHook()
-    h._printed = printed  # type: ignore[attr-defined]
+    h._buffer = buffer  # type: ignore[attr-defined]
     return h
 
 
 def _joined(hook) -> str:
-    return "\n".join(hook._printed)  # type: ignore[attr-defined]
+    return hook._buffer.getvalue()  # type: ignore[attr-defined]
 
 
 class TestContinuingState:
@@ -55,11 +61,54 @@ class TestContinuingState:
         assert "/" not in out.split("turn 5")[1].split("\u2014")[0]
 
 
-class TestAchievedState:
+class TestAchievedNoContinuations:
+    """continuations == 0: the run succeeded on the first pass. The user
+    watched it happen -- the interesting content is approximately zero, so
+    this gets a single line and nothing else (no reason, no summary, no
+    reason history), regardless of whether reason/summary were provided."""
+
     @pytest.mark.asyncio
-    async def test_achieved_renders_success_block_with_continuations_and_summary(
-        self, hook
-    ):
+    async def test_renders_single_line(self, hook):
+        await hook.on_goal_progress(
+            "orchestrator:goal_progress",
+            {
+                "state": "achieved",
+                "turn": 1,
+                "cap": None,
+                "continuations": 0,
+                "reason": "done",
+                "reasons": ["done"],
+                "summary": None,
+            },
+        )
+        out = _joined(hook)
+        # Exactly one non-empty line: the entire trivial-success message.
+        assert len([line for line in out.splitlines() if line.strip()]) == 1
+        assert "GOAL ACHIEVED" in out
+        assert "no continuations" in out
+
+    @pytest.mark.asyncio
+    async def test_does_not_render_reason_or_summary_even_when_present(self, hook):
+        await hook.on_goal_progress(
+            "orchestrator:goal_progress",
+            {
+                "state": "achieved",
+                "turn": 1,
+                "cap": None,
+                "continuations": 0,
+                "reason": "a long explanation the user already watched happen",
+                "reasons": ["a long explanation the user already watched happen"],
+                "summary": "an equally long restatement of the same thing",
+            },
+        )
+        out = _joined(hook)
+        assert "a long explanation" not in out
+        assert "equally long restatement" not in out
+
+
+class TestAchievedWithContinuations:
+    @pytest.mark.asyncio
+    async def test_renders_block_with_continuations_and_prefers_summary(self, hook):
         await hook.on_goal_progress(
             "orchestrator:goal_progress",
             {
@@ -77,18 +126,42 @@ class TestAchievedState:
         out = _joined(hook)
         assert "GOAL ACHIEVED" in out
         assert "3 continuation" in out
-        assert "all tests pass" in out
         assert "Implemented the feature and verified tests." in out
+        # reason and summary overlap heavily -- only one is shown.
+        assert "all tests pass" not in out
+        # succeeded outright: no reason-history noise.
+        assert "reason history" not in out.lower()
 
     @pytest.mark.asyncio
-    async def test_achieved_without_summary_still_renders_facts(self, hook):
+    async def test_falls_back_to_reason_when_no_summary(self, hook):
         await hook.on_goal_progress(
             "orchestrator:goal_progress",
             {
                 "state": "achieved",
-                "turn": 1,
+                "turn": 2,
                 "cap": None,
-                "continuations": 0,
+                "continuations": 1,
+                "reason": "the file now exists with the required content",
+                "reasons": ["the file now exists with the required content"],
+                "summary": None,
+            },
+        )
+        out = _joined(hook)
+        assert "GOAL ACHIEVED" in out
+        assert "the file now exists with the required content" in out
+
+    @pytest.mark.asyncio
+    async def test_unknown_continuations_still_renders_facts(self, hook):
+        """continuations is None (older orchestrator / genuinely unknown) is
+        NOT treated as the zero-continuations trivial case -- render what we
+        have rather than guessing."""
+        await hook.on_goal_progress(
+            "orchestrator:goal_progress",
+            {
+                "state": "achieved",
+                "turn": 3,
+                "cap": 10,
+                "continuations": None,
                 "reason": "done",
                 "reasons": ["done"],
                 "summary": None,
@@ -96,8 +169,8 @@ class TestAchievedState:
         )
         out = _joined(hook)
         assert "GOAL ACHIEVED" in out
+        assert "unknown number of continuations" in out
         assert "done" in out
-        assert "no summary available" in out
 
 
 class TestCapHitState:
@@ -120,6 +193,56 @@ class TestCapHitState:
         assert "NOT confirmed complete" in out
         assert "achieved" not in out.lower()
         assert "20 continuation" in out
+        # failure states prefer the concrete last reason over the narrative
+        # summary -- only one is shown.
+        assert "still working" in out
+        assert "Ran out of turns before finishing." not in out
+
+    @pytest.mark.asyncio
+    async def test_cap_hit_falls_back_to_summary_when_no_reason(self, hook):
+        await hook.on_goal_progress(
+            "orchestrator:goal_progress",
+            {
+                "state": "cap_hit",
+                "turn": 20,
+                "cap": 20,
+                "continuations": 20,
+                "reason": None,
+                "reasons": [],
+                "summary": "Ran out of turns before finishing.",
+            },
+        )
+        out = _joined(hook)
+        assert "Ran out of turns before finishing." in out
+
+    @pytest.mark.asyncio
+    async def test_cap_hit_shows_collapsed_reason_history_when_it_struggled(self, hook):
+        await hook.on_goal_progress(
+            "orchestrator:goal_progress",
+            {
+                "state": "cap_hit",
+                "turn": 5,
+                "cap": 5,
+                "continuations": 5,
+                "reason": "still not done",
+                "reasons": [
+                    "blocked on X",
+                    "blocked on X",
+                    "blocked on X",
+                    "still not done",
+                ],
+                "summary": None,
+            },
+        )
+        out = _joined(hook)
+        assert "reason history" in out.lower()
+        assert "blocked on X" in out
+        # collapsed: the duplicate is annotated with a count, not repeated
+        # three separate times.
+        assert out.count("blocked on X") == 1
+        assert "\u00d73" in out
+        # the last (current) reason isn't duplicated into the history too.
+        assert out.count("still not done") == 1
 
 
 class TestStalledState:
@@ -142,9 +265,49 @@ class TestStalledState:
         assert "GOAL FAILED" in out
         assert "stalled" in out.lower()
         assert "repeated the same blocked claim with no tool calls" in out
-        assert "reason history" in out
+        assert "reason history" in out.lower()
         assert "blocked A" in out
         assert "GOAL ACHIEVED" not in out
+
+    @pytest.mark.asyncio
+    async def test_stalled_with_no_reason_history_is_not_rendered(self, hook):
+        """Only one reason total (or none preceding the current one) means
+        there's no history worth showing."""
+        await hook.on_goal_progress(
+            "orchestrator:goal_progress",
+            {
+                "state": "stalled",
+                "turn": 1,
+                "cap": None,
+                "continuations": 1,
+                "reason": "blocked immediately",
+                "reasons": ["blocked immediately"],
+                "stall_detail": "no tool calls on the only turn taken",
+                "summary": None,
+            },
+        )
+        out = _joined(hook)
+        assert "reason history" not in out.lower()
+
+    @pytest.mark.asyncio
+    async def test_stalled_caps_very_long_reason_history(self, hook):
+        reasons = [f"blocked variant {i}" for i in range(10)] + ["still blocked"]
+        await hook.on_goal_progress(
+            "orchestrator:goal_progress",
+            {
+                "state": "stalled",
+                "turn": 10,
+                "cap": None,
+                "continuations": 10,
+                "reason": "still blocked",
+                "reasons": reasons,
+                "stall_detail": "no progress across many turns",
+                "summary": None,
+            },
+        )
+        out = _joined(hook)
+        assert "reason history" in out.lower()
+        assert "earlier" in out.lower()  # truncation is surfaced, not silent
 
 
 class TestCancelledAndErrorStates:


### PR DESCRIPTION
## Summary

Two UX fixes from direct user feedback on initial ship:

1. **End-of-run display block did not survive terminal wrapping** — Long values wrapped back to column 0 destroying indentation. Rewrote `_render_terminal` using real rich renderables (`Rule`, `Table.grid`, `Padding`) matching patterns in `ui/error_display.py` and `commands/version.py`. Also reduced verbosity: eliminated duplicate reason/summary, scaled detail to outcome interest.

2. **Setting a goal echoed the whole condition back** — User had just typed it. Now shows one-line confirmation with actionable detail: `Goal set (max 5 turns).` Fixed both interactive and headless code paths that were duplicated.

## Verification

**Unit tests:**
```
pytest tests/test_goal_progress_hook.py tests/test_goal_command.py -q → 34 passed
```

Hook test fixture rewritten to render through real `rich.Console` at fixed width (was `str(obj)`, which silently stopped seeing content once real renderables were introduced).

**Full suite:**
```
1215 passed, 14 failed, 13 deselected, 1 xfailed
```
The 14 failures are pre-existing and unrelated (session-lifecycle/spawner/skill-loading — confirmed via grep that none touch the changed files).

**End-to-end with real provider:**
```
Goal set (max 4 turns).
✓ GOAL ACHIEVED — no continuations needed
```
```
Goal set (unlimited turns).
GOAL ACHIEVED ────────────────────────────────────────────────────
sent back to assistant: 1 continuation
  summary: The assistant was asked to create or display a done.txt file
  containing the word COMPLETE and show its contents. The first attempt failed
  because the file did not exist in the current directory. On the second
  attempt, the assistant successfully created the file with the required content
  and displayed it.
```
```
GOAL FAILED — stalled (no progress detected) ──────────────────────
sent back to assistant: 4 continuations (cap: 8)
  stalled on: The same unresolved blocker—that the required information exists
  only in the user's mind and was never communicated to the assistant—recurs
  identically across all four turns with no attempt at new strategies, narrowing
  of possibilities, or incremental progress toward the goal.
```

Wrapped lines maintain proper hanging indent under labels.

## Follow-up

`uv.lock` is stale (pins `amplifier-core` 1.3.0; repo's `prepare.py` needs `>=1.5.2`). This PR does not touch it — separate follow-up PR should bump to 1.6.0 and raise floor.

Generated with [Amplifier](https://github.com/microsoft/amplifier)