### PR TITLE
feat(bundle): compose context-intelligence logging + navigation by default

### DIFF
--- a/amplifier_app_cli/runtime/config.py
+++ b/amplifier_app_cli/runtime/config.py
@@ -85,6 +85,11 @@ async def resolve_bundle_config(
         # Always available - users choose to use /mode commands or not
         compose_behaviors.extend(_build_modes_behaviors())
 
+        # Context Intelligence: record session events to local JSONL files, and
+        # provide an agent that can answer questions about them by reading those
+        # files. Local-only - no server, database, or container runtime needed.
+        compose_behaviors.extend(_build_context_intelligence_behaviors())
+
         # Notification behaviors (desktop and push notifications). The flags
         # object is the single source of truth for "is this enabled?" — the
         # hook-override emitter in AppSettings.get_notification_hook_overrides()
@@ -881,6 +886,34 @@ def _build_modes_behaviors() -> list[str]:
     return [
         # Only load the behavior, NOT the root bundle (which includes foundation)
         "git+https://github.com/microsoft/amplifier-bundle-modes@main#subdirectory=behaviors/modes.yaml",
+    ]
+
+
+def _build_context_intelligence_behaviors() -> list[str]:
+    """Return context-intelligence behavior URIs for composition.
+
+    Two orthogonal behaviors, both local-only:
+
+    - ``logging`` mounts a hook that records session events to local JSONL
+      files under the session directory. No agents, no server required.
+    - ``navigation`` mounts ``session-navigator``, an agent that answers
+      questions about those recorded sessions by reading the files directly.
+      It carries no server tooling.
+
+    Neither behavior includes the graph analysis layer, so no graph server,
+    database, or container runtime is required or contacted. Server fan-out
+    stays off unless the user explicitly configures a destination.
+
+    Returns:
+        List of context-intelligence behavior URIs.
+    """
+    base = "git+https://github.com/microsoft/amplifier-bundle-context-intelligence@main#subdirectory=behaviors"
+    return [
+        # Load only these two behaviors - NOT the analysis/design layers (which
+        # add graph-server tooling) and NOT the root bundle (which includes
+        # foundation).
+        f"{base}/context-intelligence-logging.yaml",
+        f"{base}/context-intelligence-navigation.yaml",
     ]
 
 


### PR DESCRIPTION
## What

Adds two Context Intelligence behaviors to the set the CLI composes into every session by default:

- `context-intelligence-logging` — a hook that records session events to local JSONL files
- `context-intelligence-navigation` — `session-navigator`, an agent that answers questions about those recorded sessions by reading the files directly

## Why

Session activity is already written to disk by the CLI's own logging hook, but that data isn't queryable from inside a session. Composing these two behaviors makes sessions self-describing: events are captured, and an agent can read them back to answer questions like "what did I do in my last session?" or "which tools do I use most often?"

Both behaviors are local-only. Neither requires a server, a database, or a container runtime.

## What is deliberately not included

The bundle's `analysis` and `design` layers are not composed. Those add graph-database query tooling and a design mode. This change is limited to local file recording plus local file reading.

Server fan-out remains off unless a user explicitly configures a destination — both credential settings default to empty, which routes the hook down its local-JSONL-only path.

## Verification

Tested in an isolated container with no context-intelligence environment variables set:

| Check | Result |
|---|---|
| Session starts cleanly | Pass — exit 0, zero warnings or errors |
| Local event + metadata files written | Pass — on every session, including delegated sub-sessions |
| `session-navigator` present in the agent catalog | Pass |
| Agent answers questions about recorded sessions | Pass |
| Conflicts with the existing default stack | None — one `tool-delegate`, one `tool-skills`; the skills list merges rather than replaces |
| Existing session recording | Unaffected — the native logging hook keeps its own config and output path |
| Cold-start cost | +~1s (24s → 25s); warm runs unchanged at 2–3s |
| Cache footprint | +~15MB |

## Known rough edge

The `session-navigator` description states that it must not be invoked directly and that callers should route through a `graph-analyst` agent. That agent lives in the analysis layer, which this change deliberately excludes.

In testing, the model invoked the agent and produced good results under some phrasings, and declined under others, citing that description. Nothing enforces the restriction in code — it is prose in the agent description, and the capability works correctly when invoked.

Fixing this belongs in the Context Intelligence bundle, by making the description aware of which layers are composed. This change leaves that bundle untouched.