### PR TITLE
fix: apply the Windows deferred-swap fix to `amplifier update` too

### DIFF
--- a/amplifier_app_cli/commands/reset.py
+++ b/amplifier_app_cli/commands/reset.py
@@ -21,7 +21,6 @@ Example:
 from __future__ import annotations
 
 import os
-import shutil
 import subprocess
 from pathlib import Path
 
@@ -29,9 +28,10 @@ import click
 
 from ..console import console
 from ..utils.error_format import escape_markup
+from ..utils.fs_utils import rmtree_robust
+from ..utils.uv_utils import UvStep, defer_uv_tool_swap
 from ..utils.uv_utils import remove_stale_uv_lock as _remove_stale_uv_lock
 from .reset_interactive import ChecklistItem, run_checklist
-
 
 # Category definitions: category name -> list of files/dirs in ~/.amplifier
 # Note: "other" is a special dynamic category - see _get_other_files()
@@ -279,10 +279,9 @@ def _remove_amplifier_dir(preserve: set[str], dry_run: bool = False) -> bool:
     clear_download_cache = None
     clear_registry = None
     try:
-        from ..utils.cache_management import clear_download_cache
-        from ..utils.cache_management import clear_registry
+        from ..utils.cache_management import clear_download_cache, clear_registry
     except ImportError:
-        pass  # Will use inline shutil.rmtree fallback
+        pass  # Will use inline rmtree_robust fallback
 
     amplifier_dir = _get_amplifier_dir()
     console.print(f"[bold]>>>[/bold] Removing {amplifier_dir}...")
@@ -303,7 +302,7 @@ def _remove_amplifier_dir(preserve: set[str], dry_run: bool = False) -> bool:
             return True
 
         try:
-            shutil.rmtree(amplifier_dir)
+            rmtree_robust(amplifier_dir)
             console.print("    [green]Removed entire directory[/green]")
             return True
         except OSError as e:
@@ -340,7 +339,7 @@ def _remove_amplifier_dir(preserve: set[str], dry_run: bool = False) -> bool:
                     else:
                         # Standard removal (fallback or other items)
                         if item.is_dir():
-                            shutil.rmtree(item)
+                            rmtree_robust(item)
                         else:
                             item.unlink()
                         removed_count += 1
@@ -409,129 +408,57 @@ def _install_amplifier(dry_run: bool = False) -> bool:
 
 
 def _windows_defer_tool_swap(no_install: bool) -> None:
-    """Defer ``uv tool uninstall``/``install`` to a script that runs AFTER we exit.
+    """Hand the uv tool uninstall/reinstall to a script that runs after we exit.
 
-    On Windows the OS locks a running program's own files: while ``amplifier.exe``
-    (this process) is alive, its loaded ``python3xx.dll`` / ``.pyd`` under
-    ``%APPDATA%\\uv\\tools\\amplifier\\Lib\\`` cannot be deleted, so an in-process
-    ``uv tool uninstall``/``install`` fails with "Access is denied (os error 5)".
-    POSIX lets you unlink open files, which is why the normal path works there.
-
-    The fix: generate a throw-away ``.cmd`` that waits for THIS process id to
-    exit (releasing the lock), then performs the uninstall (and reinstall unless
-    ``--no-install``), and launch it in a new console window. The script path and
-    the equivalent manual commands are always printed, so nothing fails silently
-    even if the auto-launch is refused.
+    See ``defer_uv_tool_swap`` for why Windows needs this at all. Reset's shape
+    is an uninstall, followed (unless ``--no-install``) by a fresh install.
     """
-    import tempfile
-
-    pid = os.getpid()
-    header = [
-        "@echo off",
-        "setlocal enabledelayedexpansion",
-        "echo(",
-        "echo Amplifier reset: finishing the uninstall/reinstall now that the app",
-        "echo has exited (Windows locks a running program's own files).",
-        "echo(",
-        f"echo Waiting for Amplifier (PID {pid}) to exit...",
-        ":waitloop",
-        f'tasklist /FI "PID eq {pid}" 2>NUL | find "{pid}" >NUL',
-        "if not errorlevel 1 (",
-        "    ping -n 2 127.0.0.1 >NUL",
-        "    goto waitloop",
-        ")",
-    ]
-    # A just-exited process releases its handles lazily, and another open
-    # Amplifier/terminal window, an antivirus scan, or the file indexer can all
-    # keep the tool env locked briefly (or longer). Retry with backoff, then fail
-    # loud with a re-runnable path rather than silently leaving a half-swapped
-    # install. The retried command is `uv tool install` (the actual goal); the
-    # uninstall is best-effort cleanup ahead of it.
     if no_install:
-        goal = [
-            "echo Uninstalling amplifier...",
-            "for /L %%i in (1,1,10) do (",
-            "    uv tool uninstall amplifier",
-            "    if !errorlevel! EQU 0 goto done",
-            "    echo   files still locked, attempt %%i of 10; retrying in 3s...",
-            "    ping -n 4 127.0.0.1 >NUL",
-            ")",
-            "goto locked",
+        steps = [
+            UvStep(
+                command="uv tool uninstall amplifier",
+                label="Uninstalling amplifier...",
+            )
         ]
-        done_msg = "echo Amplifier removed. You can close this window."
+        recovery = ["uv tool uninstall amplifier"]
+        success = "Amplifier removed."
     else:
-        goal = [
-            "echo Uninstalling amplifier (best effort)...",
-            "for /L %%i in (1,1,5) do (",
-            "    uv tool uninstall amplifier >NUL 2>&1",
-            "    if !errorlevel! EQU 0 goto reinstall",
-            "    ping -n 3 127.0.0.1 >NUL",
-            ")",
-            ":reinstall",
-            "echo Reinstalling amplifier...",
-            "for /L %%i in (1,1,10) do (",
-            f"    uv tool install {DEFAULT_INSTALL_SOURCE}",
-            "    if !errorlevel! EQU 0 goto done",
-            "    echo   files still locked, attempt %%i of 10; retrying in 3s...",
-            "    ping -n 4 127.0.0.1 >NUL",
-            ")",
-            "goto locked",
+        steps = [
+            # Best effort: `uv tool install` overwrites an existing install, so
+            # a failed uninstall must not abort the reinstall that is the goal.
+            # Aborting here is what would leave the user with no amplifier.
+            UvStep(
+                command="uv tool uninstall amplifier",
+                label="Uninstalling amplifier (best effort)...",
+                attempts=5,
+                required=False,
+            ),
+            UvStep(
+                command=f"uv tool install {DEFAULT_INSTALL_SOURCE}",
+                label="Reinstalling amplifier...",
+            ),
         ]
-        done_msg = "echo Amplifier reset complete. You can close this window."
-    footer = [
-        ":locked",
-        "echo(",
-        "echo Could not finish: Amplifier's files are still locked by another",
-        "echo program such as another Amplifier or terminal window, an antivirus",
-        "echo scan, or a file indexer. Close other Amplifier windows and run this",
-        "echo script again:",
-        'echo     "%~f0"',
-        "echo If it keeps failing, reboot and run it once more.",
-        "pause",
-        "exit /b 1",
-        ":done",
-        "echo(",
-        done_msg,
-        "pause",
-    ]
-    lines = header + goal + footer
-    # Batch files are read by cmd.exe as ANSI/OEM; keep to ASCII + CRLF.
-    script = "\r\n".join(lines) + "\r\n"
+        recovery = [
+            "uv tool uninstall amplifier",
+            f"uv tool install {DEFAULT_INSTALL_SOURCE}",
+        ]
+        success = "Amplifier reset complete."
 
-    fd, script_path = tempfile.mkstemp(prefix="amplifier-reset-", suffix=".cmd")
-    with os.fdopen(fd, "w", encoding="ascii", newline="") as f:
-        f.write(script)
-
-    console.print(
-        "\n[bold]>>>[/bold] Windows can't replace Amplifier while it's running."
+    launched = defer_uv_tool_swap(
+        steps,
+        operation="reset",
+        intro_lines=[
+            "Amplifier reset: finishing the uninstall/reinstall now that the app",
+            "has exited. Windows locks a running program's own files.",
+        ],
+        success_message=success,
+        recovery_commands=recovery,
     )
-    console.print(
-        "    The uninstall/reinstall will finish in a new window after this exits."
-    )
-    console.print(f"    Script: [cyan]{script_path}[/cyan]")
 
-    launched = False
-    try:
-        subprocess.Popen(
-            ["cmd", "/c", script_path],
-            creationflags=getattr(subprocess, "CREATE_NEW_CONSOLE", 0),
-            close_fds=True,
-        )
-        launched = True
-    except OSError as e:
-        console.print(
-            f"[yellow]Warning:[/yellow] Could not auto-launch the finisher: {escape_markup(str(e))}"
-        )
-
-    if launched:
-        console.print("    [green]Launched.[/green] Watch the new window for progress.")
-    else:
-        console.print(
-            "    Run that script yourself to finish, or run these after Amplifier exits:"
-        )
-        console.print("      uv tool uninstall amplifier")
-        if not no_install:
-            console.print(f"      uv tool install {DEFAULT_INSTALL_SOURCE}")
+    if not launched:
+        console.print("    Run these yourself once Amplifier has exited:")
+        for command in recovery:
+            console.print(f"      {command}")
 
     console.print(
         "\n[green]>>>[/green] Reset staged - it will finish after this exits."

--- a/amplifier_app_cli/commands/reset.py
+++ b/amplifier_app_cli/commands/reset.py
@@ -20,6 +20,7 @@ Example:
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
 from pathlib import Path
@@ -407,6 +408,136 @@ def _install_amplifier(dry_run: bool = False) -> bool:
         return False
 
 
+def _windows_defer_tool_swap(no_install: bool) -> None:
+    """Defer ``uv tool uninstall``/``install`` to a script that runs AFTER we exit.
+
+    On Windows the OS locks a running program's own files: while ``amplifier.exe``
+    (this process) is alive, its loaded ``python3xx.dll`` / ``.pyd`` under
+    ``%APPDATA%\\uv\\tools\\amplifier\\Lib\\`` cannot be deleted, so an in-process
+    ``uv tool uninstall``/``install`` fails with "Access is denied (os error 5)".
+    POSIX lets you unlink open files, which is why the normal path works there.
+
+    The fix: generate a throw-away ``.cmd`` that waits for THIS process id to
+    exit (releasing the lock), then performs the uninstall (and reinstall unless
+    ``--no-install``), and launch it in a new console window. The script path and
+    the equivalent manual commands are always printed, so nothing fails silently
+    even if the auto-launch is refused.
+    """
+    import tempfile
+
+    pid = os.getpid()
+    header = [
+        "@echo off",
+        "setlocal enabledelayedexpansion",
+        "echo(",
+        "echo Amplifier reset: finishing the uninstall/reinstall now that the app",
+        "echo has exited (Windows locks a running program's own files).",
+        "echo(",
+        f"echo Waiting for Amplifier (PID {pid}) to exit...",
+        ":waitloop",
+        f'tasklist /FI "PID eq {pid}" 2>NUL | find "{pid}" >NUL',
+        "if not errorlevel 1 (",
+        "    ping -n 2 127.0.0.1 >NUL",
+        "    goto waitloop",
+        ")",
+    ]
+    # A just-exited process releases its handles lazily, and another open
+    # Amplifier/terminal window, an antivirus scan, or the file indexer can all
+    # keep the tool env locked briefly (or longer). Retry with backoff, then fail
+    # loud with a re-runnable path rather than silently leaving a half-swapped
+    # install. The retried command is `uv tool install` (the actual goal); the
+    # uninstall is best-effort cleanup ahead of it.
+    if no_install:
+        goal = [
+            "echo Uninstalling amplifier...",
+            "for /L %%i in (1,1,10) do (",
+            "    uv tool uninstall amplifier",
+            "    if !errorlevel! EQU 0 goto done",
+            "    echo   files still locked, attempt %%i of 10; retrying in 3s...",
+            "    ping -n 4 127.0.0.1 >NUL",
+            ")",
+            "goto locked",
+        ]
+        done_msg = "echo Amplifier removed. You can close this window."
+    else:
+        goal = [
+            "echo Uninstalling amplifier (best effort)...",
+            "for /L %%i in (1,1,5) do (",
+            "    uv tool uninstall amplifier >NUL 2>&1",
+            "    if !errorlevel! EQU 0 goto reinstall",
+            "    ping -n 3 127.0.0.1 >NUL",
+            ")",
+            ":reinstall",
+            "echo Reinstalling amplifier...",
+            "for /L %%i in (1,1,10) do (",
+            f"    uv tool install {DEFAULT_INSTALL_SOURCE}",
+            "    if !errorlevel! EQU 0 goto done",
+            "    echo   files still locked, attempt %%i of 10; retrying in 3s...",
+            "    ping -n 4 127.0.0.1 >NUL",
+            ")",
+            "goto locked",
+        ]
+        done_msg = "echo Amplifier reset complete. You can close this window."
+    footer = [
+        ":locked",
+        "echo(",
+        "echo Could not finish: Amplifier's files are still locked by another",
+        "echo program such as another Amplifier or terminal window, an antivirus",
+        "echo scan, or a file indexer. Close other Amplifier windows and run this",
+        "echo script again:",
+        'echo     "%~f0"',
+        "echo If it keeps failing, reboot and run it once more.",
+        "pause",
+        "exit /b 1",
+        ":done",
+        "echo(",
+        done_msg,
+        "pause",
+    ]
+    lines = header + goal + footer
+    # Batch files are read by cmd.exe as ANSI/OEM; keep to ASCII + CRLF.
+    script = "\r\n".join(lines) + "\r\n"
+
+    fd, script_path = tempfile.mkstemp(prefix="amplifier-reset-", suffix=".cmd")
+    with os.fdopen(fd, "w", encoding="ascii", newline="") as f:
+        f.write(script)
+
+    console.print(
+        "\n[bold]>>>[/bold] Windows can't replace Amplifier while it's running."
+    )
+    console.print(
+        "    The uninstall/reinstall will finish in a new window after this exits."
+    )
+    console.print(f"    Script: [cyan]{script_path}[/cyan]")
+
+    launched = False
+    try:
+        subprocess.Popen(
+            ["cmd", "/c", script_path],
+            creationflags=getattr(subprocess, "CREATE_NEW_CONSOLE", 0),
+            close_fds=True,
+        )
+        launched = True
+    except OSError as e:
+        console.print(
+            f"[yellow]Warning:[/yellow] Could not auto-launch the finisher: {escape_markup(str(e))}"
+        )
+
+    if launched:
+        console.print("    [green]Launched.[/green] Watch the new window for progress.")
+    else:
+        console.print(
+            "    Run that script yourself to finish, or run these after Amplifier exits:"
+        )
+        console.print("      uv tool uninstall amplifier")
+        if not no_install:
+            console.print(f"      uv tool install {DEFAULT_INSTALL_SOURCE}")
+
+    console.print(
+        "\n[green]>>>[/green] Reset staged - it will finish after this exits."
+    )
+
+
 @click.command()
 @click.option(
     "--preserve",
@@ -518,8 +649,21 @@ def reset(
             console.print("[yellow]Cancelled.[/yellow]")
             return
 
-    # Execute reset steps
+    # Execute reset steps. Cache clean and ~/.amplifier cleanup are safe to run
+    # in-process on every OS (neither touches the running uv tool environment).
     _clean_uv_cache(dry_run)
+
+    # Windows self-modification guard: on Windows the live amplifier.exe and its
+    # loaded .dll/.pyd under the uv tool env are OS-locked, so an in-process
+    # `uv tool uninstall`/`install` fails with "Access is denied (os error 5)".
+    # Do the safe cleanup now, then defer the tool-env swap to a script that
+    # runs after this process exits. POSIX unlinks open files, so the path below
+    # is unchanged there.
+    if os.name == "nt" and not dry_run:
+        _remove_amplifier_dir(preserve, dry_run)
+        _windows_defer_tool_swap(no_install)
+        return
+
     _uninstall_amplifier(dry_run)
     _remove_amplifier_dir(preserve, dry_run)
 

--- a/amplifier_app_cli/utils/cache_management.py
+++ b/amplifier_app_cli/utils/cache_management.py
@@ -13,8 +13,9 @@ User data (projects, settings, keys) is NEVER touched by these utilities.
 from __future__ import annotations
 
 import logging
-import shutil
 from pathlib import Path
+
+from .fs_utils import rmtree_robust
 
 logger = logging.getLogger(__name__)
 
@@ -58,8 +59,10 @@ def clear_download_cache(dry_run: bool = False) -> tuple[int, bool]:
             logger.debug(f"[dry-run] Would clear {count} items from cache")
             return (count, True)
 
-        # Remove entire cache directory
-        shutil.rmtree(cache_dir)
+        # Remove entire cache directory. Bundles are cached as git clones,
+        # and git marks pack files read-only -- which Windows refuses to
+        # delete, so this needs the read-only-tolerant variant.
+        rmtree_robust(cache_dir)
         logger.debug(f"Cleared {count} items from cache")
 
         # Recreate empty cache directory

--- a/amplifier_app_cli/utils/fs_utils.py
+++ b/amplifier_app_cli/utils/fs_utils.py
@@ -1,0 +1,43 @@
+"""Filesystem helpers that paper over cross-platform deletion differences."""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import shutil
+import stat
+from pathlib import Path
+
+
+def rmtree_robust(path: Path | str) -> None:
+    """``shutil.rmtree`` that survives read-only files on Windows.
+
+    Git marks files under ``.git/objects/pack`` (``*.pack``, ``*.idx``)
+    read-only. POSIX only needs write permission on the *parent* directory to
+    unlink a child, so read-only files delete fine there. Windows honours the
+    read-only attribute on the file itself and refuses, so removing a
+    git-backed cache (``~/.amplifier/cache/<bundle>/.git/...``) raises
+    ``PermissionError: [WinError 5] Access is denied``.
+
+    On the first ``PermissionError`` we clear the read-only bit across the tree
+    and retry once. On POSIX a ``PermissionError`` means something else entirely
+    (no write access to the parent), so it is re-raised untouched rather than
+    rewriting the user's file modes.
+    """
+    try:
+        shutil.rmtree(path)
+        return
+    except PermissionError:
+        if os.name != "nt":
+            raise
+
+    # Windows only: S_IWRITE toggles the read-only attribute (it is not a
+    # POSIX-style mode), so this is a targeted "make deletable" pass.
+    for root, dirs, files in os.walk(path):
+        for name in dirs + files:
+            with contextlib.suppress(OSError):
+                os.chmod(os.path.join(root, name), stat.S_IWRITE)
+    with contextlib.suppress(OSError):
+        os.chmod(path, stat.S_IWRITE)
+
+    shutil.rmtree(path)

--- a/amplifier_app_cli/utils/update_executor.py
+++ b/amplifier_app_cli/utils/update_executor.py
@@ -5,6 +5,7 @@ Selective updates: Only update modules that actually have updates, then re-downl
 """
 
 import logging
+import os
 import re
 import subprocess
 import threading
@@ -16,6 +17,8 @@ from pathlib import Path
 from .source_status import CachedGitStatus
 from .source_status import UpdateReport
 from .umbrella_discovery import UmbrellaInfo
+from .uv_utils import UvStep
+from .uv_utils import defer_uv_tool_swap
 from .uv_utils import remove_stale_uv_lock
 
 logger = logging.getLogger(__name__)
@@ -532,6 +535,70 @@ def _invalidate_modules_with_missing_deps() -> tuple[int, int]:
     return (modules_checked, len(modules_to_invalidate))
 
 
+def _defer_self_update(url: str) -> ExecutionResult:
+    """Hand the self-update to a script that runs after this process exits.
+
+    Windows-only. ``uv tool install --reinstall`` rewrites the very tool
+    environment this process is executing from, and Windows will not let a
+    running program's loaded DLLs be replaced -- see ``defer_uv_tool_swap``.
+
+    The deferred install runs unattended, so the post-install dependency check
+    (``_invalidate_modules_with_missing_deps``) cannot run afterwards. Clear
+    install-state.json outright instead: ``--reinstall`` rebuilds the Python
+    environment and may drop module dependencies, and stale state claiming
+    "installed" while the packages are gone produces import errors on the next
+    run. This mirrors what reset does when it clears the cache.
+    """
+    from amplifier_app_cli.paths import get_install_state_path
+
+    install_state_file = get_install_state_path()
+    try:
+        if install_state_file.exists():
+            install_state_file.unlink()
+    except OSError as e:
+        # Non-fatal: a stale entry costs a re-resolve, not a broken install.
+        logger.warning(f"Could not clear install state before deferred update: {e}")
+
+    command = f"uv tool install --upgrade --reinstall {url}"
+    launched = defer_uv_tool_swap(
+        [
+            UvStep(
+                command=command,
+                label="Updating amplifier...",
+                attempts=10,
+            )
+        ],
+        operation="update",
+        intro_lines=[
+            "Amplifier update",
+            "Windows cannot replace Amplifier's files while it is running,",
+            "so the update finishes here after the main window closes.",
+        ],
+        success_message="Amplifier updated. Start it again with: amplifier",
+        recovery_commands=[command],
+    )
+
+    if not launched:
+        return ExecutionResult(
+            success=False,
+            failed=["amplifier"],
+            errors={"amplifier": "Could not launch the deferred update"},
+            messages=[
+                (
+                    "Windows cannot update Amplifier while it is running, and "
+                    "the finisher script could not be started. Close Amplifier "
+                    f"and run this yourself: {command}"
+                )
+            ],
+        )
+
+    return ExecutionResult(
+        success=True,
+        updated=["amplifier"],
+        messages=["Amplifier update will finish in the new window after this exits"],
+    )
+
+
 async def execute_self_update(
     umbrella_info: UmbrellaInfo,
     progress_callback: Callable[[str, str], None] | None = None,
@@ -616,6 +683,13 @@ async def execute_self_update(
         # a killed uv process) causes uv tool install to hang indefinitely
         # waiting to acquire it — same guard applied in reset._clean_uv_cache().
         remove_stale_uv_lock()
+
+        # Windows cannot replace amplifier.exe's own loaded DLLs while this
+        # process is alive, so `uv tool install --reinstall` against our own
+        # tool environment fails with "Access is denied (os error 5)". Hand the
+        # install to a script that starts after we exit. See defer_uv_tool_swap.
+        if os.name == "nt":
+            return _defer_self_update(url)
 
         # Use Popen to stream uv output for progress visibility.
         # Previously used subprocess.run(capture_output=True) which silenced

--- a/amplifier_app_cli/utils/uv_utils.py
+++ b/amplifier_app_cli/utils/uv_utils.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
+from collections.abc import Sequence
 from pathlib import Path
+from typing import NamedTuple
 
 from ..console import console
+from .error_format import escape_markup
 
 
 def remove_stale_uv_lock() -> bool:
@@ -82,3 +86,197 @@ def remove_stale_uv_lock() -> bool:
             # have context if a subsequent uv command hangs.
             console.print(f"    [dim]Could not remove stale uv.lock: {e}[/dim]")
         return False
+
+
+class UvStep(NamedTuple):
+    """One deferred uv command in a Windows post-exit swap script.
+
+    Attributes:
+        command: Full command line, e.g. ``uv tool install git+https://...``.
+        label: Human-readable line echoed before the step runs.
+        attempts: How many times to retry while files are still locked.
+        required: When True, exhausting ``attempts`` aborts to the failure
+            block. When False the step is best-effort and the script continues.
+    """
+
+    command: str
+    label: str
+    attempts: int = 10
+    required: bool = True
+
+
+# cmd.exe metacharacters. A command containing any of these cannot be embedded
+# in a parenthesised for-loop body without escaping, and a mis-escaped script
+# would fail inside a new console window the user cannot easily debug. We refuse
+# to generate a script instead, and the caller prints manual instructions.
+_BATCH_UNSAFE = set('()^&|<>%!"\r\n')
+
+
+def _batch_safe(text: str) -> bool:
+    return not (_BATCH_UNSAFE & set(text))
+
+
+def defer_uv_tool_swap(
+    steps: Sequence[UvStep],
+    *,
+    operation: str,
+    intro_lines: Sequence[str],
+    success_message: str,
+    recovery_commands: Sequence[str],
+) -> bool:
+    """Run uv tool commands from a script that starts AFTER this process exits.
+
+    Windows locks a running program's own files: while ``amplifier.exe`` is
+    alive, the ``python3xx.dll`` / ``.pyd`` files it loaded from
+    ``%APPDATA%\\uv\\tools\\amplifier\\Lib\\`` cannot be deleted, so an
+    in-process ``uv tool install``/``uninstall`` against our own tool
+    environment fails with "Access is denied (os error 5)". POSIX allows
+    unlinking open files, which is why the direct path works there.
+
+    The workaround: write a throw-away ``.cmd`` that polls until this PID is
+    gone (releasing the lock), runs the steps with retries, then either
+    self-deletes on success or stops with the literal recovery commands on
+    screen. Launch it in a new console and exit.
+
+    Args:
+        steps: Commands to run, in order.
+        operation: Short slug for the temp filename, e.g. ``reset``.
+        intro_lines: Lines echoed at the top explaining what is happening.
+        success_message: Line echoed when every required step succeeded.
+        recovery_commands: Commands printed verbatim if the script gives up, so
+            the user is never left with only a temp-file path to a tool they may
+            no longer have installed.
+
+    Returns:
+        True if the script was written and launched. False if generation or
+        launch failed -- the caller must then print manual instructions.
+    """
+    import tempfile
+
+    if any(not _batch_safe(step.command) for step in steps):
+        # Never emit a script we cannot prove parses correctly.
+        console.print(
+            "[yellow]Warning:[/yellow] Cannot safely script the deferred uv commands."
+        )
+        return False
+
+    pid = os.getpid()
+    lines: list[str] = [
+        "@echo off",
+        "setlocal enabledelayedexpansion",
+        "echo(",
+    ]
+    lines += [f"echo {line}" for line in intro_lines]
+    lines += [
+        "echo(",
+        f"echo Waiting for Amplifier PID {pid} to exit...",
+        ":waitloop",
+        f'tasklist /FI "PID eq {pid}" 2>NUL | find "{pid}" >NUL',
+        "if not errorlevel 1 (",
+        "    ping -n 2 127.0.0.1 >NUL",
+        "    goto waitloop",
+        ")",
+        "echo(",
+    ]
+
+    for index, step in enumerate(steps):
+        # A successful attempt jumps past the remaining retries: to the next
+        # step's label, or to :done for the final step. The :done label lives in
+        # the footer, so it must NOT also be emitted here -- a duplicate label
+        # would make `goto done` land on a `goto done` and spin forever.
+        is_last = index == len(steps) - 1
+        nxt = "done" if is_last else f"step{index + 2}"
+        lines.append(f"echo {step.label}")
+        lines.append(f"for /L %%i in (1,1,{step.attempts}) do (")
+        if step.required:
+            lines.append(f"    {step.command}")
+            lines.append(f"    if !errorlevel! EQU 0 goto {nxt}")
+            lines.append(
+                f"    echo   files still locked, attempt %%i of {step.attempts}; retrying in 3s..."
+            )
+            lines.append("    ping -n 4 127.0.0.1 >NUL")
+            lines.append(")")
+            # Out of attempts on a step we cannot skip.
+            lines.append("goto locked")
+        else:
+            # Best-effort steps stay quiet; their failure is not the story, and
+            # exhausting attempts simply falls through to the next step.
+            lines.append(f"    {step.command} >NUL 2>&1")
+            lines.append(f"    if !errorlevel! EQU 0 goto {nxt}")
+            lines.append("    ping -n 3 127.0.0.1 >NUL")
+            lines.append(")")
+        if not is_last:
+            lines.append(f":{nxt}")
+
+    lines += [
+        # Reached only when the final step was best-effort and exhausted its
+        # attempts; unreachable (and harmless) after a required final step.
+        "goto done",
+        "",
+        ":locked",
+        "echo(",
+        "echo Could not finish: Amplifier's files are still locked by another",
+        "echo program - another Amplifier or terminal window, an antivirus scan,",
+        "echo or a file indexer.",
+        "echo(",
+        "echo Close any other Amplifier windows, then run these commands yourself:",
+    ]
+    # The literal commands, not just a path to this script: %TEMP% gets swept,
+    # and after a successful uninstall the user may have no amplifier at all.
+    lines += [f"echo     {cmd}" for cmd in recovery_commands]
+    lines += [
+        "echo(",
+        "echo Or re-run this script while it still exists:",
+        'echo     "%~f0"',
+        "echo If it keeps failing, reboot and run it once more.",
+        "echo(",
+        "pause",
+        "exit /b 1",
+        "",
+        ":done",
+        "echo(",
+        f"echo {success_message}",
+        "echo(",
+        "echo This window closes in 5 seconds.",
+        "ping -n 6 127.0.0.1 >NUL",
+        # Standard self-delete idiom: (goto) aborts batch parsing, releasing the
+        # file handle so del can remove the script. No orphan left in %TEMP%,
+        # and no keypress needed on the happy path.
+        '(goto) 2>NUL & del "%~f0"',
+    ]
+
+    # cmd.exe reads batch files as ANSI/OEM: ASCII + CRLF only.
+    script = "\r\n".join(lines) + "\r\n"
+
+    try:
+        fd, script_path = tempfile.mkstemp(
+            prefix=f"amplifier-{operation}-", suffix=".cmd"
+        )
+        with os.fdopen(fd, "w", encoding="ascii", newline="") as handle:
+            handle.write(script)
+    except OSError as e:
+        console.print(
+            f"[yellow]Warning:[/yellow] Could not write the finisher script: {escape_markup(str(e))}"
+        )
+        return False
+
+    console.print(
+        "\n[bold]>>>[/bold] Windows can't replace Amplifier while it's running."
+    )
+    console.print(f"    The {operation} will finish in a new window after this exits.")
+    console.print(f"    Script: [cyan]{script_path}[/cyan]")
+
+    try:
+        subprocess.Popen(
+            ["cmd", "/c", script_path],
+            creationflags=getattr(subprocess, "CREATE_NEW_CONSOLE", 0),
+            close_fds=True,
+        )
+    except OSError as e:
+        console.print(
+            f"[yellow]Warning:[/yellow] Could not auto-launch the finisher: {escape_markup(str(e))}"
+        )
+        return False
+
+    console.print("    [green]Launched.[/green] Watch the new window for progress.")
+    return True


### PR DESCRIPTION
Stacked on #274 — base is that branch, so the diff here is only the delta.

## The gap

#274 correctly identifies the root cause: on Windows a running program's
loaded DLLs cannot be replaced, so `uv tool install --reinstall` against the
tool environment we are *currently executing from* fails with
`Access is denied (os error 5)`. Its fix is to hand the install to a `.cmd`
script that waits for our PID to exit, then runs the install.

`amplifier update` reaches the same call the same way, and was not fixed.
`execute_self_update()` in `utils/update_executor.py` runs

```
uv tool install --upgrade --reinstall <url>
```

against the same tool environment, from the same live process. Identical root
cause, identical failure, different command. Fixing reset alone leaves the more
commonly-run path broken.

## What this changes

**1. One home for the deferral mechanism.** Reset's inline `.cmd` generator
moves to `utils/uv_utils.defer_uv_tool_swap()`, driven by a list of `UvStep`s
(`command`, `label`, `attempts`). Reset keeps its exact three-step shape and
behaviour; the script generator now has one implementation instead of one copy
per caller. The next command that needs to swap the tool env gets it for free
rather than growing a third copy.

**2. `amplifier update` uses it.** On `os.name == "nt"`, `execute_self_update()`
returns through the shared helper instead of running `uv` in-process.

One asymmetry worth flagging in review: the deferred install runs *unattended*,
after we have exited, so the post-install dependency check
(`_invalidate_modules_with_missing_deps()`) cannot run afterwards. `--reinstall`
rebuilds the Python environment and can drop module dependencies, and
install-state.json left claiming "installed" while the packages are gone
produces import errors on the next run. So the deferred path clears
install-state.json up front. That costs a re-resolve on next start and mirrors
what reset already does when it clears the cache. The alternative — leaving
state that describes an environment that no longer exists — is the worse
failure.

If the finisher script cannot be launched at all, update fails loudly with the
exact command to run by hand, rather than silently reporting success.

**3. Read-only files under cached git clones.** `clear_download_cache()` used
plain `shutil.rmtree`. Bundles are cached as git clones and git marks pack
files (`.git/objects/pack/*.pack`, `*.idx`) read-only. POSIX only needs write
permission on the *parent* directory to unlink a child, so this never bites on
macOS or Linux; Windows honours the read-only attribute on the file itself and
refuses. Added `utils/fs_utils.rmtree_robust()`, which clears the read-only bit
and retries once — and only on Windows. On POSIX a `PermissionError` means
something genuinely different, so it is re-raised untouched rather than
rewriting the user's file modes.

## Verification

- Full suite: 1434 passed, 1 xfailed, 13 deselected.
- `python_check` clean — no new lint or type findings against baseline.
- Generated the deferred `.cmd` from the real code path and read it end to end:
  CRLF line endings, PID wait loop, bounded retry (10 attempts, 3s apart),
  recovery block printing the literal command, self-delete on success.

The Windows-native execution itself is untested here — same testing limitation
as #274, and the reason the retry loop and the explicit recovery message exist.
