### PR TITLE
feat(goalify): write condition to file and reorder output

### DIFF
--- a/amplifier_app_cli/data/skills/goalify/SKILL.md
+++ b/amplifier_app_cli/data/skills/goalify/SKILL.md
@@ -8,7 +8,7 @@ description: >
   goal condition", "make this a /goal", "turn this into a goal", or asks for
   help wording a condition for /goal.
 user-invocable: true
-version: 1.1.0
+version: 1.2.0
 license: MIT
 ---
 
@@ -163,9 +163,23 @@ Do not present a condition that still fails a BLOCKER.
 
 ## Output format
 
-Always output the condition inside a fenced code block — terminal reflow
-will otherwise destroy its multi-line structure. Follow it with the lint
-report as a table, then offer (do not auto-run) `/goal`.
+Produce output in this exact order:
+
+1. **Write the file.** Write the condition text to
+   `.amplifier/goals/<slug>.md` (create the directory if it does not exist),
+   where `<slug>` is a kebab-case slug (≤ 40 chars) of the one-sentence
+   outcome. Overwrite if the file already exists. State the path on its own
+   line, e.g. `Wrote: .amplifier/goals/usable-checkout-flow.md`.
+2. **Render inline.** Immediately after, show the same condition inside a
+   fenced code block — terminal reflow will otherwise destroy its
+   multi-line structure.
+3. **Lint table.** Follow with the lint report as a table.
+4. **Next step, last.** End the entire response with the recommended next
+   step and nothing after it: offer (do not auto-run) `/goal @<path>` using
+   the path from step 1, framed as what to run once any edits to the file
+   are made and saved.
+
+Wrote: `.amplifier/goals/<slug>.md`
 
 ```
 <the condition text>
@@ -184,5 +198,7 @@ report as a table, then offer (do not auto-run) `/goal`.
 A clean table means no *known* failure pattern was detected — not that the
 condition is validated. Say so if the user reads it as a guarantee.
 
-Then: "Pass this to `/goal` to start the loop — want me to run it now, or
+Edit `.amplifier/goals/<slug>.md` directly for any changes. Then, as the
+last line of the response: "Once you're happy with the file, run `/goal
+@.amplifier/goals/<slug>.md` to start the loop — want me to run it now, or
 would you like to adjust anything first?"


### PR DESCRIPTION
Three changes to the `goalify` skill's output, all in `SKILL.md` (no code):

1. The composed goal condition is now **written to a file** in addition to being rendered inline, so the user can open and edit it rather than hand-copying fenced text. Because `@`-mentions in a goal condition are expanded at set time, the file can then be handed straight to `/goal @<path>` and its full content becomes the condition — which makes an edit-then-run loop natural.

2. The inline rendering is kept, so the condition is still reviewable in the flow of conversation without opening anything.

3. The **next-step command moved to the very end**, after the lint table. Whatever sits closest to the user's input is what they act on; previously that was the lint table, now it is the copy-pasteable `/goal @<path>`, framed as the step to take after saving any edits.

**Verification.** Tested by real runs, not inspection: the file is written where the skill says, its content matches the inline rendering, the `/goal @<path>` line is literally last in the output, and both shipped known-bad fixtures still get blocked (the L1 fixture fires L1; the L2 fixture fires L2 and L0) — the lint is untouched. Test suite 1297 passed, identical to baseline.