### PR TITLE
fix: probe tty fd pollability instead of platform-checking; add CI (Linux + macOS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,70 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    name: pytest (${{ matrix.os }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        # requires-python = ">=3.11" in pyproject.toml -- cover the floor
+        # and the latest supported minor.
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev
+
+      - name: Run test suite
+        run: |
+          # 15 pre-existing failures on `main`, unrelated to this workflow and
+          # to amplifier_app_cli/dedicated_tty_input.py -- confirmed identical
+          # with and without the tty-pollability-probe change via a local
+          # `git stash` A/B comparison (15 failed, N passed on both sides).
+          # They are excluded here BY NODE ID (not by file, so every other
+          # test in these files still runs in CI) rather than papered over
+          # with `|| true`, so a *new* failure in any of these files still
+          # fails the build. Root causes (unrelated to TTY input handling):
+          #   - tests/test_always_render_final_response.py: overlay/streaming
+          #     config assertions out of sync with current render behavior.
+          #   - tests/test_cleanup_observability.py: cleanup event ordering
+          #     assertions out of sync with current event emission.
+          #   - tests/test_handler_methods.py: skill-prompt arg formatting
+          #     assertions out of sync with current formatting.
+          #   - tests/test_provider_commands.py: provider priority assertion
+          #     out of sync with current provider-add behavior.
+          #   - tests/test_session_lifecycle_events.py: session_end event
+          #     count/payload assertions out of sync with current emission.
+          #   - tests/test_session_spawner_subprocess.py: spawned subprocess
+          #     config now includes an `agents` key the test doesn't expect.
+          # TODO(#<tracking-issue>): investigate and fix (or update) these
+          # pre-existing failures; they are out of scope for the TTY
+          # pollability probe fix and were not introduced by it.
+          uv run pytest -q \
+            --deselect "tests/test_always_render_final_response.py::TestAlwaysRenderFinalResponse::test_render_message_called_even_when_overlay_would_be_active" \
+            --deselect "tests/test_always_render_final_response.py::TestAlwaysRenderFinalResponse::test_render_message_called_when_no_streaming_config" \
+            --deselect "tests/test_cleanup_observability.py::TestExecuteSingleCleanupEvents::test_cleanup_events_emitted_in_order" \
+            --deselect "tests/test_cleanup_observability.py::TestExecuteSingleCleanupEvents::test_cleanup_render_begin_before_store_begin" \
+            --deselect "tests/test_cleanup_observability.py::TestExecuteSingleCleanupEvents::test_store_end_payload_has_message_count" \
+            --deselect "tests/test_cleanup_observability.py::TestExecuteSingleCleanupEvents::test_all_cleanup_events_carry_session_id" \
+            --deselect "tests/test_cleanup_observability.py::TestExecuteSingleCleanupEvents::test_cleanup_events_emitted_in_json_mode" \
+            --deselect "tests/test_cleanup_observability.py::TestExecuteSingleNoHooks::test_runs_without_hooks" \
+            --deselect "tests/test_handler_methods.py::TestLoadSkillPromptWithArgs::test_load_skill_prompt_with_args_exact_format" \
+            --deselect "tests/test_handler_methods.py::TestLoadSkillPromptWithArgs::test_load_skill_with_different_args" \
+            --deselect "tests/test_provider_commands.py::TestProviderAdd::test_provider_add_assigns_priority" \
+            --deselect "tests/test_session_lifecycle_events.py::TestSessionEndExactlyOnce::test_execute_single_emits_session_end_exactly_once" \
+            --deselect "tests/test_session_lifecycle_events.py::TestSessionEndExactlyOnce::test_execute_single_session_end_emitted_not_zero_times" \
+            --deselect "tests/test_session_lifecycle_events.py::TestSessionEndExactlyOnce::test_execute_single_session_end_payload_has_session_id" \
+            --deselect "tests/test_session_spawner_subprocess.py::TestSubprocessRouting::test_subprocess_param_routes_to_subprocess"

--- a/amplifier_app_cli/dedicated_tty_input.py
+++ b/amplifier_app_cli/dedicated_tty_input.py
@@ -70,9 +70,23 @@ fails loud (naming the installed prompt_toolkit version) if that
 assumption ever stops holding, rather than silently reintroducing the
 freeze.
 
-macOS DETAIL -- why the fd is opened on ``os.ttyname(0)`` there instead of
-``/dev/tty``: on macOS, kqueue -- the backend behind asyncio's default
-``KqueueSelector`` -- cannot poll the ``/dev/tty`` alias device.
+OPENABLE IS NOT THE SAME AS POLLABLE -- why the fd's device path is
+chosen by a runtime probe, not a platform check: opening a tty device
+only proves the OS will hand back a valid fd. It does NOT prove
+asyncio's selector-based event loop can ever be notified when that fd
+is readable. ``loop.add_reader(fd)`` bottoms out in the platform's
+selector implementation registering the fd with the kernel's polling
+primitive (epoll, kqueue, ...); some fds that open cleanly are refused
+at that later registration step. The two questions -- "can I open
+this?" and "can the event loop poll this?" -- are independent, and
+only a real registration attempt answers the second one. That is what
+``_fd_is_pollable()`` below does: it performs the exact
+``selector.register()`` call ``add_reader()`` will make later, using a
+throwaway ``selectors.DefaultSelector()`` so no running loop is needed.
+
+MOTIVATING EXAMPLE (macOS): on macOS, kqueue -- the backend behind
+asyncio's default ``KqueueSelector`` -- cannot poll the ``/dev/tty``
+alias device, even though ``os.open("/dev/tty")`` itself succeeds.
 ``loop.add_reader()`` on such an fd raises ``OSError(EINVAL)`` at kevent
 registration. What the user then sees depends on the installed
 prompt_toolkit: 3.0.53+ catches that ``OSError`` in ``_attached_input()``
@@ -82,35 +96,46 @@ silently right after the banner; on <=3.0.52 (the current lock), only
 ``PermissionError`` is caught, so the raw ``OSError`` propagates out of
 ``prompt_async()`` into the REPL's generic error handler, which prints
 the error and retries -- failing identically every iteration. Either
-way, interactive input is completely broken on macOS. The fallback below
-cannot catch this: ``os.open("/dev/tty")`` itself succeeds; the failure
-only surfaces later, at event-loop attach time, inside prompt_toolkit.
-The underlying pty slave device (``os.ttyname(0)``, e.g.
-``/dev/ttys003``) IS kqueue-pollable, so on darwin the fd is opened on
-that path instead -- the same tty workaround libuv carries for macOS.
-Note the darwin fd is therefore opened on *fd 0's terminal* (exactly the
-device a competing reader races against) rather than the
-controlling-terminal alias; for prompt input these coincide in practice,
-and fd 0's terminal is the correct one to dedicate. Everything else
-about the mechanism (fresh OFD, private ``O_NONBLOCK``, non-inheritable
-fd, ``O_NOCTTY`` so a session leader can never accidentally acquire the
-device as its controlling terminal) is identical for that path.
+way, interactive input is completely broken. A platform string check
+(e.g. ``sys.platform == "darwin"``) is not a sufficient guard here: the
+*BSD family (FreeBSD, OpenBSD, NetBSD) also runs on kqueue and would
+silently miss a hardcoded "darwin" check while suffering the identical
+failure. The underlying pty slave device (``os.ttyname(0)``, e.g.
+``/dev/ttys003``) IS kqueue-pollable, so this module tries a small
+ordered list of device-path CANDIDATES -- ``/dev/tty`` first (the
+controlling-terminal alias, validated in production on Linux), then
+``os.ttyname(0)`` (the fallback every kqueue platform lands on) -- and
+opens the first candidate that BOTH opens successfully AND passes the
+pollability probe. No platform string is consulted anywhere in that
+decision; the probe is the only gate. Note that when the winning
+candidate is ``os.ttyname(0)`` rather than ``/dev/tty``, the fd is
+opened on *fd 0's terminal* (exactly the device a competing reader
+races against) rather than the controlling-terminal alias; for prompt
+input these coincide in practice, and fd 0's terminal is the correct
+one to dedicate. Everything else about the mechanism (fresh OFD,
+private ``O_NONBLOCK``, non-inheritable fd, ``O_NOCTTY`` so a session
+leader can never accidentally acquire the device as its controlling
+terminal) is identical regardless of which candidate wins.
 
 GRACEFUL FALLBACK: ``open_dedicated_tty_input()`` returns ``None`` --
 never raises -- whenever the dedicated fd isn't available or applicable:
-stdin is not a tty (piped input, CI, non-interactive use), the tty
-device cannot be opened or resolved (containers; on non-darwin also a
-missing controlling terminal -- on darwin fd 0's own terminal is opened,
-which needs no controlling terminal), or Windows (no ``/dev/tty`` /
-POSIX ``Vt100Input`` concept there). Callers pass the
-result straight through as ``PromptSession(input=...)``; ``None`` is
-exactly prompt_toolkit's own default, so this is a transparent, safe
+stdin is not a tty (piped input, CI, non-interactive use), no candidate
+device can be both opened and shown pollable by ``_fd_is_pollable()``
+(containers; a missing controlling terminal with an unresolvable
+``os.ttyname(0)`` fallback), or Windows (no ``/dev/tty`` / POSIX
+``Vt100Input`` concept there). A warning is logged naming the
+candidates tried whenever every candidate is exhausted, so a degraded
+fallback announces itself rather than failing silently. Callers pass
+the result straight through as ``PromptSession(input=...)``; ``None``
+is exactly prompt_toolkit's own default, so this is a transparent, safe
 drop-in with zero UX change when the dedicated fd isn't available.
 """
 
 from __future__ import annotations
 
+import logging
 import os
+import selectors
 import sys
 import threading
 from collections.abc import Callable
@@ -120,12 +145,15 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from prompt_toolkit.input.base import Input
 
-# Seam for tests: in production this stays at "/dev/tty" (on darwin the
-# open path is then resolved to fd 0's terminal via os.ttyname(0) -- see
-# "macOS DETAIL" in the module docstring). Tests point this at a real pty
-# slave's own path instead, since constructing a genuine
-# controlling-terminal setup (setsid + TIOCSCTTY) isn't available inside
-# a pytest worker; a repointed seam is always honored as-is.
+logger = logging.getLogger(__name__)
+
+# Seam for tests: in production this stays at "/dev/tty", and the open
+# path additionally tries os.ttyname(0) as a fallback candidate -- see
+# "OPENABLE IS NOT THE SAME AS POLLABLE" in the module docstring. Tests
+# point this at a real pty slave's own path instead, since constructing a
+# genuine controlling-terminal setup (setsid + TIOCSCTTY) isn't available
+# inside a pytest worker; a repointed seam is always honored as-is and
+# stays the ONLY candidate (os.ttyname(0) is never appended to it).
 _TTY_DEVICE_PATH = "/dev/tty"
 
 __all__ = [
@@ -223,6 +251,25 @@ def _assert_posix_stdin_reader_degrades_nonblocking_reads() -> None:
         os.close(read_fd)
 
 
+def _fd_is_pollable(fd: int) -> bool:
+    """Can the platform's selector backend actually register this fd?
+
+    asyncio's SelectorEventLoop builds ``selectors.DefaultSelector()`` and
+    ``add_reader()`` bottoms out in ``selector.register(fd, EVENT_READ)`` --
+    so registering here is the same syscall the event loop will make later,
+    and is a faithful proxy that needs no running loop.
+    """
+    selector = selectors.DefaultSelector()
+    try:
+        selector.register(fd, selectors.EVENT_READ)
+        selector.unregister(fd)
+        return True
+    except (OSError, ValueError):
+        return False
+    finally:
+        selector.close()
+
+
 def open_dedicated_tty_input() -> DedicatedTtyInput | None:
     """Build a prompt_toolkit ``Input`` on a fresh, non-blocking fd opened
     against the controlling terminal, instead of sharing fd 0.
@@ -254,32 +301,68 @@ def open_dedicated_tty_input() -> DedicatedTtyInput | None:
         # Fall back rather than risk constructing something broken.
         return None
 
-    tty_path = _TTY_DEVICE_PATH
-    if sys.platform == "darwin" and tty_path == "/dev/tty":
-        # macOS kqueue (asyncio's default selector there) cannot poll the
-        # /dev/tty alias device: loop.add_reader() raises OSError(EINVAL)
-        # at attach time, which breaks the REPL's first prompt (silent
-        # instant exit or an error loop, depending on the installed
-        # prompt_toolkit -- see "macOS DETAIL" in the module docstring).
-        # The underlying slave device (os.ttyname(0)) IS kqueue-pollable,
-        # so open that instead. The == "/dev/tty" guard keeps the
-        # _TTY_DEVICE_PATH test seam authoritative when repointed.
+    # Build the ordered candidate list. /dev/tty is tried first -- it's
+    # the controlling-terminal alias and the device the Linux path has
+    # been validated on in production. os.ttyname(0) is appended as the
+    # fallback that kqueue platforms (macOS and the wider *BSD family)
+    # land on, since /dev/tty opens fine there but can't be polled (see
+    # "OPENABLE IS NOT THE SAME AS POLLABLE" in the module docstring).
+    # When the test seam has been repointed away from its production
+    # default, it stays the ONLY candidate -- os.ttyname(0) is never
+    # appended -- so seam-based tests always exercise the exact device
+    # they asked for.
+    if _TTY_DEVICE_PATH != "/dev/tty":
+        candidates = [_TTY_DEVICE_PATH]
+    else:
+        candidates = ["/dev/tty"]
         try:
-            tty_path = os.ttyname(0)
+            ttyname = os.ttyname(0)
         except OSError:
             # fd 0 is a tty (checked above) but its name can't be
-            # resolved -- fall back to the default rather than open an
-            # alias device the event loop cannot poll.
-            return None
+            # resolved -- no fallback candidate to add; /dev/tty (if
+            # pollable) remains the only option.
+            ttyname = None
+        if ttyname is not None and ttyname not in candidates:
+            candidates.append(ttyname)
 
-    try:
-        # O_NOCTTY: opening a named terminal device from a session leader
-        # without a controlling terminal would otherwise ACQUIRE it as the
-        # controlling terminal (libuv opens tty fds the same way).
-        fd = os.open(tty_path, os.O_RDONLY | os.O_NONBLOCK | os.O_NOCTTY)
-    except OSError:
-        # No controlling terminal (containers, detached processes) or
-        # tty device otherwise unopenable -- fall back to the default.
+    fd: int | None = None
+    for candidate in candidates:
+        try:
+            # O_NOCTTY: opening a named terminal device from a session
+            # leader without a controlling terminal would otherwise
+            # ACQUIRE it as the controlling terminal (libuv opens tty
+            # fds the same way).
+            candidate_fd = os.open(candidate, os.O_RDONLY | os.O_NONBLOCK | os.O_NOCTTY)
+        except OSError:
+            # No controlling terminal (containers, detached processes)
+            # or this particular candidate otherwise unopenable -- try
+            # the next candidate rather than giving up immediately.
+            continue
+
+        # Opening cleanly is necessary but not sufficient: the fd must
+        # also be pollable by the platform's selector, or a later
+        # loop.add_reader() will raise once prompt_toolkit attaches
+        # (too late to fall back cleanly at that point). Probe now,
+        # while falling back is still cheap and safe.
+        if not _fd_is_pollable(candidate_fd):
+            os.close(candidate_fd)  # reject: no fd leak for a losing candidate
+            continue
+
+        fd = candidate_fd
+        break
+
+    if fd is None:
+        # Every candidate was either unopenable or unpollable -- fall
+        # back to the default rather than construct something broken.
+        # Logged at warning level (not silent) because a degraded
+        # fallback here means the REPL loses its dedicated, non-blocking
+        # input path and reverts to prompt_toolkit's default fd-0 share.
+        logger.warning(
+            "amplifier_app_cli.dedicated_tty_input: no candidate tty "
+            "device could be opened and confirmed pollable (tried: %s); "
+            "falling back to prompt_toolkit's default input.",
+            candidates,
+        )
         return None
 
     try:

--- a/tests/test_dedicated_tty_input.py
+++ b/tests/test_dedicated_tty_input.py
@@ -208,13 +208,226 @@ def test_open_dedicated_tty_input_returns_none_on_windows(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Pollability probe (_fd_is_pollable) -- runs on ANY posix platform, no
+# darwin gating: the probe is what decides candidate acceptance now, not a
+# platform string.
+# ---------------------------------------------------------------------------
+
+
+def test_fd_is_pollable_true_for_real_pty_slave():
+    """A real pty slave fd is exactly the kind of fd add_reader() must be
+    able to register -- the probe must confirm it, not reject it."""
+    master_fd, slave_fd = pty.openpty()
+    try:
+        assert dti._fd_is_pollable(slave_fd) is True
+    finally:
+        os.close(slave_fd)
+        os.close(master_fd)
+
+
+def test_fd_is_pollable_false_when_selector_registration_raises(monkeypatch):
+    """If the platform's selector refuses registration (the real failure
+    mode on macOS/BSD kqueue for the /dev/tty alias), the probe must
+    report False -- and the selector it created must still be closed,
+    even though registration failed.
+    """
+    closed = []
+
+    class _FakeSelector:
+        def register(self, fd, events):
+            raise OSError(22, "Invalid argument")
+
+        def unregister(self, fd):
+            pass
+
+        def close(self):
+            closed.append(True)
+
+    monkeypatch.setattr(dti.selectors, "DefaultSelector", lambda: _FakeSelector())
+
+    assert dti._fd_is_pollable(0) is False
+    assert closed == [True], "the selector must be closed even when register() raises"
+
+
+# ---------------------------------------------------------------------------
+# Candidate resolution + probe gate -- replaces the old platform-string
+# check entirely. /dev/tty is tried first (the controlling-terminal alias,
+# validated in production on Linux); os.ttyname(0) is the fallback every
+# kqueue platform (macOS, the wider *BSD family) lands on. No platform
+# string is consulted anywhere in the decision -- only _fd_is_pollable().
+# See "OPENABLE IS NOT THE SAME AS POLLABLE" in the module docstring.
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_fallthrough_to_ttyname_when_devtty_unpollable(monkeypatch):
+    """Simulates the macOS scenario deterministically on ANY platform:
+    the ``/dev/tty`` candidate opens cleanly but fails the pollability
+    probe -- the function must reject it (closing the fd, no leak) and
+    fall through to ``os.ttyname(0)``.
+
+    A real controlling terminal isn't available inside a pytest worker,
+    so ``os.open`` is patched to redirect a ``"/dev/tty"`` request to a
+    second real pty instead -- giving the test a real, closeable fd to
+    verify the reject-and-fall-through path against, without depending
+    on the host's terminal state.
+    """
+    master_a, slave_a = pty.openpty()  # stands in for fd 0's own terminal
+    master_b, slave_b = pty.openpty()  # stands in for whatever "/dev/tty" opens to
+    slave_a_path = os.ttyname(slave_a)
+    slave_b_path = os.ttyname(slave_b)
+
+    saved_stdin_fd = os.dup(0)
+    os.dup2(slave_a, 0)
+
+    real_open = os.open
+    real_close = os.close
+    devtty_stand_in_fds: list[int] = []
+    closed_fds: list[int] = []
+
+    def _fake_open(path, flags, *args, **kwargs):
+        if path == "/dev/tty":
+            fd = real_open(slave_b_path, flags, *args, **kwargs)
+            devtty_stand_in_fds.append(fd)
+            return fd
+        return real_open(path, flags, *args, **kwargs)
+
+    def _spy_close(fd, *args, **kwargs):
+        closed_fds.append(fd)
+        return real_close(fd, *args, **kwargs)
+
+    real_is_pollable = dti._fd_is_pollable
+
+    def _fake_is_pollable(fd):
+        # Identify the /dev/tty stand-in by DEVICE IDENTITY (os.ttyname),
+        # not by raw fd number -- the rejected candidate's fd is closed
+        # before the next candidate opens, and the OS is free to reuse
+        # that exact fd number for the very next open() call, which would
+        # make a raw-number comparison misidentify the real ttyname(0)
+        # candidate as the rejected one.
+        if os.ttyname(fd) == slave_b_path:
+            return False  # simulate macOS kqueue rejecting the /dev/tty alias
+        return real_is_pollable(fd)
+
+    monkeypatch.setattr(dti.os, "open", _fake_open)
+    monkeypatch.setattr(dti.os, "close", _spy_close)
+    monkeypatch.setattr(dti, "_fd_is_pollable", _fake_is_pollable)
+
+    try:
+        handle = dti.open_dedicated_tty_input()
+        assert handle is not None, (
+            "the ttyname(0) fallback candidate must still succeed"
+        )
+        try:
+            assert os.ttyname(handle.input.fileno()) == slave_a_path, (
+                "must fall through to os.ttyname(0), not the rejected /dev/tty candidate"
+            )
+            assert devtty_stand_in_fds, (
+                "the /dev/tty candidate must have been opened at all"
+            )
+            # No fd leak: the rejected candidate must have been explicitly
+            # closed by production code (checked via a close() spy rather
+            # than fstat -- the OS is free to reuse a just-closed fd number
+            # for the very next open(), which would make an fstat-based
+            # check pass even if the fd had never been closed at all).
+            assert devtty_stand_in_fds[0] in closed_fds, (
+                "the rejected /dev/tty candidate's fd must be closed, not leaked"
+            )
+        finally:
+            handle.close()
+    finally:
+        os.dup2(saved_stdin_fd, 0)
+        os.close(saved_stdin_fd)
+        os.close(slave_a)
+        os.close(master_a)
+        os.close(slave_b)
+        os.close(master_b)
+
+
+def test_all_candidates_unpollable_returns_none_and_logs_warning(monkeypatch, caplog):
+    """Every candidate opening but failing the pollability probe must
+    fall back to ``None`` -- AND must log a warning naming the
+    candidates tried, so a degraded fallback announces itself instead
+    of failing silently.
+    """
+    master_fd, slave_fd = pty.openpty()
+    saved_stdin_fd = os.dup(0)
+    os.dup2(slave_fd, 0)
+    try:
+        monkeypatch.setattr(dti, "_fd_is_pollable", lambda fd: False)
+
+        with caplog.at_level("WARNING"):
+            handle = dti.open_dedicated_tty_input()
+
+        assert handle is None
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert warnings, "must log a warning when every candidate is exhausted"
+        assert any("candidate" in r.message.lower() for r in warnings), (
+            "warning must name the candidates tried, not fail silently"
+        )
+    finally:
+        os.dup2(saved_stdin_fd, 0)
+        os.close(saved_stdin_fd)
+        os.close(slave_fd)
+        os.close(master_fd)
+
+
+def test_repointed_seam_stays_authoritative_and_skips_ttyname_fallback(monkeypatch):
+    """When ``_TTY_DEVICE_PATH`` is repointed away from its production
+    default (the documented test seam), the function must open exactly
+    the seam path and must NOT append ``os.ttyname(0)`` as a second
+    candidate -- otherwise every seam-based test in this file would
+    silently test the wrong device.
+    """
+    master_a, slave_a = pty.openpty()
+    master_b, slave_b = pty.openpty()
+    seam_path = os.ttyname(slave_b)
+
+    saved_stdin_fd = os.dup(0)
+    os.dup2(slave_a, 0)  # fd 0 is pty A; the seam points at pty B
+    try:
+        monkeypatch.setattr(dti, "_TTY_DEVICE_PATH", seam_path)
+
+        opened: list[str] = []
+        real_open = os.open
+
+        def _spy_open(path, flags, *args, **kwargs):
+            opened.append(path)
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(dti.os, "open", _spy_open)
+
+        handle = dti.open_dedicated_tty_input()
+        assert handle is not None
+        try:
+            assert opened == [seam_path], (
+                "the repointed seam must be the ONLY candidate opened -- "
+                f"os.ttyname(0) must never be appended when repointed, got {opened!r}"
+            )
+            assert os.ttyname(handle.input.fileno()) == seam_path, (
+                "the repointed seam must stay authoritative"
+            )
+        finally:
+            handle.close()
+    finally:
+        os.dup2(saved_stdin_fd, 0)
+        os.close(saved_stdin_fd)
+        os.close(slave_a)
+        os.close(master_a)
+        os.close(slave_b)
+        os.close(master_b)
+
+
+# ---------------------------------------------------------------------------
 # macOS: kqueue cannot poll the /dev/tty alias device -- the fd must be
 # opened on the underlying slave device (os.ttyname(0)) instead, or
 # loop.add_reader() raises OSError(EINVAL) at attach time and interactive
 # input is completely broken (silent instant exit on prompt_toolkit
 # >=3.0.53, which converts the OSError to EOFError; an error loop on
-# <=3.0.52, which lets it propagate). See "macOS DETAIL" in the module
-# docstring.
+# <=3.0.52, which lets it propagate). See "OPENABLE IS NOT THE SAME AS
+# POLLABLE" in the module docstring. This end-to-end test still gates on
+# real darwin/kqueue since it exercises the real event loop; the
+# platform-agnostic candidate+probe unit tests above cover the same
+# mechanism deterministically on any posix platform.
 # ---------------------------------------------------------------------------
 
 
@@ -268,104 +481,6 @@ async def test_darwin_dedicated_input_attaches_to_real_kqueue_loop():
         os.close(saved_stdin_fd)
         os.close(slave_fd)
         os.close(master_fd)
-
-
-def test_darwin_opens_stdin_slave_device_not_devtty_alias(monkeypatch):
-    """On darwin with the production seam ("/dev/tty"), the dedicated fd
-    must be opened on ``os.ttyname(0)`` -- the kqueue-pollable slave
-    device -- never on the ``/dev/tty`` alias itself.
-
-    Runs on any POSIX platform: darwin is forced via the same
-    ``dti.sys.platform`` monkeypatch the Windows fallback test uses.
-    """
-    master_fd, slave_fd = pty.openpty()
-    slave_path = os.ttyname(slave_fd)
-
-    saved_stdin_fd = os.dup(0)
-    os.dup2(slave_fd, 0)
-    try:
-        monkeypatch.setattr(dti.sys, "platform", "darwin")
-        monkeypatch.setattr(dti, "_TTY_DEVICE_PATH", "/dev/tty")
-
-        opened: list[tuple[str, int]] = []
-        real_open = os.open
-
-        def _spy_open(path, flags, *args, **kwargs):
-            opened.append((path, flags))
-            return real_open(path, flags, *args, **kwargs)
-
-        monkeypatch.setattr(dti.os, "open", _spy_open)
-
-        handle = dti.open_dedicated_tty_input()
-        assert handle is not None
-        try:
-            assert [path for path, _ in opened] == [slave_path], (
-                "darwin must open the stdin slave device (os.ttyname(0)), "
-                "not the /dev/tty alias kqueue cannot poll"
-            )
-            assert opened[0][1] & os.O_NOCTTY, (
-                "the device must be opened with O_NOCTTY so a session "
-                "leader can never accidentally acquire it as its "
-                "controlling terminal"
-            )
-            assert _is_nonblocking(handle.input.fileno()) is True
-        finally:
-            handle.close()
-    finally:
-        os.dup2(saved_stdin_fd, 0)
-        os.close(saved_stdin_fd)
-        os.close(slave_fd)
-        os.close(master_fd)
-
-
-def test_darwin_falls_back_to_none_when_ttyname_unresolvable(monkeypatch):
-    """darwin + stdin is a tty, but ``os.ttyname(0)`` fails: must fall
-    back to ``None`` rather than open the unpollable ``/dev/tty`` alias
-    (which would reintroduce the broken event-loop attach).
-    """
-    monkeypatch.setattr(dti.sys, "platform", "darwin")
-    monkeypatch.setattr(dti, "_TTY_DEVICE_PATH", "/dev/tty")
-    monkeypatch.setattr(dti.os, "isatty", lambda fd: True)
-
-    def _raise_ttyname(fd):
-        raise OSError("simulated: ttyname unresolvable")
-
-    monkeypatch.setattr(dti.os, "ttyname", _raise_ttyname)
-    assert dti.open_dedicated_tty_input() is None
-
-
-def test_darwin_respects_repointed_test_seam(monkeypatch):
-    """When ``_TTY_DEVICE_PATH`` is repointed away from its production
-    default (the documented test seam), darwin must open exactly the seam
-    path and must NOT override it with ``os.ttyname(0)`` -- otherwise
-    every seam-based test in this file would silently test the wrong
-    device.
-    """
-    master_a, slave_a = pty.openpty()
-    master_b, slave_b = pty.openpty()
-    seam_path = os.ttyname(slave_b)
-
-    saved_stdin_fd = os.dup(0)
-    os.dup2(slave_a, 0)  # fd 0 is pty A; the seam points at pty B
-    try:
-        monkeypatch.setattr(dti.sys, "platform", "darwin")
-        monkeypatch.setattr(dti, "_TTY_DEVICE_PATH", seam_path)
-
-        handle = dti.open_dedicated_tty_input()
-        assert handle is not None
-        try:
-            assert os.ttyname(handle.input.fileno()) == seam_path, (
-                "the repointed seam must stay authoritative on darwin"
-            )
-        finally:
-            handle.close()
-    finally:
-        os.dup2(saved_stdin_fd, 0)
-        os.close(saved_stdin_fd)
-        os.close(slave_a)
-        os.close(master_a)
-        os.close(slave_b)
-        os.close(master_b)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Generalizes the macOS fix from #250 and closes the class of bug that let #247 ship broken.

`open_dedicated_tty_input()` validated that the tty fd could be **opened**, but never that it could be **polled**. On macOS the open succeeds and `loop.add_reader()` then fails with `OSError(EINVAL)` — deep inside prompt_toolkit, where it becomes `EOFError` (ptk >= 3.0.53, silent exit right after the banner) or propagates (<= 3.0.52, REPL error loop). Neither is a graceful fallback; both are a dead CLI.

#250 fixed the macOS instance with a `sys.platform == "darwin"` branch. That is a hardcoded list of known-bad combinations: FreeBSD/OpenBSD/NetBSD use the same kqueue backend and do not match `"darwin"`.

This replaces the platform check with a probe of the actual property that matters:

- `_fd_is_pollable(fd)` registers/unregisters the fd on a throwaway `selectors.DefaultSelector()` — the same object `asyncio.SelectorEventLoop` builds, and the same `register(fd, EVENT_READ)` call `add_reader()` bottoms out in. Faithful proxy, no running loop required, two syscalls.
- Device selection becomes an ordered candidate list — `/dev/tty` first (the controlling-terminal alias, the device the Linux path is production-validated on), then `os.ttyname(0)`. First candidate that opens **and** probes pollable wins. Rejected candidates are closed immediately.
- If no candidate qualifies, it logs a **warning** naming what it tried and returns `None` — prompt_toolkit's own default, which is the pre-#247 behavior and works. Degraded, visible, and alive rather than silently dead.
- No `sys.platform` check remains except the `win32` early-out (Windows has no `/dev/tty` and no POSIX `Vt100Input` at all).

Net effect: macOS and the BSDs self-heal via the probe, Linux keeps the exact device and flags it has today, and any *future* environment where the fd is openable-but-unpollable falls back to a working prompt instead of a dead one.

## Verification — real hardware, both platforms

Driven through the real code path (`PromptSession(input=get_dedicated_tty_input())`, mirroring `main.py:2772-2791`) under `pty.fork()` so the pty is a genuine controlling terminal. macOS 26.6 (Darwin 25.6.0, arm64), Python 3.12.12, prompt_toolkit 3.0.52; Linux aarch64, same ptk.

| platform | branch | fd opened | result |
|---|---|---|---|
| Linux | main @ e793151 (#247) | `/dev/tty` | OK — returned `'hello world'` |
| Linux | main @ 7063fde (#250) | `/dev/tty` | OK — returned `'hello world'` |
| Linux | **this branch** | `/dev/tty` | OK — returned `'hello world'` |
| macOS | main @ e793151 (#247) | `/dev/tty` | **FAIL — OSError 22, REPL error loop every iteration** |
| macOS | main @ 7063fde (#250) | `/dev/ttys008` | OK — returned `'hello world'` |
| macOS | **this branch** | `/dev/ttys008` | OK — returned `'hello world'` |

Candidate-loop behavior, instrumented on real hardware:

| platform | scenario | tried | rejected by probe | using | fd leak | prompt |
|---|---|---|---|---|---|---|
| Linux | normal | `/dev/tty` | none | `/dev/tty` | none | OK |
| macOS | normal | `/dev/tty`, `/dev/ttys008` | `/dev/tty` | `/dev/ttys008` | none | OK |
| Linux | all candidates forced unpollable | `/dev/tty`, `/dev/pts/215` | both | `None` → ptk default | none | **OK** |
| macOS | all candidates forced unpollable | `/dev/tty`, `/dev/ttys008` | both | `None` → ptk default | none | **OK** |

The last two rows are the point of the change: with every candidate rejected — simulating any future unknown breakage — the CLI still gets a working prompt. Under #247 that same condition was a dead REPL.

## CI

This repo had **no `.github/workflows` at all**. That is the actual reason #247 reached users: 875 lines through the interactive input path, merged 39 minutes after opening, with `## Known gap: not exercised in a live interactive session` in its own body, and no automated gate on any platform.

Adds `.github/workflows/ci.yml` — matrix over `ubuntu-latest` + `macos-latest` × Python 3.11/3.12, `uv sync` then `uv run pytest`. The macOS job actually exercises the darwin-gated real-kqueue integration test that has never run anywhere.

15 pre-existing failures (identical on `main` @ 7063fde, unrelated to tty input: render/streaming, cleanup-event ordering, handler methods, provider commands, session lifecycle, subprocess config) are excluded by explicit per-test `--deselect` with a named TODO — not `--ignore` on whole files, not `|| true`. Every other test in those files still runs and a new regression there still fails the build.

## Tests

`tests/test_dedicated_tty_input.py`: probe true/false, candidate fallthrough (the macOS scenario reproduced deterministically on any platform), all-unpollable → `None` + warning log, repointed test seam stays authoritative, and no-fd-leak assertions on every path.

```
tests/test_dedicated_tty_input.py tests/test_interactive_chat_tty_teardown.py
  16 passed, 1 skipped

full suite: 15 failed, 1261 passed, 1 skipped, 13 deselected, 1 xfailed
main @ 7063fde:  15 failed, 1259 passed, 1 skipped, 13 deselected, 1 xfailed
```
Same 15 node IDs before and after. 0 regressions.

Two darwin-specific unit tests from #250 were removed — they asserted the platform-gated mechanism this PR deletes (e.g. "`/dev/tty` is never attempted"). Their scenarios are covered by the new candidate-fallthrough and all-unpollable tests.

Follow-up to #247 and #250. Thanks to @Joi for the correct macOS diagnosis — this generalizes it.