### PR TITLE
fix: Enter key works in `amplifier reset` on Windows

### DIFF
--- a/amplifier_app_cli/commands/reset_interactive.py
+++ b/amplifier_app_cli/commands/reset_interactive.py
@@ -82,7 +82,12 @@ def _get_key() -> str:
     else:
         # Windows
         ch = msvcrt.getch()
-        if ch == b"\\xe0":  # Arrow key prefix
+        # msvcrt.getch() returns raw bytes: arrow keys arrive as a two-byte
+        # sequence prefixed by 0x00 or 0xe0. These MUST be single-escaped byte
+        # literals (b"\xe0", b"\r", b"\x03") -- a double-escaped b"\\r" is the
+        # two CHARACTERS backslash+r and never matches a real keypress, so Enter
+        # would fall through and the menu would just re-render ("flash").
+        if ch in (b"\x00", b"\xe0"):  # Arrow key / function key prefix
             ch2 = msvcrt.getch()
             if ch2 == b"H":
                 return "UP"
@@ -92,12 +97,13 @@ def _get_key() -> str:
                 return "RIGHT"
             elif ch2 == b"K":
                 return "LEFT"
+            return "ESC"
 
-        if ch in (b"\\r", b"\\n"):
+        if ch in (b"\r", b"\n"):
             return "ENTER"
         if ch == b" ":
             return " "
-        if ch == b"\\x03":
+        if ch == b"\x03":
             raise KeyboardInterrupt
 
         return ch.decode("utf-8", errors="ignore")


### PR DESCRIPTION
## The bug

In `amplifier reset`, the interactive checklist ignored **Enter** on Windows — pressing it just re-rendered the menu ("flash") and the reset never confirmed. Only `[q]` worked. Reported from a real Windows install.

## Root cause

`amplifier_app_cli/commands/reset_interactive.py`, the Windows branch of `_get_key()`, compared `msvcrt.getch()` bytes against **double-escaped** byte literals:

```python
if ch == b"\\xe0":          # 4 chars: backslash x e 0  — never a real keypress
if ch in (b"\\r", b"\\n"):  # 2 chars: backslash r      — never matches Enter
if ch == b"\\x03":          # backslash x 0 3
```

`msvcrt.getch()` returns the real byte `b"\r"` (0x0D) for Enter, which never equals the two-character sequence `b"\\r"`. So Enter fell through to the `ch.decode()` catch-all, returned `"\r"`, matched no branch in the checklist loop, and the menu simply re-rendered. `[q]` worked only because `"q"` is a plain byte needing no escape.

The POSIX branch was already correct (single-escaped `"\r"`, `"\x1b"`), so **POSIX users were never affected** — this is Windows-only.

## The fix

Single-escape the four literals. Also accept both `0x00` and `0xe0` as the arrow/function-key prefix (Windows uses either) and return `"ESC"` on an unrecognized prefix, mirroring the POSIX branch. **Entirely within the `sys.platform == "win32"` branch — the POSIX path is byte-identical.**

## Evidence — native Windows 11, Python 3.14.3

Deterministic teeth test feeding `_get_key()` the real bytes `msvcrt.getch()` returns, baseline (main) vs fixed:

```
[BASELINE] platform=win32
    Enter(b'\r')  -> '\r'      ← not "ENTER": the reported bug
    Up(0xe0 H)    -> ''        ← arrows silently broken too
    VERDICT: Enter confirms + arrows navigate = False

[FIXED] platform=win32
    Enter(b'\r')  -> 'ENTER'
    Space(b' ')   -> ' '
    q             -> 'q'
    Up(0xe0 H)    -> 'UP'
    Up(0x00 H)    -> 'UP'
    VERDICT: Enter confirms + arrows navigate = True
```

The baseline reproduces the exact symptom (`q` works, Enter doesn't) and also reveals arrow-key navigation was broken by the same double-escape — invisible because the menu redrew identically.

## Limits

One Windows machine, one Python version (3.14.3). No Windows CI leg on this repo yet.