### PR TITLE
fix: resolve @mention expansion ordering and snapshot goal conditions

### DIFF
--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -1219,6 +1219,13 @@ class CommandProcessor:
                 f"[{_GOAL_MAX_TURNS_FLAG} N] <condition>"
             )
 
+        # Expand @mentions in the condition once, here, at set time --
+        # snapshot semantics (see docs/GOAL_COMMAND.md). The condition is
+        # re-sent to the evaluator model every turn; without this it would
+        # see the literal "@file" token forever instead of the file's
+        # content.
+        condition = await process_runtime_mentions(self.session, condition)
+
         session_state["goal"] = {
             "condition": condition,
             "turns_used": 0,
@@ -3442,9 +3449,6 @@ async def execute_single(
 
         register_goal_progress_hook(session)
 
-        # Process runtime @mentions in user input
-        prompt = await process_runtime_mentions(session, prompt)
-
         # === /goal support in headless mode (see docs/GOAL_COMMAND.md) ===
         # The auto-continue loop itself now lives in the orchestrator (see
         # loop-streaming's execute()), so headless mode only needs to set
@@ -3452,6 +3456,14 @@ async def execute_single(
         # the orchestrator does the rest, including printing progress via
         # plain print() (this process has no rich console driving stdout
         # from inside the orchestrator).
+        #
+        # This detection MUST run on the RAW prompt, BEFORE the general
+        # @mention expansion below -- expansion prepends a <context_file
+        # ...> block ahead of the text, which would make the
+        # startswith("/goal ") check always fail for a /goal prompt that
+        # also contains an @mention (the prompt would no longer start with
+        # "/goal " once expanded).
+        goal_prompt_handled = False
         if prompt.strip().lower().startswith("/goal "):
             goal_args = prompt.strip()[len("/goal ") :].strip()
             if goal_args:
@@ -3499,6 +3511,15 @@ async def execute_single(
                         console.print(f"[red]{msg}[/red]")
                     sys.exit(1)
 
+                # Expand @mentions in the condition once, here, at set time
+                # -- snapshot semantics (see docs/GOAL_COMMAND.md). The
+                # condition is re-sent to the evaluator model every turn;
+                # without this it would see the literal "@file" token
+                # forever instead of the file's content.
+                goal_condition = await process_runtime_mentions(
+                    session, goal_condition
+                )
+
                 session.coordinator.session_state["goal"] = {
                     "condition": goal_condition,
                     "turns_used": 0,
@@ -3518,6 +3539,11 @@ async def execute_single(
                 # docs/GOAL_COMMAND.md).
                 console.print(f"Goal set{cap_suffix}.")
                 prompt = goal_condition
+                goal_prompt_handled = True
+
+        if not goal_prompt_handled:
+            # Process runtime @mentions in user input
+            prompt = await process_runtime_mentions(session, prompt)
 
         if verbose:
             console.print(f"[dim]Executing: {prompt}[/dim]")

--- a/docs/GOAL_COMMAND.md
+++ b/docs/GOAL_COMMAND.md
@@ -257,6 +257,19 @@ that only describe the end state.
 It also means the evaluator can be satisfied by a *claim* rather than a fact. `/goal` is not
 a substitute for verifying important work yourself.
 
+### @mentions in a condition (snapshot semantics)
+
+A condition can reference a file with an `@mention` (e.g. `/goal fix every issue listed in
+@TODO.md`). The `@mention` is expanded **once, at the moment you set the goal** -- the file's
+content is substituted in and stored as part of the condition. This is what the evaluator sees
+on *every* turn for the life of the goal, not just the first one.
+
+Because expansion happens at set time, the condition is a **snapshot**: if the file changes
+mid-run, the evaluator keeps judging against the content as it was when the goal was set, not
+the file's current content. This is deliberate -- the condition is a fixed spec for the run, not
+a moving target that drifts as files change underneath it. If the file's content matters and it
+changes, clear the goal and set it again to take a fresh snapshot.
+
 ---
 
 ## Status and progress

--- a/tests/test_goal_command.py
+++ b/tests/test_goal_command.py
@@ -5,6 +5,7 @@ opt-in cap, state shape, and status display (docs/GOAL_COMMAND.md).
 
 import sys
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -15,6 +16,8 @@ from amplifier_app_cli.main import (
     _parse_goal_max_turns,
 )
 from helpers import _make_command_processor
+
+_MODULE = "amplifier_app_cli.main"
 
 # === _parse_goal_max_turns ===
 
@@ -173,3 +176,217 @@ class TestHandleGoalStatus:
         result = await cp._handle_goal("clear")
         assert cp.session.coordinator.session_state["goal"] is None
         assert "Goal cleared: ship the feature" in result
+
+
+# === @mention expansion (docs/GOAL_COMMAND.md -- snapshot semantics) ===
+#
+# Bug 1: @mention expansion in execute_single() used to run BEFORE /goal
+# detection, so a /goal prompt containing an @mention no longer started
+# with "/goal " once expanded (expansion prepends a <context_file ...>
+# block ahead of the text) -- the goal was silently never set.
+#
+# Bug 2: the stored condition was never expanded, so the evaluator saw the
+# literal "@file" token forever instead of the file's content. Fix:
+# expand once, at set time (snapshot semantics) -- both in the interactive
+# _handle_goal() and in execute_single()'s headless /goal handling.
+
+
+async def _fake_expand_mentions(session, text: str) -> str:
+    """Stand-in for process_runtime_mentions().
+
+    Mirrors the real function's shape (see its docstring at
+    amplifier_app_cli.main.process_runtime_mentions): prepends a
+    <context_file> block ahead of the original text for any @mention it
+    recognizes, and returns the text unchanged otherwise.
+    """
+    if "@note.md" in text:
+        return (
+            '<context_file paths="note.md">The number is 42.</context_file>\n\n' + text
+        )
+    return text
+
+
+def _make_headless_session() -> MagicMock:
+    """Minimal mock AmplifierSession for headless execute_single() tests."""
+    session = MagicMock()
+    session.session_id = "test-session"
+    session.execute = AsyncMock(return_value="done")
+    session.coordinator = MagicMock()
+    session.coordinator.session_state = {}
+    session.coordinator.get = MagicMock(return_value=None)
+    session.coordinator.cancellation = MagicMock()
+    session.coordinator.cancellation.is_cancelled = False
+    return session
+
+
+def _make_headless_initialized(session: MagicMock) -> MagicMock:
+    """Minimal mock InitializedSession for headless execute_single() tests."""
+    initialized = MagicMock()
+    initialized.session = session
+    initialized.session_id = "test-session"
+    initialized.cleanup = AsyncMock()
+    return initialized
+
+
+class TestHeadlessGoalMentionExpansion:
+    """Headless /goal + @mention regressions (execute_single())."""
+
+    @pytest.mark.asyncio
+    async def test_goal_with_mention_sets_goal_state(self, tmp_path: Path):
+        """Regression guard for Bug 1: a /goal prompt containing an
+        @mention must still set session_state["goal"]. This fails against
+        the pre-fix code, where @mention expansion ran before /goal
+        detection and broke the startswith("/goal ") check."""
+        from amplifier_app_cli.main import execute_single
+
+        session = _make_headless_session()
+        initialized = _make_headless_initialized(session)
+
+        with (
+            patch(
+                f"{_MODULE}.create_initialized_session",
+                new=AsyncMock(return_value=initialized),
+            ),
+            patch(f"{_MODULE}.SessionStore") as MockStore,
+            patch(f"{_MODULE}.console"),
+            patch(
+                f"{_MODULE}.process_runtime_mentions",
+                new=AsyncMock(side_effect=_fake_expand_mentions),
+            ),
+        ):
+            store_instance = MockStore.return_value
+            store_instance.get_metadata.return_value = {}
+            store_instance.save.return_value = None
+
+            await execute_single(
+                prompt="/goal --max-turns 1 state the number found in @note.md",
+                config={},
+                search_paths=[tmp_path],
+                verbose=False,
+                output_format="text",
+                bundle_name="test-bundle",
+            )
+
+        goal = session.coordinator.session_state.get("goal")
+        assert goal is not None, (
+            "Goal was not set -- /goal detection likely ran AFTER @mention "
+            "expansion (Bug 1 regression)."
+        )
+        assert goal["cap"] == 1
+
+    @pytest.mark.asyncio
+    async def test_goal_condition_is_expanded_not_literal(self, tmp_path: Path):
+        """Bug 2: the stored condition must contain the expanded file
+        content, not just the literal "@note.md" mention token."""
+        from amplifier_app_cli.main import execute_single
+
+        session = _make_headless_session()
+        initialized = _make_headless_initialized(session)
+
+        with (
+            patch(
+                f"{_MODULE}.create_initialized_session",
+                new=AsyncMock(return_value=initialized),
+            ),
+            patch(f"{_MODULE}.SessionStore") as MockStore,
+            patch(f"{_MODULE}.console"),
+            patch(
+                f"{_MODULE}.process_runtime_mentions",
+                new=AsyncMock(side_effect=_fake_expand_mentions),
+            ),
+        ):
+            store_instance = MockStore.return_value
+            store_instance.get_metadata.return_value = {}
+            store_instance.save.return_value = None
+
+            await execute_single(
+                prompt="/goal state the number found in @note.md",
+                config={},
+                search_paths=[tmp_path],
+                verbose=False,
+                output_format="text",
+                bundle_name="test-bundle",
+            )
+
+        goal = session.coordinator.session_state.get("goal")
+        assert goal is not None
+        assert "The number is 42." in goal["condition"]
+
+    @pytest.mark.asyncio
+    async def test_bad_max_turns_with_mention_still_fails_loud(self, tmp_path: Path):
+        """A malformed --max-turns value must still exit loud (and set no
+        goal) even when the condition also contains an @mention --
+        --max-turns parsing happens before expansion and must not be
+        masked by it."""
+        from amplifier_app_cli.main import execute_single
+
+        session = _make_headless_session()
+        initialized = _make_headless_initialized(session)
+
+        with (
+            patch(
+                f"{_MODULE}.create_initialized_session",
+                new=AsyncMock(return_value=initialized),
+            ),
+            patch(f"{_MODULE}.SessionStore") as MockStore,
+            patch(f"{_MODULE}.console"),
+            patch(
+                f"{_MODULE}.process_runtime_mentions",
+                new=AsyncMock(side_effect=_fake_expand_mentions),
+            ),
+        ):
+            store_instance = MockStore.return_value
+            store_instance.get_metadata.return_value = {}
+            store_instance.save.return_value = None
+
+            with pytest.raises(SystemExit) as exc_info:
+                await execute_single(
+                    prompt=(
+                        f"/goal {_GOAL_MAX_TURNS_FLAG} abc state the number "
+                        "found in @note.md"
+                    ),
+                    config={},
+                    search_paths=[tmp_path],
+                    verbose=False,
+                    output_format="text",
+                    bundle_name="test-bundle",
+                )
+
+        assert exc_info.value.code == 1
+        assert session.coordinator.session_state.get("goal") is None
+
+
+class TestInteractiveHandleGoalMentionExpansion:
+    """Interactive CommandProcessor._handle_goal() + @mention (Bug 2)."""
+
+    @pytest.mark.asyncio
+    async def test_handle_goal_with_mention_expands_condition(self):
+        """The condition stored by the interactive /goal handler must be
+        expanded, not the literal @mention token."""
+        cp = _make_command_processor()
+
+        with patch(
+            f"{_MODULE}.process_runtime_mentions",
+            new=AsyncMock(side_effect=_fake_expand_mentions),
+        ):
+            await cp._handle_goal("state the number found in @note.md")
+
+        goal = cp.session.coordinator.session_state["goal"]
+        assert "The number is 42." in goal["condition"]
+
+    @pytest.mark.asyncio
+    async def test_handle_goal_bad_max_turns_with_mention_not_set(self):
+        """A malformed --max-turns value must still fail loud (no goal
+        set) even when the condition contains an @mention."""
+        cp = _make_command_processor()
+
+        with patch(
+            f"{_MODULE}.process_runtime_mentions",
+            new=AsyncMock(side_effect=_fake_expand_mentions),
+        ):
+            result = await cp._handle_goal(
+                f"{_GOAL_MAX_TURNS_FLAG} abc state the number found in @note.md"
+            )
+
+        assert cp.session.coordinator.session_state.get("goal") is None
+        assert "Goal not set" in result


### PR DESCRIPTION
## Summary

Two bugs in the `/goal` slash command.

### Bug 1: Silent breakage in headless mode

In headless mode (`amplifier run --mode single`), @mention expansion ran BEFORE the `/goal ` prefix check. Expansion *prepends* a `<context_file>` block, so the prefix check then failed, the goal was never set, and no error surfaced — `/goal` quietly stopped being a goal command.

**Reproduced on the host before the fix:**
```
$ amplifier run --mode single "/goal --max-turns 1 state the number found in @note.md"
```
No `Goal set` line appeared.

**Fix:** `/goal` is now detected and parsed on the RAW prompt, before mention expansion.

### Bug 2: Goal condition never mention-expanded

The goal condition stored in `session_state` was never mention-expanded. The evaluator LLM re-reads that condition every turn, so it saw the literal `@note.md` forever and could never see the file.

**Fix:** The condition is expanded once, at set time — snapshot semantics, chosen deliberately because the goal is a spec fixed when the user set it and must not drift as files change mid-run. Applied to both the interactive `_handle_goal` path and the headless path.

## Testing

- 5 new tests added to `tests/test_goal_command.py`
- 22 total tests in the file, all passing
- `docs/GOAL_COMMAND.md` now includes a section on @mention snapshot semantics

## Validation Evidence

Both changes were proven end-to-end in an isolated Digital Twin Universe running the exact unpushed commits (verified by commit SHA and sha256 match of the module source inside the container), with a custom routing matrix mapping `fast` to `claude-sonnet-*` so the correct answer is distinguishable from both failure modes:

- `Goal set (max 1 turns).` present in stdout with an @mention in the condition — this fix verified
- `✓ Goal met` and the model reported the number from the un-mentioned-in-prompt file — expansion reached the model
- Two `llm:request` events: main turn `claude-opus-5` (session default), evaluator **`claude-sonnet-5`** — the routing override working
