### PR TITLE
test: repair pre-existing test failures + stale docstring fix (extracted from #259)

### DIFF
--- a/amplifier_app_cli/lib/bundle_loader/resolvers.py
+++ b/amplifier_app_cli/lib/bundle_loader/resolvers.py
@@ -192,7 +192,7 @@ class SettingsProviderProtocol(Protocol):
 class FoundationSettingsResolver:
     """Settings-based resolver using foundation's source handling.
 
-    Uses the same 6-layer resolution strategy as StandardModuleSourceResolver,
+    Uses the same resolution strategy as StandardModuleSourceResolver,
     but returns Source objects that use foundation's GitSourceHandler for
     git operations. This ensures the NEW cache format is used:
     {repo-name}-{hash}/ instead of legacy {hash}/{ref}/ format.
@@ -201,8 +201,8 @@ class FoundationSettingsResolver:
     1. Environment variable (AMPLIFIER_MODULE_<ID>)
     2. Workspace convention (workspace_dir/<id>/)
     3. Settings provider (merges project + user settings)
-    4. Legacy module pattern (removed)
-    6. Installed package
+    4. Source hint (from bundle config)
+    5. Installed package (fallback)
     """
 
     def __init__(

--- a/tests/test_provider_commands.py
+++ b/tests/test_provider_commands.py
@@ -152,7 +152,14 @@ class TestProviderAdd:
             ]
             MockPM.return_value = mock_pm
 
-            result = runner.invoke(provider, ["add", "openai"])
+            # `provider add` now detects that the env var this instance would
+            # use is already claimed by another instance and prompts for a
+            # distinct one. Left unanswered it reads EOF and cancels, so the
+            # provider is never written and the priority assertion below has
+            # nothing to inspect. Supply the per-instance var name.
+            result = runner.invoke(
+                provider, ["add", "openai"], input="OPENAI_PROVIDER_OPENAI_API_KEY\n"
+            )
 
         assert result.exit_code == 0, f"Output: {result.output}"
         providers = settings.get_provider_overrides()

--- a/tests/test_session_spawner_subprocess.py
+++ b/tests/test_session_spawner_subprocess.py
@@ -101,7 +101,13 @@ class TestSubprocessRouting:
         # Verify subprocess runner was called
         fake_module.run_session_in_subprocess.assert_called_once()
         call_kwargs = fake_module.run_session_in_subprocess.call_args
-        assert call_kwargs.kwargs["config"] == {"session": {}}
+        # The child config carries whatever the parent composed, which now
+        # includes an "agents" key. Assert on the contract this test exists
+        # to guard -- that the session config is forwarded -- rather than
+        # on an exact dict that drifts every time composition gains a key.
+        forwarded = call_kwargs.kwargs["config"]
+        assert forwarded["session"] == {}
+        assert "spawn_mode" not in forwarded
         assert call_kwargs.kwargs["prompt"] == "Do something"
         assert call_kwargs.kwargs["parent_id"] == "parent-session-id"
         assert call_kwargs.kwargs["session_id"] == "fixed-test-id"

--- a/tests/test_session_spawner_subprocess.py
+++ b/tests/test_session_spawner_subprocess.py
@@ -101,13 +101,14 @@ class TestSubprocessRouting:
         # Verify subprocess runner was called
         fake_module.run_session_in_subprocess.assert_called_once()
         call_kwargs = fake_module.run_session_in_subprocess.call_args
-        # The child config carries whatever the parent composed, which now
-        # includes an "agents" key. Assert on the contract this test exists
-        # to guard -- that the session config is forwarded -- rather than
-        # on an exact dict that drifts every time composition gains a key.
-        forwarded = call_kwargs.kwargs["config"]
-        assert forwarded["session"] == {}
-        assert "spawn_mode" not in forwarded
+        # Exact-equality is intentional here: this parent's coordinator.config
+        # carries no "agents" key (see _make_parent_session), so the issue
+        # #233 live-registry propagation in spawn_sub_session has nothing to
+        # add and the forwarded config is exactly the merge_configs() stub's
+        # return value, unchanged. See
+        # test_live_registry_agents_propagate_to_subprocess_config below for
+        # the case where an "agents" key legitimately appears.
+        assert call_kwargs.kwargs["config"] == {"session": {}}
         assert call_kwargs.kwargs["prompt"] == "Do something"
         assert call_kwargs.kwargs["parent_id"] == "parent-session-id"
         assert call_kwargs.kwargs["session_id"] == "fixed-test-id"


### PR DESCRIPTION
## What this is

Janitorial extraction from #259 (`fix/gap-003-020-023-027-021`). Two pre-existing commits, cherry-picked clean onto `main`, plus one follow-up fix:

- `6885b2c` — test: repair all 15 pre-existing test failures (`tests/test_provider_commands.py`, `tests/test_session_spawner_subprocess.py`)
- `30ff56b` — fix: correct stale resolution-order docstring in `FoundationSettingsResolver` (`amplifier_app_cli/lib/bundle_loader/resolvers.py`, docstring only, no behaviour change)
- a new commit on top restoring an assertion that `6885b2c` had weakened (see below)

**No product/behaviour changes.** This PR can be reviewed and merged completely independently of #259, #263, #264, and #265.

## The 15 repairs (per `6885b2c`'s own message)

- 11: stale mock target (renamed `process_runtime_mentions`)
- 2: stale prompt assertions (fork-skill `load_skill` form changed)
- 1: unanswered `provider-add` credential-collision prompt
- 1: stale session-config dict assertion (`agents` key)

## The weakened-assertion question (flagged by reviewer)

`6885b2c` changed `test_subprocess_param_routes_to_subprocess` from an exact
`assert call_kwargs.kwargs["config"] == {"session": {}}` to two looser checks,
with a comment blaming a now-present `"agents"` key. The reviewer suspected
this was a mocking artifact (`coordinator.config` as an unstubbed `MagicMock`
being truthy) rather than real behaviour, and that stubbing it properly would
have kept the strong assertion.

Investigated and confirmed: the fixture (`_make_parent_session`) already
stubs `coordinator.config` as a real dict, and with the default (empty)
fixture value there is no `"agents"` key to produce, so
`spawn_sub_session`'s issue-#233 live-registry propagation has nothing to
merge in. Restored the exact-equality assertion in a follow-up commit and
verified the full `test_session_spawner_subprocess.py` file — including the
sibling test that legitimately exercises a populated live registry — still
passes. The strong assertion is correct and ships in this PR.

## Verification

- `git diff origin/main...HEAD --stat` — touches only the 3 expected files.
- `uv run pytest -q` — full suite green (1301 passed, 1 skipped, 13 deselected, 1 xfailed).
- `uv run ruff check` clean on all touched lines (one pre-existing, unrelated
  `F821` in `test_provider_commands.py` at a line this PR does not touch —
  present on `origin/main` too).

Note: in this environment, running the plain `origin/main` baseline already
shows the full suite green (no repro of the original 15 failures) — most
likely because the failures were specific to the *full* original branch
context (stacked GAP-003/SIGINT behaviour changes, or an author-machine
environment difference) rather than anything reproducible against a clean
`main`. The test-file changes here are still correct, minimal, and net
either neutral or strictly better (see assertion-strength fix above) on a
clean `main`, so they're included as instructed.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
