### PR TITLE
fix: upgrade amplifier-core floor to >=1.5.3, sync dependencies & document goal exits

### DIFF
--- a/amplifier_app_cli/goal_progress_hook.py
+++ b/amplifier_app_cli/goal_progress_hook.py
@@ -80,13 +80,6 @@ _STYLE: dict[str, str] = {
     "error": "yellow",
 }
 
-# Sane character budget for any single rendered prose line. The orchestrator
-# is being changed in parallel to constrain generated reason/summary text to
-# one sentence, but this hook doesn't trust that -- it truncates defensively
-# at render, on a word boundary, so a misbehaving upstream can't dump a
-# paragraph into the terminal.
-_MAX_PROSE_CHARS = 180
-
 # Matches a trailing "(\u00d7N)" repeat-count annotation the orchestrator's
 # own dedupe may already have attached to a reason string (e.g.
 # "blocked on X (\u00d73)"). Parsed defensively so this hook's own collapsing
@@ -141,7 +134,7 @@ class GoalProgressHook:
         turn_label = f"{turn}/{cap}" if cap else f"{turn}"
         line = f"\u27f3 goal: turn {turn_label}"
         if reason:
-            line += f" \u2014 {_truncate(reason)}"
+            line += f" \u2014 {reason.strip()}"
         _print(line)
 
     def _render_terminal(self, state: str, data: dict[str, Any]) -> None:
@@ -221,13 +214,13 @@ def _body_lines(state: str, data: dict[str, Any]) -> list[str]:
         lines: list[str] = []
         narrative = data.get("summary") or data.get("reason")
         if narrative:
-            lines.append(_truncate(f"still open: {narrative}"))
+            lines.append(f"still open: {narrative.strip()}")
         lines.append("rerun with a higher cap to finish")
         return lines
 
     if state in ("cancelled", "error"):
         narrative = data.get("reason") or data.get("summary")
-        return [_truncate(narrative)] if narrative else []
+        return [narrative.strip()] if narrative else []
 
     return []
 
@@ -255,18 +248,18 @@ def _stalled_line(data: dict[str, Any]) -> str | None:
         )
         if len(collapsed) == 1:
             blocker, _count = collapsed[0]
-            return _truncate(f"same blocker {total_turns} turns running: {blocker}")
-        return _truncate(
+            return f"same blocker {total_turns} turns running: {blocker}"
+        return (
             f"{total_turns} turns, {len(collapsed)} different blockers, none resolved"
         )
 
     stall_detail = data.get("stall_detail")
     if stall_detail:
-        return _truncate(stall_detail)
+        return stall_detail.strip()
 
     reason = data.get("reason")
     if reason:
-        return _truncate(reason)
+        return reason.strip()
 
     return None
 
@@ -314,17 +307,6 @@ def _count_word(n: int) -> str:
     if n == 2:
         return "twice"
     return f"{n} times"
-
-
-def _truncate(text: str, limit: int = _MAX_PROSE_CHARS) -> str:
-    """Truncate prose to ``limit`` chars on a word boundary, with an ellipsis."""
-    text = text.strip()
-    if len(text) <= limit:
-        return text
-    head = text[:limit]
-    if " " in head:
-        head = head.rsplit(" ", 1)[0]
-    return f"{head.rstrip()}\u2026"
 
 
 def _print(text: str) -> None:

--- a/docs/GOAL_COMMAND.md
+++ b/docs/GOAL_COMMAND.md
@@ -122,13 +122,15 @@ fenced — set one explicitly:
 This is enforced in Python, not judged by a model. When it trips:
 
 ```
-GOAL STOPPED — turn cap hit (NOT confirmed complete) ──────────────
-sent back to assistant: 5 continuations (cap: 5)
-  reason: ...
+⚠ Goal unconfirmed — hit the 5-turn cap
+  still open: ...
+  rerun with a higher cap to finish
 ```
 
 A cap hit means the run stopped **without the evaluator confirming the goal was met** — it
-is not a success signal.
+is not a success signal. It is not a failure signal either: the work may well have been
+finished on the last turn and simply never confirmed. That is what "unconfirmed" means, and
+it is why the line names what is *still open* rather than what went wrong.
 
 ### Unlimited runs (`--max-turns 0`)
 
@@ -148,8 +150,57 @@ An invalid value fails immediately and sets no goal:
 → Goal not set: Invalid --max-turns value: 'abc' -- must be a non-negative integer (0 means unlimited).
 ```
 
-**Writing "or stop after 20 turns" into the condition text is not a bound** — that is a
-sentence for a model to interpret. Use the flag.
+### Write the exit into the condition
+
+`--max-turns` is an *external* budget cap: Python counts turns and stops the loop. The agent
+cannot see it, reason about it, or report progress against it. A bound written into the
+condition itself is a different thing, and usually the better one.
+
+A condition with no reachable exit has no fixed point:
+
+```
+/goal output the exact code I am thinking of
+```
+
+The evaluator can only ever say "not yet." The run's only endings are a cap or the stall
+detector — both *external* rescues. Add a disjunctive clause and the shape changes entirely:
+
+```
+/goal output the exact code I am thinking of, or stop after 3 attempts
+```
+
+That terminates **by construction**, on the goal's own terms: it reaches a clean, honest
+"didn't get it" without any machinery having to infer the agent was stuck.
+
+**A goal that states its own exit is stronger than a detector that has to infer one.** The
+stall detector is a safety net for goals that lack an exit, not a substitute for writing one.
+
+In practice:
+
+- **Prefer conditions the agent's own output can demonstrate.** The evaluator reads the
+  transcript; it does not run commands or read files (see below).
+- **When a goal might not be achievable, say what should happen instead** — `...or explain
+  specifically why it cannot be done`.
+- **A bound clause can count attempts, turns, or elapsed time** — whatever the agent can
+  actually observe and report against.
+
+**Unbounded:**
+```
+/goal find the root cause of the flaky test in tests/test_sync.py
+```
+If the cause is genuinely elusive there is no state the agent can reach that satisfies this.
+It runs until something external stops it.
+
+**Bounded:**
+```
+/goal find the root cause of the flaky test in tests/test_sync.py, or after 5 attempts
+report the suspects you narrowed it to and what you ruled out.
+```
+Both branches are reachable, and both are demonstrable in the transcript.
+
+A clause like this is **not a mechanical bound** — it is a sentence a model interprets, and a
+model can talk itself past it. When you need the guarantee, use `--max-turns`. The two are
+complementary: the flag fences the run from outside, the clause gives it somewhere to land.
 
 ### Stalled runs
 
@@ -158,16 +209,19 @@ detected the agent making zero progress — repeated turns with no tool calls an
 unchanging blocker — and gave up rather than burning turns against nothing:
 
 ```
-GOAL FAILED — stalled (no progress detected) ──────────────
-sent back to assistant: 3 continuations
-  stalled on: agent repeated the same blocked claim 3 turns in a row without making a tool call
-  reason: ...
-  reason history:
-    - ...
+✗ Goal not met — stalled
+  same blocker 3 turns running: ...
 ```
 
-`stalled` is a **failure outcome**, same as hitting an unhandled error — the goal was not
-achieved. It is not gated by `--max-turns`; it can trip well before the cap if the run is
+The first stall detection does not end the run. It spends one escalation turn telling the
+agent to try a genuinely different approach or say plainly why the goal cannot be met as
+defined. Only a second stall — or a first one with no cap budget left for the escalation —
+ends the run.
+
+`stalled` is the only **failure** outcome: it is the one case where the agent visibly failed
+to make progress. (`cancelled` and `error` render as *unconfirmed*, not failed — you stopping
+the run, or the evaluator itself breaking, says nothing about whether the goal was
+achievable.) It is not gated by `--max-turns`; it can trip well before the cap if the run is
 genuinely stuck.
 
 ### What the cap does NOT bound
@@ -228,9 +282,20 @@ percentage, no milestone list, and no burn-down — a synthesized progress numbe
 guess presented as a measurement.
 
 At the end of a run (achieved, cap hit, cancelled, error, or stalled), the CLI prints a
-distinct end-of-run block with the outcome, the continuation count, and — when available — a
-fast-model summary of the run. `cap_hit` and `stalled` are both rendered as **not
-successful** (the goal was not confirmed complete); only `achieved` is a success outcome.
+single-line outcome header. It is always one of exactly three verdicts — `✓ Goal met`,
+`✗ Goal not met`, or `⚠ Goal unconfirmed` — so the first three words carry the answer and
+nothing after them can invert it:
+
+```
+✓ Goal met · sent back twice
+```
+
+`achieved` is the only success outcome, and the only one that prints the continuation count.
+It prints no explanatory prose at all — you just watched it succeed. Every other outcome adds
+a short cause to the header (`— hit the 5-turn cap`, `— stalled`, `— cancelled`,
+`— evaluator failed`) and at most a line or two of prose beneath it. For `cap_hit`, `stalled`,
+and `error`, that prose is a fast-model line naming the one thing you could not see live:
+what is still open, what blocked the run, or what broke.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "rich>=13.0.0",
     "pygments>=2.13.0",
     "pydantic>=2.0.0",
-    "amplifier-core>=1.0.10",
+    "amplifier-core>=1.5.3",
     "amplifier-foundation",
     "pyyaml>=6.0.3",
     "prompt-toolkit>=3.0.52",

--- a/tests/test_goal_progress_hook.py
+++ b/tests/test_goal_progress_hook.py
@@ -266,15 +266,18 @@ class TestStalledState:
         assert "Goal not met" in out
 
     @pytest.mark.asyncio
-    async def test_long_blocker_is_truncated(self, hook):
+    async def test_long_blocker_passes_through_untruncated(self, hook):
+        """No character budget: a long blocker survives verbatim, with no
+        ellipsis and nothing lost -- the terminal wraps it, this hook
+        doesn't cut it."""
         long_blocker = "x" * 400
         await hook.on_goal_progress(
             "orchestrator:goal_progress",
             {"state": "stalled", "reasons": [long_blocker]},
         )
         out = _joined(hook)
-        assert "\u2026" in out
-        assert long_blocker not in out
+        assert "\u2026" not in out
+        assert long_blocker in out
 
 
 class TestCapHitState:
@@ -551,3 +554,25 @@ class TestWidthAgnosticRendering:
         matching_lines = [line for line in out.splitlines() if "still open" in line]
         assert len(matching_lines) == 1
         assert long_summary in matching_lines[0]
+
+    @pytest.mark.asyncio
+    async def test_very_long_prose_survives_verbatim_no_truncation(self, monkeypatch):
+        """There is no character budget: a 300+ char prose string comes back
+        completely intact, with no ellipsis and nothing cut -- the terminal
+        wraps it, this hook never truncates it."""
+        very_long_reason = (
+            "the evaluator determined the goal was not fully satisfied because "
+            "several acceptance criteria remained unaddressed, including the "
+            "requirement to update the changelog, the requirement to add "
+            "regression tests covering the new edge cases, and the requirement "
+            "to update the public documentation describing the changed behavior"
+        )
+        assert len(very_long_reason) > 300
+        h, buffer = _make_hook(monkeypatch, width=80)
+        await h.on_goal_progress(
+            "orchestrator:goal_progress",
+            {"state": "cancelled", "reason": very_long_reason},
+        )
+        out = buffer.getvalue()
+        assert very_long_reason in out
+        assert "\u2026" not in out

--- a/uv.lock
+++ b/uv.lock
@@ -28,7 +28,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "amplifier-core", specifier = ">=1.0.10" },
+    { name = "amplifier-core", specifier = ">=1.5.3" },
     { name = "amplifier-foundation", git = "https://github.com/microsoft/amplifier-foundation?branch=main" },
     { name = "click", specifier = ">=8.1.0" },
     { name = "filelock", specifier = ">=3.29.6" },
@@ -49,7 +49,7 @@ dev = [
 
 [[package]]
 name = "amplifier-core"
-version = "1.3.0"
+version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -59,20 +59,18 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/0a/c9f979aa34ff43d86323fd02c6e0b2049cf583f48a75eefe4e2d4ea39a5b/amplifier_core-1.3.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:e94a6adfb538c2f621ddd4eb44f2f2dc645934fef804bc5318d4595520f4f4c9", size = 8096649, upload-time = "2026-03-19T14:01:24.218Z" },
-    { url = "https://files.pythonhosted.org/packages/01/58/619daa63943870340673c625695038b86567adc9896b9d81ff8a2a707b3b/amplifier_core-1.3.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:d051f91a2c3c61c240f828daf892ac2cfa8d34e9850b245e7ebc96e87f9ac606", size = 7216307, upload-time = "2026-03-19T14:01:26.032Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/35/6aeb099f012c8d97ccd4aad878a1422fe3148840922e4818a7c1279fdc57/amplifier_core-1.3.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:af25c5e691638496226aa88e80056cb1870b715ddebd311bccb855c653ace05f", size = 7593745, upload-time = "2026-03-19T14:01:28.027Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/8e/d2a092e31f1924c6c977a3a091b026560a31133fb1f94bf4389f71a8b249/amplifier_core-1.3.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18f1d9e2ffa6a9aac507699c039d3dc8dc23fe696a5af515e2fce1d90b34e11b", size = 8624234, upload-time = "2026-03-19T14:01:30.068Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a3/d6e83e879ecdc300fb4516f1f68f6bab4ab5e2dcc4037a90b9df74861911/amplifier_core-1.3.0-cp311-abi3-win_amd64.whl", hash = "sha256:1bf419d8d659821589b6af68d7a9d6c5e4495095bd7b240ff67527e0ab137985", size = 8887729, upload-time = "2026-03-19T14:01:32.392Z" },
-    { url = "https://files.pythonhosted.org/packages/12/00/36e1f6456a7a6782986918f4ec6890fe6526d3fda478bd46c57fd7cfa9b3/amplifier_core-1.3.0-cp311-abi3-win_arm64.whl", hash = "sha256:eebac607c14c5fac1e12eabb97c09ade64bd2d003f2e9fa1566ac4898bfe848d", size = 7658166, upload-time = "2026-03-19T14:01:34.443Z" },
-    { url = "https://files.pythonhosted.org/packages/02/f0/3beca3cc30323e60f88c8126612a05e3d97f0c951c2d7920458e7ae8e480/amplifier_core-1.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:a2f8c128f78c8c615f6e411f378b6ad5dc70db9d342a347435df759e4ea4cdbf", size = 7648908, upload-time = "2026-03-19T14:01:36.763Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/38/84b012e1b50226ab97cf8ad9f688708bcb6a34a2c6dd139a28d60d40cd71/amplifier_core-1.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:5bbfac975bf6757c479b31bd07b1d465fde49d95dded497c4d161509919dd93b", size = 7647745, upload-time = "2026-03-19T14:01:38.955Z" },
+    { url = "https://files.pythonhosted.org/packages/32/90/d520390cd91aae3d02db53653f828046089c79203dbb142e9bda346fa1d6/amplifier_core-1.6.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d35130e4262cf0db2d6c5f7e65e244a9ef2c7397bfe2a9853bc9b0d9fd05be64", size = 8113151, upload-time = "2026-05-18T16:13:46.825Z" },
+    { url = "https://files.pythonhosted.org/packages/94/75/3ab3126ba5a6f2fc6051a4d08e42364899e4c9ac4daa9d0a60947bf8acd1/amplifier_core-1.6.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:387a2c58fcf4caefdb45c52ec228307bc225e73606897f242154782bc3e123da", size = 7268223, upload-time = "2026-05-18T16:13:48.749Z" },
+    { url = "https://files.pythonhosted.org/packages/21/22/5a36160b3487170bcba0cbc61535101ff624e8314ed38fd35e561cb711a1/amplifier_core-1.6.0-cp311-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8344fccdedd725a51c018de17867cdf1c35abb571dabc0bbccdb5c1242324a47", size = 7532259, upload-time = "2026-05-18T16:13:50.614Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/d7/3874c2308523209411367cf3b8b690e14e869f5f6bfb64cb1b1971e06a96/amplifier_core-1.6.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5a8e0103242a2e2a975c880b1de0e5a02501e0421c1e5386dadae3f111e1d2b5", size = 8507642, upload-time = "2026-05-18T16:13:52.977Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/3646a89537b4556274183519f6db9c354fb3d183f52ef4a2179af12dd386/amplifier_core-1.6.0-cp311-abi3-win_amd64.whl", hash = "sha256:5113aa2d88038776eb257af9e7d9de7af13b3cd9097d2ac67aef5730fa0678e3", size = 8910313, upload-time = "2026-05-18T16:13:55.249Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/9e/58b141115e5eea65703f0b01459eefed36b561e9642ba96d48542345cd8f/amplifier_core-1.6.0-cp311-abi3-win_arm64.whl", hash = "sha256:e1b2731dc09d1cbc668b411007e7f9a2c7edbd75b2525407cae1e6b4a4de0b83", size = 7661416, upload-time = "2026-05-18T16:13:57.513Z" },
 ]
 
 [[package]]
 name = "amplifier-foundation"
 version = "1.0.0"
-source = { git = "https://github.com/microsoft/amplifier-foundation?branch=main#91dc9dc0bfc3a3890a190214aa584f903461ae91" }
+source = { git = "https://github.com/microsoft/amplifier-foundation?branch=main#0d5c5204befc33febfc2bdb8cd8d72ff0a3e6c84" }
 dependencies = [
     { name = "amplifier-core" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Summary

This PR fixes a broken dependency lock and documents goal termination conditions.

### Part 1: Unstick the dependency lock (amplifier-core floor)

The repo was pinned to amplifier-core 1.3.0 and an old amplifier-foundation commit (91dc9dc), but the codebase had already outrun that pin. Every CLI invocation crashed with:
- `TypeError: Bundle.prepare() got unexpected keyword argument 'strict'`
- `TypeError: Object of type Decimal is not JSON serializable`

**Floor determined via end-to-end testing** of each candidate version in a clean venv:

| Version | Result |
|---------|--------|
| 1.3.0 | Decimal TypeError |
| 1.5.0 | Decimal TypeError |
| 1.5.1 | ✓ PASS (cost_usd field serializer) |
| 1.5.2 | ✓ PASS (FFI sanitization) |
| 1.5.3 | ✓ PASS (hook-registry emit Decimal fix) |
| 1.6.0 | ✓ PASS (current stable) |

Floor is **>=1.5.3** — three independent Decimal-serialization issues exist across the dependency tree. Only 1.5.3 closes the third issue in hook-registry emit().

**Changes:**
- `pyproject.toml`: `amplifier-core>=1.0.10` → `>=1.5.3`
- `uv.lock`: regenerated via `uv lock` (amplifier-core 1.3.0 → 1.6.0, foundation 91dc9dc → 0d5c5204)

**Verification (clean environment):**
- `rm -rf .venv && uv sync` ✓ PASS
- `.venv/bin/amplifier --version` → `core 1.6.0`
- `.venv/bin/amplifier run --mode single "say SMOKE_OK"` → exit 0, output SMOKE_OK
- Full test suite before vs after: `15 failed, 1240 passed, 13 deselected, 1 xfailed` (same 15 test IDs — zero new failures)

**Blast radius review:** 44 commits between v1.3.0 and v1.6.0 checked. No removed APIs, no breaking signatures. v1.6.0 fixes session:start semantics (bug fix, not breaking).

### Part 2: Document how to write goal conditions that terminate

`docs/GOAL_COMMAND.md` gains **"Write the exit into the condition"** section between `--max-turns` and stall-detector material.

Core principle: `--max-turns` is an external budget cap the agent cannot see. A bound written into the condition itself is superior—the goal terminates **by construction**, reaching clean "didn't get it" without requiring system-level stall detection.

**Also corrected five stale passages:**
1. Cap-hit render: old block → new one-liner with turn count
2. Stalled render: removed old multi-line reason history
3. Outcome mapping: clarified error/cancelled (unconfirmed) vs stalled (not met)
4. Stall escalation: added missing note on one-shot escalation turn
5. End-of-run description: updated for one-line render

## Test plan

- [x] Clean environment: `rm -rf .venv && uv sync` succeeds, CLI operational
- [x] Smoke test: `amplifier run --mode single "say SMOKE_OK"` returns SMOKE_OK, exit 0
- [x] Full suite: before-and-after test count byte-for-byte identical (zero new failures)
- [x] Blast radius: 44 commits between v1.3.0 and v1.6.0 reviewed — no breaking changes
- [x] Documentation: Five stale examples and descriptions corrected against current implementation