### PR TITLE
refactor: let /goal prose wrap naturally instead of truncating at 180 chars

### DIFF
--- a/amplifier_app_cli/goal_progress_hook.py
+++ b/amplifier_app_cli/goal_progress_hook.py
@@ -80,13 +80,6 @@ _STYLE: dict[str, str] = {
     "error": "yellow",
 }
 
-# Sane character budget for any single rendered prose line. The orchestrator
-# is being changed in parallel to constrain generated reason/summary text to
-# one sentence, but this hook doesn't trust that -- it truncates defensively
-# at render, on a word boundary, so a misbehaving upstream can't dump a
-# paragraph into the terminal.
-_MAX_PROSE_CHARS = 180
-
 # Matches a trailing "(\u00d7N)" repeat-count annotation the orchestrator's
 # own dedupe may already have attached to a reason string (e.g.
 # "blocked on X (\u00d73)"). Parsed defensively so this hook's own collapsing
@@ -141,7 +134,7 @@ class GoalProgressHook:
         turn_label = f"{turn}/{cap}" if cap else f"{turn}"
         line = f"\u27f3 goal: turn {turn_label}"
         if reason:
-            line += f" \u2014 {_truncate(reason)}"
+            line += f" \u2014 {reason.strip()}"
         _print(line)
 
     def _render_terminal(self, state: str, data: dict[str, Any]) -> None:
@@ -221,13 +214,13 @@ def _body_lines(state: str, data: dict[str, Any]) -> list[str]:
         lines: list[str] = []
         narrative = data.get("summary") or data.get("reason")
         if narrative:
-            lines.append(_truncate(f"still open: {narrative}"))
+            lines.append(f"still open: {narrative.strip()}")
         lines.append("rerun with a higher cap to finish")
         return lines
 
     if state in ("cancelled", "error"):
         narrative = data.get("reason") or data.get("summary")
-        return [_truncate(narrative)] if narrative else []
+        return [narrative.strip()] if narrative else []
 
     return []
 
@@ -255,18 +248,18 @@ def _stalled_line(data: dict[str, Any]) -> str | None:
         )
         if len(collapsed) == 1:
             blocker, _count = collapsed[0]
-            return _truncate(f"same blocker {total_turns} turns running: {blocker}")
-        return _truncate(
+            return f"same blocker {total_turns} turns running: {blocker}"
+        return (
             f"{total_turns} turns, {len(collapsed)} different blockers, none resolved"
         )
 
     stall_detail = data.get("stall_detail")
     if stall_detail:
-        return _truncate(stall_detail)
+        return stall_detail.strip()
 
     reason = data.get("reason")
     if reason:
-        return _truncate(reason)
+        return reason.strip()
 
     return None
 
@@ -314,17 +307,6 @@ def _count_word(n: int) -> str:
     if n == 2:
         return "twice"
     return f"{n} times"
-
-
-def _truncate(text: str, limit: int = _MAX_PROSE_CHARS) -> str:
-    """Truncate prose to ``limit`` chars on a word boundary, with an ellipsis."""
-    text = text.strip()
-    if len(text) <= limit:
-        return text
-    head = text[:limit]
-    if " " in head:
-        head = head.rsplit(" ", 1)[0]
-    return f"{head.rstrip()}\u2026"
 
 
 def _print(text: str) -> None:

--- a/tests/test_goal_progress_hook.py
+++ b/tests/test_goal_progress_hook.py
@@ -266,15 +266,18 @@ class TestStalledState:
         assert "Goal not met" in out
 
     @pytest.mark.asyncio
-    async def test_long_blocker_is_truncated(self, hook):
+    async def test_long_blocker_passes_through_untruncated(self, hook):
+        """No character budget: a long blocker survives verbatim, with no
+        ellipsis and nothing lost -- the terminal wraps it, this hook
+        doesn't cut it."""
         long_blocker = "x" * 400
         await hook.on_goal_progress(
             "orchestrator:goal_progress",
             {"state": "stalled", "reasons": [long_blocker]},
         )
         out = _joined(hook)
-        assert "\u2026" in out
-        assert long_blocker not in out
+        assert "\u2026" not in out
+        assert long_blocker in out
 
 
 class TestCapHitState:
@@ -551,3 +554,25 @@ class TestWidthAgnosticRendering:
         matching_lines = [line for line in out.splitlines() if "still open" in line]
         assert len(matching_lines) == 1
         assert long_summary in matching_lines[0]
+
+    @pytest.mark.asyncio
+    async def test_very_long_prose_survives_verbatim_no_truncation(self, monkeypatch):
+        """There is no character budget: a 300+ char prose string comes back
+        completely intact, with no ellipsis and nothing cut -- the terminal
+        wraps it, this hook never truncates it."""
+        very_long_reason = (
+            "the evaluator determined the goal was not fully satisfied because "
+            "several acceptance criteria remained unaddressed, including the "
+            "requirement to update the changelog, the requirement to add "
+            "regression tests covering the new edge cases, and the requirement "
+            "to update the public documentation describing the changed behavior"
+        )
+        assert len(very_long_reason) > 300
+        h, buffer = _make_hook(monkeypatch, width=80)
+        await h.on_goal_progress(
+            "orchestrator:goal_progress",
+            {"state": "cancelled", "reason": very_long_reason},
+        )
+        out = buffer.getvalue()
+        assert very_long_reason in out
+        assert "\u2026" not in out


### PR DESCRIPTION
## What

Removes the leftover `_MAX_PROSE_CHARS = 180` budget and its `_truncate()` helper from the `/goal` end-of-run render (~7 call sites).

## Why

The module is already width-agnostic — zero `console.width`/`get_terminal_size` calls, no `Rule`/`Table`/`Padding`/`Panel`, and `soft_wrap=True` on every print so Rich never inserts line breaks and the terminal wraps naturally (and reflows on resize).

Truncation contradicted that. If a sentence is 200 characters the terminal simply wraps it onto another line, which is correct at every width. Truncating instead destroyed the end of the sentence permanently to solve a problem the terminal already solves for free. And 180 characters cannot be right at any particular width — it is three lines on a phone and a third of a line on a wide desktop.

`.strip()` hygiene is preserved at every call site — that was legitimate, not width management. Nothing else changed: the `<glyph> <status> — <cause>` header grammar, per-state body lines, the two-space indent on detail lines, and the blank line before non-success blocks are untouched.

## Verification

`pytest tests/test_goal_progress_hook.py -v` → **43 passed**

- `test_long_blocker_is_truncated` was **inverted, not deleted** → `test_long_blocker_passes_through_untruncated`, asserting a 400-char blocker survives verbatim with no ellipsis
- New `test_very_long_prose_survives_verbatim_no_truncation` covers a 322-char string
- `TestWidthAgnosticRendering` (renders every payload at 40/80/200 columns, asserts **byte-for-byte** equality) remains green — the load-bearing guard for this module

`python_check` (ruff-format, ruff-lint, stub-check, pyright): clean on both files.

Rendered proof — `cancelled` state with a 322-char reason, emitted as one unbroken buffer line for the terminal to wrap:

```
⚠ Goal unconfirmed — cancelled
  the evaluator determined the goal was not fully satisfied because several acceptance criteria remained unaddressed, including the requirement to update the changelog, the requirement to add regression tests covering the new edge cases, and the requirement to update the public documentation describing the changed behavior
```

Full string intact, no ellipsis.

## Follow-up (not in this PR)

`uv.lock` is stale — pins `amplifier-core` 1.3.0 while this repo's own `prepare.py` calls `Bundle.prepare(strict=...)`. Pre-existing and unrelated. Worth its own PR: bump to core 1.6.0, floor `>=1.5.2`.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>