### PR TITLE
fix(spawn): honor an agent's declared agents: access-control policy

### DIFF
--- a/amplifier_app_cli/session_spawner.py
+++ b/amplifier_app_cli/session_spawner.py
@@ -319,6 +319,45 @@ async def spawn_sub_session(
             live_agents = (parent_coord.config or {}).get("agents") or {}
         except AttributeError:
             live_agents = {}
+
+        # Reconcile this propagation with the overlay's OWN access-control
+        # declaration (agent_config["agents"] -- a Smart Single Value:
+        # "none" | list-of-names | "all"/absent). merge_configs() already
+        # applied this same declaration once, but only against the STATIC
+        # parent snapshot it can see -- a mode-contributed live agent named
+        # in an explicit allowlist isn't in that snapshot, so merge_configs
+        # resolves it to an empty dict there (this was PR #178/#233's own
+        # documented under-delivery: "even an explicit agents: [sibling_b]
+        # declaration wouldn't reach sibling_b -- the source dict is the
+        # wrong one"). Left unhandled, the block below would then blindly
+        # union in the FULL live registry regardless of that declaration,
+        # silently re-opening delegation for an agent that said "none" or
+        # handing it agents outside its stated allowlist -- defeating the
+        # sub-agent access-control contract merge_configs() exists to
+        # enforce (commit d609bb2; documented in AGENT_AUTHORING.md).
+        #
+        # So: apply the declaration a second time here, against the live
+        # registry, before it gets merged in. This reconciles both intents
+        # in one place -- #233's "mode siblings must be reachable" and the
+        # original "agents: declares exactly who I can delegate to."
+        #
+        # Gate on the OVERLAY (agent_config), NOT on merged_config["agents"].
+        # An unrestricted agent (no `agents:` key) whose parent simply has
+        # no STATIC agents also produces an empty merged_config["agents"] --
+        # gating on emptiness there would wrongly suppress propagation for
+        # that agent too. The overlay's own declared value is the only
+        # signal that distinguishes "restricted to nothing/some" from
+        # "unrestricted, parent just has nothing (yet) in the snapshot."
+        agent_filter = agent_config.get("agents")
+        if agent_filter == "none":
+            live_agents = {}
+        elif isinstance(agent_filter, list):
+            live_agents = {
+                name: cfg for name, cfg in live_agents.items() if name in agent_filter
+            }
+        # else: "all", None, or absent -- inherit the live registry unchanged
+        # (current/original #233 behavior).
+
         if live_agents:
             # Build a FRESH dict and rebind it; never mutate the dict
             # merged_config already holds. merge_configs() deep-copies the

--- a/tests/test_session_spawner_issue_233.py
+++ b/tests/test_session_spawner_issue_233.py
@@ -23,6 +23,16 @@ SCENARIOS:
        caller passing extra context.
   S5 — skill capability propagation: parent's coordinator has
        runtime_skill_overlay capability; child coordinator inherits it.
+  S6 — parent isolation: propagation writes into the child's config only,
+       never mutates the parent's.
+  S7 — access-control declaration honored (fix/honor-agents-declaration):
+       the spawned agent's OWN `agents:` Smart Single Value declaration
+       ("none" | list-of-names | "all"/absent) must be respected when the
+       live registry is unioned in, not silently overridden by the #233
+       propagation. Covers all five rows of the target-behavior table:
+       "none" -> {}, ["sibling_b"] -> {sibling_b} (fixes PR #178's
+       under-delivery), ["explorer"] -> {explorer}, "all" -> full union,
+       absent -> full union (both unchanged from #233 behavior).
 """
 
 from __future__ import annotations
@@ -478,4 +488,171 @@ class TestS6ParentIsolation:
         )
         assert captured["agents"] is not parent.coordinator.config["agents"], (
             "child's agents dict is the parent's LIVE registry object"
+        )
+
+
+# ---------------------------------------------------------------------------
+# S7 — Access-control declaration honored (fix/honor-agents-declaration)
+# ---------------------------------------------------------------------------
+
+
+class TestS7AccessControlDeclaration:
+    """The spawned agent's OWN `agents:` declaration gates propagation.
+
+    Fixture shared across all five rows (matches the issue's target-behavior
+    table exactly):
+
+        Parent STATIC agents  (session.config):     {explorer, builder}
+        Parent LIVE registry  (coordinator.config):  {explorer, builder, sibling_b}
+                                                      (sibling_b is mode-contributed
+                                                       only -- absent from the static
+                                                       snapshot)
+
+    The agent "explorer" is spawned with a varying `agents:` overlay value.
+    Each assertion checks the EXACT resulting child agent name set, not mere
+    membership -- both over-delivery (declared "none"/allowlist but child
+    gets more) and under-delivery (declared allowlist but child gets less,
+    PR #178's original bug) are real failure modes here.
+    """
+
+    def _make_fixture_parent(self) -> MagicMock:
+        return _make_parent_session(
+            session_config_agents={
+                "explorer": {"description": "Explorer agent"},
+                "builder": {"description": "Builder agent"},
+            },
+            coordinator_config_agents={
+                "explorer": {"description": "Explorer agent"},
+                "builder": {"description": "Builder agent"},
+                "sibling_b": {"description": "Mode-contributed sibling B"},
+            },
+        )
+
+    @pytest.mark.asyncio
+    async def test_agents_none_disables_all_delegation(self) -> None:
+        """`agents: "none"` must yield an EMPTY child agents dict.
+
+        Before the fix: the #233 propagation block unconditionally unioned
+        in the full live registry, reopening delegation the overlay
+        explicitly disabled.
+        """
+        parent = self._make_fixture_parent()
+        child = _make_child_session_mock()
+        captured: dict = {}
+
+        await _run_spawn(
+            parent,
+            {"explorer": {"description": "Explorer agent", "agents": "none"}},
+            child,
+            "explorer",
+            captured,
+        )
+
+        assert captured.get("agents", {}) == {}, (
+            "agents: 'none' must disable ALL sub-agent delegation. "
+            f"Got: {sorted(captured.get('agents', {}).keys())}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_agents_list_of_live_only_name_is_honored_from_live_registry(
+        self,
+    ) -> None:
+        """`agents: ["sibling_b"]` must yield EXACTLY {sibling_b}.
+
+        sibling_b is mode-contributed-only (absent from the static parent
+        snapshot). merge_configs() filters the STATIC dict and resolves this
+        to {} (PR #178's documented under-delivery). The spawner must apply
+        the same allowlist against the LIVE registry so sibling_b still
+        reaches the child -- and nothing else does.
+        """
+        parent = self._make_fixture_parent()
+        child = _make_child_session_mock()
+        captured: dict = {}
+
+        await _run_spawn(
+            parent,
+            {"explorer": {"description": "Explorer agent", "agents": ["sibling_b"]}},
+            child,
+            "explorer",
+            captured,
+        )
+
+        assert captured.get("agents", {}).keys() == {"sibling_b"}, (
+            "agents: ['sibling_b'] must yield EXACTLY {sibling_b} -- honored "
+            "from the live registry even though sibling_b is absent from "
+            f"the static snapshot. Got: {sorted(captured.get('agents', {}).keys())}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_agents_list_of_static_name_is_honored_as_allowlist(self) -> None:
+        """`agents: ["explorer"]` must yield EXACTLY {explorer}.
+
+        Before the fix: the #233 propagation block would blow the allowlist
+        open by unioning in the full live registry (builder, sibling_b too).
+        """
+        parent = self._make_fixture_parent()
+        child = _make_child_session_mock()
+        captured: dict = {}
+
+        await _run_spawn(
+            parent,
+            {"explorer": {"description": "Explorer agent", "agents": ["explorer"]}},
+            child,
+            "explorer",
+            captured,
+        )
+
+        assert captured.get("agents", {}).keys() == {"explorer"}, (
+            "agents: ['explorer'] must yield EXACTLY {explorer} -- the "
+            "allowlist must not be blown open by live-registry propagation. "
+            f"Got: {sorted(captured.get('agents', {}).keys())}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_agents_all_yields_full_union(self) -> None:
+        """`agents: "all"` must yield the FULL union: {explorer, builder, sibling_b}.
+
+        Unchanged from #233 behavior -- explicit "all" inherits everything,
+        static and live-registry alike.
+        """
+        parent = self._make_fixture_parent()
+        child = _make_child_session_mock()
+        captured: dict = {}
+
+        await _run_spawn(
+            parent,
+            {"explorer": {"description": "Explorer agent", "agents": "all"}},
+            child,
+            "explorer",
+            captured,
+        )
+
+        assert captured.get("agents", {}).keys() == {"explorer", "builder", "sibling_b"}, (
+            "agents: 'all' must yield the full union of static + live agents. "
+            f"Got: {sorted(captured.get('agents', {}).keys())}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_agents_absent_yields_full_union(self) -> None:
+        """No `agents:` key at all must yield the FULL union (unrestricted).
+
+        Unchanged from #233 behavior -- absence of the declaration means
+        "unrestricted," identical to explicit "all".
+        """
+        parent = self._make_fixture_parent()
+        child = _make_child_session_mock()
+        captured: dict = {}
+
+        await _run_spawn(
+            parent,
+            {"explorer": {"description": "Explorer agent"}},  # no "agents" key
+            child,
+            "explorer",
+            captured,
+        )
+
+        assert captured.get("agents", {}).keys() == {"explorer", "builder", "sibling_b"}, (
+            "Absent agents: declaration must be unrestricted (full union), "
+            "identical to explicit 'all'. "
+            f"Got: {sorted(captured.get('agents', {}).keys())}"
         )


### PR DESCRIPTION
## What

An agent can declare `agents:` — a Smart Single Value (`"all"" | `"none"" | list) that controls which sub-agents its spawned session may delegate to. `merge_configs()` honors it. The runtime-registry propagation block added later then silently undid it.

Measured on `main` (parent static = `{explorer, builder}`; live registry additionally holds mode-contributed `sibling_b`):

| overlay declares | after `merge_configs` | after propagation | |
|---|---|---|---|
| `"none"` | `[]` | `[builder, explorer, sibling_b]` | **delegation re-enabled** |
| `["sibling_b"]` | `[]` | `[builder, explorer, sibling_b]` | **under- *and* over-delivers** |
| `["explorer"]` | `[explorer]` | `[builder, explorer, sibling_b]` | **allowlist blown open** |
| `"all"` | `[builder, explorer]` | `[builder, explorer, sibling_b]` | correct |
| absent | `[builder, explorer]` | `[builder, explorer, sibling_b]` | correct |

An agent that declared `agents: none` received every agent in the live registry.

## Why this is a bug and not a design decision

Traced through primary sources before changing anything:

- **`d609bb2`** (2025-11-30) introduced the field. Its commit message states the intent: *"`"none"` → empty agents dict (disable delegation); list → filter parent's agents to specified names… **This enables agents to control which sub-agents their spawned sessions can delegate to via the task tool.**"*
- **Docs promise it.** `microsoft/amplifier-profiles` `docs/AGENT_AUTHORING.md` documents `agents: none  # Cannot call task tool to delegate`, followed by a three-step "How it works" describing exactly the filtering this block defeats. `amplifier-app-cli/docs/AGENT_DELEGATION_IMPLEMENTATION.md:409-416` documents `agents: none # Disable agents`.
- **`774d8b9`** (PR #178, for `microsoft-amplifier/amplifier-support#233`) added the propagation so mode-contributed agents reach children. Its rule was *"Local agent_config declarations win over inherited live registry (never overwrite)"* — implemented only as same-name collision avoidance, never as policy enforcement. Nothing in that PR, the issue, or the maintainer's closing comment addresses the filter interaction.
- **No test encodes the current behavior as correct.** S1–S6 in `test_session_spawner_issue_233.py` never pass an overlay carrying an `agents:` key, and the two `merge_configs` filter tests in `test_agent_config.py` stop before the spawner runs. The two suites passed independently while contradicting each other at runtime.
- **#253's body already recorded this as a known unfixed bug** with the suggested gating shape.

So this restores stated intent rather than changing designed behavior.

## It also fixes PR #178's own complaint

PR #178's body noted: *"even an explicit `agents: [sibling_b]` declaration in agent A's config wouldn't reach sibling_b — the source dict is the wrong one."* That under-delivery was never fixed — `merge_configs` filters the **static** snapshot, which does not contain mode-contributed agents, so an allowlist naming one resolved to `{}`.

Applying the declaration to the live registry as well reconciles both intents in one place: the allowlist is satisfied from the union of static + live agents. Row 2 of the table goes from "everything" to exactly `[sibling_b]` — the agent gets precisely what it asked for, no more and no less.

## After

| overlay declares | child receives |
|---|---|
| `"none"` | `[]` |
| `["sibling_b"]` | `[sibling_b]` |
| `["explorer"]` | `[explorer]` |
| `"all"` | `[builder, explorer, sibling_b]` (unchanged) |
| absent | `[builder, explorer, sibling_b]` (unchanged) |

The gate keys off `agent_config` — the **overlay's own declaration** — not off `merged_config["agents"]` being empty. An unrestricted agent whose parent simply has no static agents also produces an empty merged dict; gating on emptiness would wrongly suppress propagation for it. `TestS6ParentIsolation::test_propagation_does_not_mutate_parent_config` is exactly that case and still passes unchanged.

Preserved from #253: fresh-dict-and-rebind (no cross-session mutation of the parent's live config), `deepcopy` per propagated agent, same-name local-wins.

## Blast radius: zero on the installed ecosystem

Surveyed every parsed bundle/agent/behavior/mode/profile config under `~/.amplifier/cache/` — 749 config files, 51 `agents:` key occurrences. **All 51 are the dict-shaped *defining* section** (`agents: include: [...]` rosters and inline agent definitions). **Zero** are the access-control Smart Single Value form. No installed agent declares a restriction, so nothing currently in the ecosystem changes behavior.

Checked the consumers that depend on propagation: 4 modes contribute agents at runtime, and `context-intelligence` is the one shipped configuration with a real sibling hop (facilitator → tool-designer). None of them declares `agents:`, so the gate leaves them untouched. Every `session.spawn` caller — `tool-delegate`, `tool-recipes`, `tool-skills` (which spawns `agent_name="self"`, i.e. an empty overlay by construction), attractor's loop modules — passes no `agents:` declaration.

Zero current users is also the argument for doing this now rather than later: nobody depends on the broken behavior yet, so this is the cheapest this fix will ever be.

## Tests

`TestS7AccessControlDeclaration` — 5 spawn-level tests, one per row, asserting the exact resulting agent-name set. This is the first spawn-level coverage of the access-control declaration; no prior assertion needed reversing.

```
uv run pytest -q              1287 passed, 1 skipped, 13 deselected, 1 xfailed   (was 1282; +5 new)
uv run pytest -m integration  13 passed
```

**Non-vacuousness** — with `session_spawner.py` reverted to `main` and the new tests kept:
```
3 failed, 2 passed
  test_agents_none_disables_all_delegation                      Got: ['builder', 'explorer', 'sibling_b'], expected {}
  test_agents_list_of_live_only_name_is_honored_from_live_...   Got: ['builder', 'explorer', 'sibling_b'], expected {'sibling_b'}
  test_agents_list_of_static_name_is_honored_as_allowlist       Got: ['builder', 'explorer', 'sibling_b'], expected {'explorer'}
```
The two `"all"`/absent tests correctly still pass — that behavior is unchanged by design.

## Follow-up, not in this PR

`amplifier-foundation`'s `docs/AGENT_AUTHORING.md` and `docs/BUNDLE_GUIDE.md` document `agents:` only in the bundle-roster sense and are silent on the access-control form; a repo-wide grep of the installed foundation docs for `agents: none` returns zero hits. The feature is documented only in `amplifier-app-cli` and `amplifier-profiles`. Worth a cross-repo docs pass now that the behavior matches the promise.

Follow-up to #178 and #253.