### PR TITLE
feat: move /goal-dependent skills into app-cli and compose the skills behavior bundle

### DIFF
--- a/amplifier_app_cli/data/skills/goal-batch/SKILL.md
+++ b/amplifier_app_cli/data/skills/goal-batch/SKILL.md
@@ -1,0 +1,373 @@
+---
+name: goal-batch
+description: >
+  Plan a batch of independent work into isolated lanes, get your approval, then
+  run each lane as its own autonomous /goal session — one git worktree, one
+  branch, one tmux session each — and verify and merge the results yourself.
+  Use when work decomposes into pieces that can run at the same time: "run these
+  in parallel", "goal-batch", "launch lanes for these", "work these N tasks
+  simultaneously", "batch these as goals". Nothing launches until you have seen
+  the lane split and said go. This is NOT fire-and-forget: the orchestrating
+  session re-runs the full test suite itself after every merge and never accepts
+  a lane's own claim that it finished. NOT for bounded edits that each end in
+  their own PR — use mass-change for that. Requires git, tmux, the amplifier CLI
+  on PATH, and the goalify and monitor skills.
+version: 2.0.0
+user-invocable: true
+argument-hint: "<the work to batch, or where it is enumerated>"
+allowed-tools: [bash, read_file, write_file, edit_file, grep, glob, delegate, load_skill, todo]
+model_role: general
+---
+
+# Goal Batch
+
+Split large work into lanes that cannot collide, run each as an autonomous
+`/goal` session in its own worktree, and land the results through a merge pass
+you verify yourself.
+
+You are the ORCHESTRATOR. You plan, launch, watch, verify, merge, report. You do
+not do the lanes' work — if you catch yourself editing a lane's code mid-flight,
+stop and fix the goal file or relaunch instead.
+
+Every rule here was bought with a real failure in production use — roughly 45
+lanes across three operators. Where a rule looks fussy, it is load-bearing.
+
+Shape references (plan screen, approval vocabulary, DONE.json, report) live in
+`examples/plan-and-report.md`. This file is the rules.
+
+**Invoking.** `/goal-batch <batch>` in the interactive TUI, or **"Use the
+goal-batch skill and …"** in natural language — both load this skill reliably
+(measured). What does NOT work is a bare `/goal-batch …` in a headless
+`amplifier run "<prompt>"`: the model reads the token as prose and does the work
+itself, producing plausible branches with no gate, no manifest, and no lanes.
+In a headless one-shot, **direct the assistant in natural language** — e.g.
+`amplifier run "Use the goal-batch skill and run this batch: …"` — or call
+`load_skill(skill_name="goal-batch", arguments=…)` outright. Naming the skill
+is what loads it; the bare slash token is not.
+
+**If `$ARGUMENTS` is empty, you have no batch.** This skill forks — the
+sub-session cannot see the parent conversation, so an `arguments`-less
+`load_skill` call arrives with nothing to plan against. That happened in a real
+run and the whole invocation died silently. Do not produce an empty plan and do
+not guess: reconstruct the batch from whatever context you were given, and if
+there genuinely is none, say so in one line and ask for the work. One question,
+not an interview.
+
+**Running the companion scripts.** `load_skill` returns `skill_directory`.
+Resolve every script from it — `<skill_directory>/scripts/<name>.sh` — and use
+that absolute path. Never a bare relative path: the working directory is the
+target repo, not the skill, and in a bundle the skill lives under a
+hash-suffixed cache path that changes between installs. **Never copy a script
+into the target repo** — a real run did exactly that, leaving `.amplifier/bin/`
+behind as untracked pollution in someone else's repository.
+
+**Input** — `$ARGUMENTS`: the work to batch, or a pointer to where it is
+enumerated. If lane independence is unclear, that is Phase 1's job, not a
+question for the user yet.
+
+---
+
+## Phase 1 — Plan
+
+Read enough to decompose honestly. Lanes each own a disjoint set of files, have
+a provable outcome, and do not need a sibling to finish first.
+
+Then do the work that decides whether this batch lands:
+
+- **Collision analysis.** Map every candidate lane to the files it will touch
+  and print the intersections. Where two lanes want the same file, FOLD THEM
+  INTO ONE LANE, or assign sole ownership and have the other record its needed
+  edit as a residual. Merging two lanes that would have collided is a win.
+- **Pre-assign anything numbered** — issue IDs, task IDs, migration numbers.
+  Parallel lanes *will* both grab the next free number. Two really did take 075.
+- **Name the seams.** List files no lane owns. That is where it breaks: a
+  packaging script nobody owned shipped broken because nobody tested it. Either
+  give a lane the seam, or carry it to Phase 7 as untested.
+- **Pin the base SHA** every lane branches from, and **record current test
+  baselines** so "no regressions" is a number.
+
+No lane cap. Width is bounded by the work.
+
+## Phase 2 — Review and go
+
+**Nothing is created and nothing launches before the user has seen the plan.**
+
+**Open with what the batch will NOT deliver.** The first two lines are:
+
+```
+When this finishes you WILL have: <the concrete end state>
+You will NOT have:                <what stays undone, and what it blocks>
+```
+
+This is the whole point of the gate and the one thing it has actually failed at.
+In a real run the fact that the batch *would not produce a working component*
+was disclosed — as the third bullet, inside a code block, under a heading about
+testing — and the user found out only after it finished: *"So the batch had post
+work associated with it? That was not clear to me."* Anything a reader would be
+upset to discover afterwards goes in line two, not in a section they will skim.
+
+Then the plan on one screen — lane table, contested files, parked items, unowned
+files, per-lane bounds, watching mode. Fifteen seconds to read, one sentence to
+argue with. Shape in `examples/`.
+
+Ask questions ONLY where a wrong guess costs a relaunch: an ownership call you
+cannot make from the code, a repo you are not sure you may push to, a
+human-reserved action. Bring a plan, not a form.
+
+**Every lane must trace to something the user asked for.** State the origin of
+each lane in the table. A run once invented a lane out of the orchestrator's own
+scratch notes and got 32 minutes into the gate before the user caught it:
+*"Lane F drafts five upstream feature requests against repos we don't own."
+What? Why are we changing other repos?* If you cannot name where a lane came
+from, it is not a lane.
+
+**Approval is conversational.** Accept a bare `go`, and accept a `go` carrying
+options — reporting cadence, per-lane bounds, dropping a lane — and honor them
+without re-asking. Anything that is not an affirmative is feedback: revise, show
+the diff, re-present. Never infer approval from enthusiasm, repetition, or
+silence.
+
+**Pre-authorization is valid and must be honored.** If the invocation itself
+grants approval — "pre-approved", "don't stop and ask", "go ahead and run it" —
+post the plan for the record and proceed without waiting. Users have started
+pre-arguing with the gate in the same breath as the request (*"but do NOT bug me
+about this simple design, then launch into /goal-batch"*), and the cleanest run
+in the field skipped the gate entirely. The plan is always shown; stopping is
+what a user may waive. Waiving is theirs to do, never yours to assume.
+
+## Phase 3 — Compose the goal files
+
+Load **goalify** and use it per lane; it owns outcome-first composition and
+termination linting.
+
+**Commit the goal files to the base commit before Phase 4 cuts any worktree**,
+and pin `BASE_SHA` to that commit. Goal files written only into a worktree die
+with it; goal files committed after the worktree exists are not in it, and the
+launcher will refuse the lane.
+
+Every goal carries:
+
+- **The disjunctive exit, close to verbatim.** The load-bearing sentence — what
+  makes lanes terminate honestly instead of spinning or declaring victory:
+
+  > Complete when **either** every item reaches a terminal state, **or** it is
+  > conclusively demonstrated the remainder cannot, naming the blocker for
+  > each. Items ending FAIL or BLOCKED are residuals, not failures of the goal.
+
+- **Terminal states** `PASS` / `FAIL-named` / `BLOCKED-named` / `PENDING-HUMAN`.
+  `PENDING-HUMAN` is distinct on purpose: a lane that discharges a review by
+  assigning it to a person has deferred, not finished, and Phase 7 must show
+  that separately.
+- **Working directory + branch + base SHA.** "Work ONLY here. Do not touch the
+  main checkout or sibling worktrees."
+- **File ownership** with the residual protocol: crossing into another lane's
+  files is a defect, not a courtesy — record the needed edit and stop. Draw
+  ownership around what makes the thing *work*, not around the artifact. A lane
+  owning an icon but not the packager does not own a shippable icon.
+- **Commit early, push always.** Two tmux-server crashes cost minutes instead of
+  hours because every lane pushed as it committed.
+- **Never merge to main.** The orchestrator merges.
+- **Host capability limits, stated plainly.** A lane that authors what this box
+  cannot compile ships code that breaks on someone else's first build. Live
+  shared services are read-only evidence to a lane; tests use fixtures.
+- **The time bound**, and that exceeding it is a terminal `BUDGET` state, not a
+  reason to rush the work or skip the commit.
+- **Add `DONE.json` to the repo's `.gitignore` before writing it.** Four of five
+  lanes in one run committed theirs and the batch's own merge pass collided on
+  that file. It is a signal, not an artifact.
+- **Write `DONE.json` in the worktree root as your final act** — the terminal
+  marker. Without it, an exited session is indistinguishable from a killed one.
+  Fields: `lane, session_id, verdict, branch, head, pushed, items[],
+  residuals[], pending_human[], suite`. Shape in `examples/`.
+  **`verdict` is exactly one of `COMPLETE` / `BLOCKED` / `PARTIAL`**, and
+  `session_id` is this lane's own — two lanes in one batch wrote `"PASS"` and
+  `"success"`, which no parser reads the same way, and a `DONE.json` without a
+  session_id cannot be told apart from one inherited through the base commit.
+- **KNOWN section** — env setup, suite commands, baselines, footguns. Speed
+  aid, not criteria.
+
+## Phase 4 — Preflight
+
+Fail loud here. Never launch degraded.
+
+- **Every lane's output must be COMMITTABLE — not necessarily pushable.** A
+  local-only repo is fine: a lane commits to its own branch, and those commits
+  live in the main repo's object store, so they survive `git worktree remove`
+  and merge normally with no network at all. Verify that, not a remote.
+  - **A remote is recommended, not required.** With one, lanes push as they
+    commit and a crash costs minutes; without one, the work is still safe on
+    disk but only on this machine. Say which the user is getting, once, and
+    move on — do not block the batch.
+  - **What actually loses work is output that is never committed at all.** The
+    real 47MB loss came from a repo that *had* two remotes: the lane's entire
+    output sat under gitignored paths, so it was never committed and pushing
+    would have saved none of it. So check the thing that matters: will each
+    lane's deliverables land in a commit? If a lane's real product is a
+    gitignored artifact directory, say so at the gate — that is a batch that
+    cannot deliver, and no remote fixes it.
+- **Smoke-test the launcher once**, ~90s, thrown away, and confirm any
+  capability a lane depends on is reachable from inside a lane.
+- **Create worktrees**, skipping any that already exist rather than failing on
+  them — this path is re-entered on resume:
+  `[ -d "$WT" ] || git worktree add -b <branch> "$WT" <BASE_SHA>`
+
+**One worktree per lane is not optional.** The session workspace slug is derived
+from the working directory, so lanes sharing a directory share a workspace and
+their activity becomes unattributable.
+
+## Phase 5 — Launch and register
+
+One tmux session per lane, via the companion script — once per lane:
+
+```bash
+<skill_directory>/scripts/launch_lane.sh \
+    <batch> <lane> <worktree> .amplifier/goals/<lane>.md \
+    <repo>/.amplifier/goals/manifest.tsv [wall_s] [max_turns]
+```
+
+**The script owns the manifest. Never hand-write it.** It writes the header on
+first call and appends one 8-column row per lane. Both users of v1 ended up
+hand-writing manifests because the launcher emitted 5 columns while the status
+probe read 7 — they never agreed, and no batch could use both tools as shipped.
+If you find yourself composing a `manifest.tsv` heredoc, stop: something is
+wrong and hand-writing it will hide the failure.
+
+The tmux session name and log path are **derived** from `<batch>`/`<lane>`, so
+the `gb__*` convention that the orphan sweep and pane-viewer match strings depend
+on cannot drift.
+
+It also enforces five things you must not reimplement by hand: the tmux command
+carries **no user prose** (a lone apostrophe in a launch note silently truncated
+a real launch — put launch notes INSIDE the goal file); logging survives; the
+lane runs under `timeout` in its own process group so a runaway dies with its
+children; any inherited `DONE.json` is purged before launch; and it **fails
+loud** if no session ID appears rather than writing a blank into the crash
+anchor.
+
+One-phase launch is mandatory. Never start a bare `amplifier` TUI and `send-keys`
+the `/goal` into it — keystrokes sent to a busy pane get swallowed silently (one
+run left an 8MB job with a zero-byte log), and `amplifier run` *exits* when the
+goal loop ends while a TUI sits at a prompt forever, so one-phase is what makes
+session death a real signal.
+
+Both bounds are real but live at different layers: `--max-turns` is parsed by
+**`/goal`**, not by `amplifier run`, so it rides inside the prompt string
+(`/goal --max-turns 40 @file`); wall-clock is `timeout` around the process.
+`/goal` is unlimited by default on purpose (ADR-0005) — a batch should set both.
+
+**Session names `gb__<batch>__<lane>`** — double underscore because lane names
+contain hyphens. Gives `gb__*` (every lane of every batch, for the orphan sweep
+in Phase 7 and for pane-viewer match strings), `gb__<batch>__*` (one batch),
+exact (one lane). Never use `.` or `:`: tmux silently rewrites them to `_` and
+two differently-named lanes can collide.
+
+**Write the manifest** — TSV, one row per lane: `lane · worktree · branch · tmux
+· goal · log · session_id`, beside the goal files. This is the crash anchor.
+When the tmux server dies, panes are gone but git plus this file let any session
+reconstruct the batch; without it, recovery was 40 minutes of archaeology.
+
+## Phase 6 — Watch
+
+**Every claim you make about a lane must come from a probe you just ran.** This
+is the rule; everything below serves it. Watchers that narrated from memory or
+from a pane's last line have fabricated in multiple runs — one declared
+`TIMEOUT: reached 95-minute max duration` at 30 minutes actual, and one reported
+`No DONE.json files written` 68 seconds before the merge collided with those
+exact files. The run with the lowest overhead measured (7% of spend) is the one
+that probed for everything it said.
+
+The instrument:
+
+```bash
+<skill_directory>/scripts/batch_status.sh <manifest.tsv> <BASE_SHA>
+SHOW_LAST=1 <skill_directory>/scripts/batch_status.sh <manifest.tsv>
+```
+
+Its first line is `BATCH_ELAPSED`, computed from the manifest header — **that is
+the only elapsed time that means anything.** The per-lane `LANE_IDLE` column is
+seconds since that lane last emitted an event; reading it as batch elapsed time
+is what killed a watch an hour early.
+
+Five signals are counter-intuitive and the script encodes them so you do not
+have to reason about them:
+
+- Terminal is `DONE.json`, checked against the manifest's session_id — an
+  inherited one from the base commit otherwise reads as a finished lane.
+- Alive is `kill -0` on the lane PID, **not** tmux presence. The tmux server has
+  died mid-batch in three separate runs, leaving healthy lanes running as
+  orphans while tmux-keyed probes went blind.
+- Liveness is `events.jsonl` mtime, **not** `transcript.jsonl` mtime — the
+  transcript freezes entirely while a lane delegates to a sub-agent.
+- Progress is assistant turns from the transcript, **not**
+  `metadata.turn_count`, which is corrupt (reports 1 for a 21-turn session).
+- Pushed is `git ls-remote`, **not** `@{upstream}`, never set by an
+  explicit-refspec push.
+
+**Wait on state change, not on a clock.** Sleep between probes; do not spend a
+model call to decide whether to sleep again. In one run 51 of 70 monitor calls
+were bare `sleep`, and monitoring ran 3.9× longer than the work it watched.
+Load **monitor** if you delegate the loop — it owns the SEQUENTIAL-ONLY rule and
+the batched-imposter check — but the loop's job here is mechanical: probe,
+compare, sleep, repeat.
+
+Report per the mode approved in Phase 2. Interrupt regardless for: a lane
+`DIED`, a `STALE-DONE-IGNORED` verdict, a lane asking a human a question, or the
+probe itself failing twice. Stall thresholds (120s/900s) are starting guesses —
+calibrate before letting `STALLED` justify killing anything.
+
+**Verify the watcher's verdict yourself before acting on it.** Both false-DONE
+and false-crash have happened.
+
+**Inherited artifacts are the single biggest source of false signals.** A lane's
+worktree starts as a full copy of the base commit, so every status file, every
+evidence directory, every `BLOCKED.md` that was already tracked appears to
+belong to the lane. Three false alarms in one day came from this: a `BLOCKED.md`
+byte-identical to main — *whose first line read "The lane is not blocked"* —
+read as a real block; "23 evidence files, great progress" where 20 were
+inherited; a monitor citing a device transcript that shipped with the branch.
+Before reading any artifact as a lane's own output, prove the lane wrote it:
+compare against the base commit (`git log <BASE_SHA>..HEAD -- <path>`, or a
+checksum against base). `launch_lane.sh` purges `DONE.json` for exactly this
+reason; every other artifact is on you.
+
+**Provider rate-limit errors in a pane are healthy, not a stall.** If a lane
+dies of them, that is a model-routing problem: switch the model and relaunch.
+Do not serialize the batch.
+
+**A lane that died — crashed, or killed by its time bound — takes the same
+path:** rescue-commit anything real it banked, then relaunch the same goal with
+a RESUME note naming what the prior attempt completed with SHAs, "treat that as
+your own prior work, do not redo it", and what remains. Max 2 resumes. A lane
+that hit its bound twice is a scoping problem — report it, do not extend
+forever. Never let a bounded-out lane vanish silently from the Phase 7 report.
+
+## Phase 7 — Land
+
+**Re-verify everything. Lane self-reports are hints.** Two lanes reported green
+honestly from a suite run that predated their own last file.
+
+1. `git fetch`. Diff-stat each landed branch with **three dots** —
+   `git diff main...HEAD` — not two. Two dots compares against main's *current*
+   tip, so every commit main gained while the lane ran shows up as the lane's
+   work. That produced a near-miss ownership accusation against a lane that had
+   touched none of the files.
+2. **Read the diffs across lanes, not just within them.** File ownership does
+   not catch two lanes inventing the *same* thing at *different* paths — two
+   lanes once created separate `ThreadVisibility` singletons, one written by
+   one lane and read by the other, and **both lanes' tests passed** while the
+   behavior was silently broken. It was caught only by reading the combined
+   diff. Anything that looks like a new shared abstraction deserves a
+   cross-lane look before merging.
+2. Merge **sequentially, ascending by churn, `--no-ff`**. Run the full suite
+   yourself after EVERY merge. Verify actual test counts from result files, not
+   "BUILD SUCCESSFUL".
+3. On conflict: resolve per the lanes' own merge notes. If notes are missing or
+   intents genuinely conflict, stop and surface it rather than guessing.
+4. On red: fix at the cause, or revert that merge and report. Never weaken a
+   test to pass — the gate is doing its job.
+5. Push main. Then per lane: `git worktree remove`, delete branch local and
+   remote, `tmux kill-session`. Sweep for orphans: `tmux ls -F '#{session_name}'
+   | grep '^gb__<batch>__'` must come back empty.
+6. Report verdict-first: per-lane table (shipped, SHAs, suite results), what
+   verification caught that lanes did not self-report, residuals, anything
+   `PENDING-HUMAN`, the unowned-files list from Phase 1, and new baselines.

--- a/amplifier_app_cli/data/skills/goal-batch/examples/plan-and-report.md
+++ b/amplifier_app_cli/data/skills/goal-batch/examples/plan-and-report.md
@@ -1,0 +1,72 @@
+# goal-batch — shape references
+
+Not normative. The SKILL.md rules govern; these show what the artifacts look like
+when done well. Read only if you need the shape.
+
+## The Phase 2 plan screen
+
+```
+BATCH attend-weave    base main@86ed732    baseline: pytest 871/1, cargo 83
+
+  lane        owns                             issues    size
+  contracts   fleet-tools collection reads     008,012   M
+  tools       M365 + bash surfaces (additive)  031       S
+  continuity  the gateway rail                 049       L
+
+  contested   none — A9 folded into contracts (both rewrote fleet-tools)
+  parked      B1-B5 (methods, not code) · C3-C6 (should follow reask)
+  unowned     scripts/package.sh  ← nobody will test this
+
+  bounds      2h per lane, then TERM. no lane cap.
+  watching    every 15 min, one report when all lanes land   [default]
+              also: report as each lands · only ping me if something breaks
+
+go?
+```
+
+## Approval vocabulary actually seen in the field
+
+| They say | Means |
+|---|---|
+| `go` | launch on the shown defaults |
+| `go, tell me as each lands` | per-lane reports |
+| `go, only ping me if it breaks` | exceptions only |
+| `go, check every 30` | interval override |
+| `go, 4h on continuity` | per-lane bound override |
+| `go but drop continuity` | revise, show the one-line diff, relaunch the gate |
+
+Anything that is not an affirmative is feedback. Revise and re-present.
+
+## batch_status.sh output
+
+```
+LANE       VERDICT     IDLE   TURNS    COMMITS DIRTY PUSHED BRANCH
+contracts  WORKING     3s     127+14   2       1     0      weave/contracts
+tools      LANDED      412s   88+0     3       0     1      weave/tools
+reask      STALLED     8667s  41+0     0       11    0      weave/reask
+```
+
+Verdicts: `STARTING` · `WORKING` · `SLOW` · `STALLED` · `LANDED` ·
+`LANDED-NOT-PUSHED` · `LANDED-DIRTY` · `DIED` · `NOT-STARTED` ·
+`WORKTREE-MISSING`.
+
+`SHOW_LAST=1` appends each lane's last 3 conversation turns — that is the
+"what is it actually doing" view.
+
+## DONE.json
+
+```json
+{"lane":"contracts","verdict":"COMPLETE","branch":"weave/contracts",
+ "head":"59c853e","pushed":true,
+ "items":[{"id":"D1","state":"PASS","note":"8 red-proven gates"},
+          {"id":"D4","state":"BLOCKED","note":"074 is upstream muxplex work"}],
+ "residuals":["__bool__ undefined on Bounded — recorded, not fixed"],
+ "pending_human":[],
+ "suite":"891 passed, 1 skipped (baseline 871)"}
+```
+
+## The final report
+
+Verdict first. Per-lane: what shipped, SHAs, suite result. Then what
+verification caught that the lanes did not self-report, residuals, anything
+`PENDING-HUMAN`, the unowned-files list from Phase 1, and the new baselines.

--- a/amplifier_app_cli/data/skills/goal-batch/scripts/batch_status.sh
+++ b/amplifier_app_cli/data/skills/goal-batch/scripts/batch_status.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# batch_status.sh <manifest.tsv> [base_sha]
+#
+# One line per lane. This is the instrument the watcher reads.
+# Reads the 8-column manifest that launch_lane.sh writes. Never hand-write it.
+#
+# SHOW_LAST=1  also print each lane's last 3 top-level turns.
+#
+# --- what each signal is, and why NOT the obvious alternative ----------------
+# TERMINAL  = DONE.json in the worktree root, verified against the manifest's
+#             session_id when present. Pane death alone cannot distinguish
+#             "goal satisfied" from "killed".
+# ALIVE     = kill -0 on the lane PID. NOT tmux presence: the tmux server has
+#             died mid-batch in three separate real runs, leaving healthy lanes
+#             running as orphans while a tmux-keyed probe went blind.
+# LIVENESS  = newest events.jsonl mtime in the lane's workspace. NOT
+#             transcript.jsonl mtime, which freezes entirely while a lane
+#             delegates to a sub-agent (measured: 4 live sessions, 124s apart,
+#             zero transcript movement).
+# PROGRESS  = assistant turns counted from the transcript. NOT
+#             metadata.turn_count, which is corrupt (reports 1 for 21 turns).
+# PUSHED    = git ls-remote. NOT @{upstream}, never set by explicit-refspec push.
+#
+# BATCH_ELAPSED comes from the manifest header, NOT from any lane's idle timer.
+# A watcher once read a lane's idle seconds as batch elapsed time and killed the
+# watch at 30 minutes claiming 95. The per-lane column is named LANE_IDLE so the
+# two can never be confused again.
+#
+# Requires GNU find (-printf), jq, git, tmux.
+
+set -uo pipefail
+
+MAN="${1:?usage: batch_status.sh <manifest.tsv> [base_sha]}"
+BASE_SHA="${2:-}"
+STATE="${GOAL_BATCH_STATE:-/tmp/goal-batch-state}"
+WARM="${GOAL_BATCH_WARM:-120}"    # idle < WARM -> WORKING
+COLD="${GOAL_BATCH_COLD:-900}"    # idle < COLD -> SLOW, else STALLED
+CI_BASE="${AMPLIFIER_CONTEXT_INTELLIGENCE_BASE_PATH:-$HOME/.amplifier/projects}"
+
+[ -s "$MAN" ] || { echo "FATAL: manifest missing or empty: $MAN" >&2; exit 2; }
+mkdir -p "$STATE"
+NOW=$(date +%s)
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- batch-level elapsed, from the manifest header ---------------------------
+LAUNCHED=$(sed -n 's/.*launched_at=\([0-9]*\).*/\1/p' "$MAN" | head -1)
+if [ -n "${LAUNCHED:-}" ]; then
+  E=$(( NOW - LAUNCHED ))
+  printf 'BATCH_ELAPSED %02d:%02d:%02d   manifest=%s\n' $((E/3600)) $((E%3600/60)) $((E%60)) "$MAN"
+else
+  printf 'BATCH_ELAPSED unknown (manifest header has no launched_at)   manifest=%s\n' "$MAN"
+fi
+
+printf '%-14s %-19s %-10s %-10s %-8s %-6s %-7s %s\n' \
+  LANE VERDICT LANE_IDLE TURNS COMMITS DIRTY PUSHED BRANCH
+
+while IFS=$'\t' read -r lane wt branch tmuxname goal log sid pid; do
+  case "${lane:-}" in ''|'#'*) continue ;; esac
+
+  # --- terminal marker, guarded against a stale/inherited file ---------------
+  done_state=no
+  if [ -f "$wt/DONE.json" ]; then
+    done_sid=$(jq -r '.session_id // empty' "$wt/DONE.json" 2>/dev/null)
+    if [ -n "$done_sid" ] && [ -n "${sid:-}" ] && [ "$done_sid" != "$sid" ]; then
+      done_state=stale
+    else
+      done_state=yes
+    fi
+  fi
+
+  # --- verdict normalisation: the enum drifted across lanes in one real batch
+  verdict_field=""
+  if [ "$done_state" = yes ]; then
+    verdict_field=$(jq -r '(.verdict // "") | ascii_upcase' "$wt/DONE.json" 2>/dev/null)
+    case "$verdict_field" in
+      COMPLETE|PASS|SUCCESS|OK|DONE) verdict_field=COMPLETE ;;
+      BLOCKED)                       verdict_field=BLOCKED ;;
+      PARTIAL)                       verdict_field=PARTIAL ;;
+      "")                            verdict_field=COMPLETE ;;
+      *)                             verdict_field="ODD:$verdict_field" ;;
+    esac
+  fi
+
+  # --- liveness (stat only, never a read) -----------------------------------
+  slug="$(printf '%s' "$wt" | tr '/' '-')"
+  ws="$CI_BASE/$slug/sessions"
+  newest=$(find "$ws" -maxdepth 2 -name events.jsonl -printf '%T@\n' 2>/dev/null | sort -rn | head -1)
+  newest="${newest%%.*}"
+  if [ -n "${newest:-}" ]; then idle=$(( NOW - newest )); idle_s="${idle}s"
+  else                          idle=-1;                 idle_s="n/a"; fi
+
+  # --- progress -------------------------------------------------------------
+  turns='-'
+  tr_file="$ws/${sid:-__none__}/transcript.jsonl"
+  if [ -f "$tr_file" ]; then
+    n=$(jq -r 'select(.role=="assistant")|1' "$tr_file" 2>/dev/null | wc -l | tr -d ' ')
+    prev=$(cat "$STATE/${sid}.turns" 2>/dev/null || echo 0)
+    printf '%s' "$n" > "$STATE/${sid}.turns"
+    turns="${n}+$(( n - prev ))"
+  fi
+
+  # --- git facts ------------------------------------------------------------
+  if [ -d "$wt" ]; then
+    dirty=$(git -C "$wt" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+    if [ -n "$BASE_SHA" ]; then
+      commits=$(git -C "$wt" rev-list --count "${BASE_SHA}..HEAD" 2>/dev/null || echo '-')
+    else
+      commits=$(git -C "$wt" rev-list --count HEAD 2>/dev/null || echo '-')
+    fi
+    pushed=$(timeout 20 git -C "$wt" ls-remote --heads origin "$branch" 2>/dev/null | grep -c .)
+  else
+    dirty='-'; commits='-'; pushed='-'
+  fi
+
+  # --- alive: PID first, tmux only as corroboration -------------------------
+  alive=no
+  if [ -n "${pid:-}" ] && [ "$pid" != "-" ] && kill -0 "$pid" 2>/dev/null; then
+    alive=yes
+  elif tmux has-session -t "$tmuxname" 2>/dev/null; then
+    alive=yes
+  fi
+
+  # --- verdict (precedence matters) -----------------------------------------
+  if   [ ! -d "$wt" ];                                        then v=WORKTREE-MISSING
+  elif [ "$done_state" = stale ];                             then v=STALE-DONE-IGNORED
+  elif [ "$done_state" = yes ] && [ "$dirty" != 0 ];          then v="${verdict_field}-DIRTY"
+  elif [ "$done_state" = yes ] && [ "$pushed" = 0 ];          then v="${verdict_field}-NOT-PUSHED"
+  elif [ "$done_state" = yes ];                               then v="$verdict_field"
+  elif [ "$alive" = yes ] && [ "$idle" -lt 0 ];               then v=STARTING
+  elif [ "$alive" = yes ] && [ "$idle" -lt "$WARM" ];         then v=WORKING
+  elif [ "$alive" = yes ] && [ "$idle" -lt "$COLD" ];         then v=SLOW
+  elif [ "$alive" = yes ];                                    then v=STALLED
+  elif [ "$idle" -lt 0 ];                                     then v=NOT-STARTED
+  else                                                             v=DIED
+  fi
+
+  printf '%-14s %-19s %-10s %-10s %-8s %-6s %-7s %s\n' \
+    "$lane" "$v" "$idle_s" "$turns" "$commits" "$dirty" "$pushed" "$branch"
+
+  if [ "${SHOW_LAST:-0}" = 1 ] && [ -f "$tr_file" ]; then
+    "$HERE/lane_turns.sh" "$tr_file" 3 200 | sed 's/^/    /'
+  fi
+done < "$MAN"

--- a/amplifier_app_cli/data/skills/goal-batch/scripts/lane_turns.sh
+++ b/amplifier_app_cli/data/skills/goal-batch/scripts/lane_turns.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# lane_turns.sh <transcript.jsonl> [N] [CHARS]
+#
+# Print the last N TOP-LEVEL turns of an Amplifier session as one line each.
+# This is the "what is this lane actually doing" probe.
+#
+# Why this and not `tmux capture-pane`: the pane is a TUI. Its last line is
+# box-drawing characters, and the "Processing..." spinner VANISHES while a
+# sub-agent runs, so absent-spinner reads as idle when the lane is busy.
+# Measured cost of getting this wrong: 3 of 5 lanes assessed incorrectly,
+# one declared dead while it was actively landing red-proven fixes.
+#
+# Never touches events.jsonl (reaches 750MB with 100k+ token single lines).
+
+set -uo pipefail
+
+T="${1:?usage: lane_turns.sh <transcript.jsonl> [N] [CHARS]}"
+N="${2:-20}"
+CH="${3:-300}"
+
+if [ ! -f "$T" ]; then
+  echo "(no transcript yet: $T)"
+  exit 0
+fi
+
+# The select(($txt|length) > 0) filter is load-bearing: roughly 60% of assistant
+# records are tool-call-only with empty text. Without it you get blank lines and
+# no narrative.
+jq -r --argjson w "$CH" '
+  select(.role=="user" or .role=="assistant")
+  | ((.metadata | if type=="string" then (fromjson? // {}) else . end).timestamp // "?") as $ts
+  | (if (.content|type)=="string" then .content
+     else ([.content[]? | select(.type=="text").text] | join("\n")) end) as $txt
+  | select(($txt|length) > 0)
+  | "\($ts[5:19]) [\(.role[0:5])] \($txt | gsub("\\s+";" ") | .[0:$w])"
+' "$T" 2>/dev/null | tail -n "$N"

--- a/amplifier_app_cli/data/skills/goal-batch/scripts/launch_lane.sh
+++ b/amplifier_app_cli/data/skills/goal-batch/scripts/launch_lane.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# launch_lane.sh <batch> <lane> <worktree> <goal-rel-path> <manifest> [wall_s] [max_turns]
+#
+#   batch/lane     name the batch and the lane. tmux session and log path are
+#                  DERIVED from them -- gb__<batch>__<lane> and
+#                  /tmp/gb-<batch>-<lane>.log -- so the naming convention that
+#                  the orphan sweep and pane-viewer match strings depend on
+#                  cannot drift.
+#   goal-rel-path  path RELATIVE TO THE WORKTREE. Must be committed to the base
+#                  commit before `git worktree add`, so every worktree has it.
+#   manifest       the batch manifest. THIS SCRIPT OWNS IT: it writes the header
+#                  on first call and appends one row per lane. Nothing else
+#                  should ever write it by hand.
+#   wall_s         wall-clock bound, default 7200. 0 disables.
+#   max_turns      turn bound passed to /goal, default 0 (unlimited, ADR-0005).
+#                  NOTE: --max-turns is parsed by /goal, NOT by `amplifier run`,
+#                  so it rides inside the prompt string.
+#
+# MANIFEST SCHEMA (8 columns, tab-separated) -- batch_status.sh reads exactly this:
+#   lane  worktree  branch  tmux  goal  log  session_id  pid
+#
+# v2 changes, each bought with a measured failure in real team use:
+#  - Owns the manifest end-to-end. v1 emitted 5 columns while batch_status.sh
+#    read 7; the two never agreed, and every real user hand-wrote the manifest
+#    to work around it.
+#  - Records the lane PID. tmux servers have died mid-batch in three separate
+#    runs; PID liveness keeps the status probe working when tmux is gone.
+#  - Purges any inherited DONE.json before launch. A DONE.json carried in
+#    through the base commit reads as an already-finished lane.
+#  - `setsid --wait`. Bare `setsid` launched ZERO of five lanes on another
+#    operator's machine while working fine here.
+
+set -uo pipefail
+
+BATCH="${1:?batch name}"; LANE="${2:?lane name}"; WT="${3:?worktree}"
+GOAL="${4:?goal path relative to worktree}"; MANIFEST="${5:?manifest path}"
+WALL="${6:-7200}"; MAXTURNS="${7:-0}"
+
+TMUXNAME="gb__${BATCH}__${LANE}"
+LOG="/tmp/gb-${BATCH}-${LANE}.log"
+PIDFILE="/tmp/gb-${BATCH}-${LANE}.pid"
+
+# --- preflight: fail loud, never launch degraded ------------------------------
+[ -d "$WT" ] || { echo "FATAL $LANE: worktree missing: $WT" >&2; exit 2; }
+[ -f "$WT/$GOAL" ] || {
+  echo "FATAL $LANE: goal file not in worktree: $WT/$GOAL" >&2
+  echo "  Goal files must be COMMITTED to the base commit before 'git worktree add'." >&2
+  exit 2; }
+case "$GOAL" in *[\'\"\ \$\`\\]*)
+  echo "FATAL $LANE: goal path has shell metachars: $GOAL" >&2; exit 2 ;; esac
+case "$BATCH$LANE" in *[!a-zA-Z0-9-]*)
+  echo "FATAL: batch/lane must be [a-zA-Z0-9-] only (got '$BATCH'/'$LANE')" >&2; exit 2 ;; esac
+case "$MAXTURNS" in ''|*[!0-9]*)
+  echo "FATAL $LANE: max_turns must be a non-negative integer: $MAXTURNS" >&2; exit 2 ;; esac
+
+if tmux has-session -t "$TMUXNAME" 2>/dev/null; then
+  echo "SKIP $LANE: tmux session '$TMUXNAME' already live (not clobbering)"
+  exit 3
+fi
+
+# The lane runs under a non-login shell inside tmux. `amplifier` living only on a
+# login-shell PATH is the difference between a clean abort here and a 60-second
+# wait for a Session ID that can never arrive.
+AMP="$(command -v amplifier || true)"
+if [ -z "$AMP" ]; then
+  AMP="$(bash -lc 'command -v amplifier' 2>/dev/null || true)"
+  [ -n "$AMP" ] || { echo "FATAL $LANE: 'amplifier' not on PATH (checked plain and login shell)." >&2; exit 2; }
+  echo "NOTE $LANE: amplifier only on the login PATH; pinning $AMP" >&2
+fi
+
+# --- lane-environment preflight ----------------------------------------------
+# A lane inherits the TMUX SERVER's environment, not this shell's. When a var
+# the settings interpolate is missing there, it resolves EMPTY -- e.g.
+# `base_url: ${ANTHROPIC_BASE_URL}` becomes "" and every LLM call dies with
+# "Connection error" that looks exactly like a network outage. That killed three
+# lanes twice in one day while the API was reachable the whole time. Refuse to
+# launch rather than die mid-run.
+# Vars are discovered from the settings files, not hardcoded -- a provider this
+# script has never heard of is covered for free.
+if tmux has-session 2>/dev/null || tmux ls >/dev/null 2>&1; then
+  VARS=$(cat ~/.amplifier/settings.yaml .amplifier/settings.yaml 2>/dev/null \
+         | grep -oE '\$\{[A-Z_][A-Z0-9_]*\}' | tr -d '${}' | sort -u)
+  missing=""
+  for v in $VARS; do
+    here="$(printenv "$v" 2>/dev/null || true)"
+    there="$(tmux show-environment -g "$v" 2>/dev/null | sed "s/^$v=//")"
+    case "$there" in "-$v"|"") there="" ;; esac
+    [ -n "$here" ] && [ -z "$there" ] && missing="$missing $v"
+  done
+  if [ -n "$missing" ]; then
+    echo "FATAL $LANE: set in this shell but EMPTY in the tmux server env:$missing" >&2
+    echo "  The lane would inherit empty values and fail with a misleading" >&2
+    echo "  'Connection error' on its first LLM call. Fix, then relaunch:" >&2
+    for v in $missing; do echo "    tmux set-environment -g $v \"\$$v\"" >&2; done
+    exit 2
+  fi
+fi
+
+BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '?')
+
+# A DONE.json inherited from the base commit means "finished" to every reader.
+rm -f "$WT/DONE.json" "$PIDFILE"
+
+# /goal parses a LEADING --max-turns; 0 means unlimited, so omit it entirely.
+if [ "$MAXTURNS" -gt 0 ]; then PROMPT="/goal --max-turns ${MAXTURNS} @${GOAL}"
+else                           PROMPT="/goal @${GOAL}"; fi
+
+# --- tmux guard: MECHANICAL, because knowledge failed twice -------------------
+# A lane that runs `tmux kill-server` without -L/-S kills the server it is
+# RUNNING IN. tmux resolves -S > -L > $TMUX > TMUX_TMPDIR, and $TMUX is set in
+# every process descended from an attached client -- so TMUX_TMPDIR is NOT
+# isolation. This has happened twice on this class of machine: 73 live sessions
+# destroyed 2026-08-08, 81 more on 2026-08-12. The second lane had the
+# precedence rule documented in its own context when it ran the command.
+# Documentation does not stop this. A shim on the lane's PATH does.
+# Lanes have no legitimate business on the shared server; isolated work must
+# name its socket on EVERY call, including the teardown -- the teardown is the
+# call that bites.
+GUARD_DIR="/tmp/gb-tmux-guard"
+REAL_TMUX="$(command -v tmux || true)"
+if [ -n "$REAL_TMUX" ]; then
+  mkdir -p "$GUARD_DIR"
+  cat > "$GUARD_DIR/tmux" <<GUARD
+#!/usr/bin/env bash
+# Auto-installed by goal-batch launch_lane.sh. Applies to LANES only.
+for a in "\$@"; do
+  case "\$a" in -L|-S|-L*|-S*) exec "$REAL_TMUX" "\$@" ;; esac
+done
+echo "[gb-tmux-guard] REFUSED: tmux invoked without an explicit -L <name> or -S <path>." >&2
+echo "[gb-tmux-guard] TMUX_TMPDIR is NOT isolation -- \\\$TMUX outranks it. That exact" >&2
+echo "[gb-tmux-guard] mistake destroyed 73 live sessions on 2026-08-08 and 81 on 08-12." >&2
+echo "[gb-tmux-guard] Use an isolated socket and pass -L <unique-name> on EVERY call," >&2
+echo "[gb-tmux-guard] including teardown. You are a lane; you do not need the shared server." >&2
+exit 78
+GUARD
+  chmod +x "$GUARD_DIR/tmux"
+fi
+
+# Wrapper keeps quoting off the tmux command line and owns process-group cleanup
+# that plain `timeout` does not do (it signals only its direct child).
+WRAP="$(mktemp "/tmp/gb-wrap-${BATCH}-${LANE}-XXXXXX.sh")"
+{
+  echo '#!/usr/bin/env bash'
+  [ -n "$REAL_TMUX" ] && printf 'export PATH=%q:"$PATH"\n' "$GUARD_DIR"
+  printf 'echo $$ > %q\n' "$PIDFILE"
+  echo 'trap '\''kill -- -$$ 2>/dev/null'\'' EXIT'
+  if [ "$WALL" -gt 0 ]; then
+    printf 'timeout --signal=TERM --kill-after=60s %ss %q run %q 2>&1 | tee %q\n' \
+           "$WALL" "$AMP" "$PROMPT" "$LOG"
+  else
+    printf '%q run %q 2>&1 | tee %q\n' "$AMP" "$PROMPT" "$LOG"
+  fi
+  printf 'echo "LANE_EXIT=${PIPESTATUS[0]} $(date -Is)" >> %q\n' "$LOG"
+} > "$WRAP"
+chmod +x "$WRAP"
+
+tmux new-session -d -s "$TMUXNAME" -c "$WT" "setsid --wait $WRAP"
+
+# --- harvest the session ID; FAIL LOUD if it never appears --------------------
+# The manifest is the crash anchor. A blank ID in it is worse than no manifest,
+# because recovery will trust it.
+SID=""
+for _ in $(seq 1 24); do            # up to ~60s for a cold start
+  sleep 2.5
+  SID=$(grep -am1 'Session ID:' "$LOG" 2>/dev/null | sed 's/.*Session ID: *//' | tr -d '\r')
+  [ -n "$SID" ] && break
+  tmux has-session -t "$TMUXNAME" 2>/dev/null || break   # died during startup
+done
+
+if [ -z "$SID" ]; then
+  alive=$(tmux has-session -t "$TMUXNAME" 2>/dev/null && echo yes || echo no)
+  echo "FATAL $LANE: no Session ID after 60s (session alive=$alive). Log tail:" >&2
+  tail -5 "$LOG" 2>/dev/null >&2
+  exit 4
+fi
+
+PID=$(cat "$PIDFILE" 2>/dev/null || echo '-')
+
+# --- write the manifest (header once, then one row per lane) ------------------
+if [ ! -s "$MANIFEST" ]; then
+  mkdir -p "$(dirname "$MANIFEST")"
+  {
+    printf '# lane\tworktree\tbranch\ttmux\tgoal\tlog\tsession_id\tpid\n'
+    printf '# batch=%s launched_at=%s wall_s=%s max_turns=%s\n' \
+           "$BATCH" "$(date +%s)" "$WALL" "$MAXTURNS"
+  } > "$MANIFEST"
+fi
+printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+  "$LANE" "$WT" "$BRANCH" "$TMUXNAME" "$GOAL" "$LOG" "$SID" "$PID" | tee -a "$MANIFEST"

--- a/amplifier_app_cli/data/skills/ten-lane-highway/SKILL.md
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/SKILL.md
@@ -1,0 +1,332 @@
+---
+name: ten-lane-highway
+description: >
+  Become the Highway Manager: a strategist that takes a defined outcome plus
+  constraints and drives many parallel /goal lanes continuously toward it —
+  plan, get one approval, saturate to width, then verify/merge/refill on every
+  wake so lanes never sit idle, weaving new feedback into priorities as it
+  arrives. Use when the user wants continuous parallel throughput toward an
+  outcome: "run the highway", "/highway", "10-lane highway", "keep N lanes
+  full", "keep re-feeding lanes as they drain", "drive this for me in
+  parallel". NOT for a one-shot batch that launches once and drains together —
+  use goal-batch. NOT for bounded edits that each end in their own PR — use
+  mass-change. Requires git, tmux, the amplifier CLI on PATH, and the goalify
+  and monitor skills.
+version: 1.0.0
+user-invocable: true
+shortcut: highway
+argument-hint: "<the outcome to drive, constraints/deadline, and where the work lives>"
+model_role: general
+# Deliberately NOT `context: fork`: the approval gate, mid-flight steering, and
+# conflict questions must happen in THIS conversation across many turns. A fork
+# is call-and-return; a highway manager is a standing conversation partner.
+# (`allowed-tools` omitted: it only takes effect under fork.)
+---
+
+# Ten-Lane Highway
+
+Run continuous parallel agent lanes toward a defined outcome. Success is not
+"lanes ran": it is the outcome reached (or honestly blocked with named
+reasons), every landed lane merged with the suite green after each merge, the
+Operating Picture current, and the scaffolding torn down.
+
+The predecessor pattern (goal-batch) launches a set and drains it. The highway
+replaces batching with **continuous scheduling**: "I have N units of execution
+capacity. Never wait for a batch. Continuously decide what the best available
+use of each unit is." You are doing agent capacity management — closer to OS
+scheduling than to a task list.
+
+## You are the Highway Manager — a strategist, not an intake clerk
+
+You take the user's **outcome/goal**, their **constraints** (time, authority,
+resources), the **current state**, and the set of **possible work**, and you
+drive the whole operation in proxy for the user:
+
+- **Select** work to best achieve the outcome within the constraints — you do
+  not simply execute everything that arrives, and you do not FIFO the queue.
+- **Adjust continuously** on your own: re-prioritize as lanes land, as
+  discoveries surface, as the deadline nears.
+- **Weave in new incoming** (user feedback, lane discoveries, external events)
+  by explicit decision: do it now / queue it at a priority / decline it — each
+  with a reason, recorded. Nothing enters or leaves the plan silently.
+- **Keep the context straight across lanes**: the Operating Picture
+  (`HIGHWAY.md`) is your externalized brain — outcome, constraints, lane board,
+  priority rationale, weave-in log. Rewrite it every cycle.
+- **Autonomy boundary**: you decide scheduling, priority, lane composition,
+  and merge order alone. You escalate only outcome/constraint changes,
+  irreversible external actions (publishing, deleting, spending), and genuine
+  blockers.
+
+You do not do the lanes' work. If you catch yourself editing a lane's code
+mid-flight, stop — fix the goal file or relaunch instead.
+
+## Inputs
+
+- `$ARGUMENTS`: the outcome to drive, constraints/deadline, and where the work
+  lives (repos, tracker project, backlog). If empty, ask for the outcome — this
+  skill is inline, so asking is cheap. Do not invent one.
+
+## Instruments (companion scripts — the mechanisms)
+
+Resolve paths via the `skill_directory` returned by `load_skill`; call them as
+`<skill_directory>/scripts/<name>.sh`. **Never copy a script into a target
+repo** (a real run left `.amplifier/bin/` behind as untracked pollution).
+
+| Script | Job | Rule it mechanizes |
+|---|---|---|
+| `highway_status.sh BATCH_DIR WIDTH READY` | ONE call reports every lane + watchdog liveness and **computes DEFICIT by code** | "Keep lanes full" stopped being prose the day a run sat at 1 lane with work for 10 |
+| `launch_lane.sh BATCH_DIR LANE REPO GOAL [BASE_REF]` | Worktree + branch + tmux + `/goal` session, idempotent; the ONLY writer of `manifest.tsv` | Hand-written manifests diverged on column count and broke a real batch |
+| `verify_lane.sh BATCH_DIR LANE` | Git-facts probe for one landed lane (DONE.json, ahead-count, three-dot diffstat, uncommitted work) | "Ground truth from git and the filesystem, not from what any session said about itself" |
+| `highway_watchdog.sh BATCH_DIR WIDTH SESSION_ID [INTERVAL] [MAX_HOURS]` | Detached tmux loop that re-wakes THIS session (`amplifier run --resume`) on lane-end / under-width / stale heartbeat | The highway once froze overnight because the manager stopped monitoring the moment it reported status |
+
+State lives in `BATCH_DIR` (create one per highway, e.g. `~/dev/hw-<name>`):
+`manifest.tsv` (scripts write), `HIGHWAY.md` (you write), `lanes/` (worktrees),
+`.manager-heartbeat`, `wake-needed`, `watchdog.log`.
+
+## Phase 1 — Intake
+
+Establish with the user (from `$ARGUMENTS` plus at most one round of
+questions): the **outcome** in checkable terms, **constraints** (deadline,
+authority boundary, protected repos/paths), **width** (target lane count —
+default 10; ceiling is always ready work), **where work comes from**
+(work-tracker project, backlog file, or decompose-from-outcome), and the
+**completion intent** — how the user wants THIS engagement to end and how to
+treat new work while it runs. This is the user's call to make; capture it, do
+not impose one. Common shapes (not an exhaustive list — honor what they
+actually asked):
+- *Achieve-then-hold:* reach the outcome, then stop building — but stay open to
+  adjustments/new work they send before the deadline, or surface and ask
+  whether to take more on.
+- *Run-to-deadline:* use the whole budget — get the outcome solid first, then
+  keep going, smartly choosing the most valuable beyond-minimum work from the
+  backlog until time is up.
+- *Achieve-and-close:* no live clock; when the outcome is verified and nothing
+  is pending, close.
+Record the captured intent in `HIGHWAY.md` as the engagement's completion
+policy, and honor it with judgment at close (Phase 7).
+
+Create `BATCH_DIR` and write the first `HIGHWAY.md` from
+`examples/operating-picture.md`.
+
+**Success criteria**: `HIGHWAY.md` exists with outcome, constraints, width,
+work source, AND completion intent filled in — not placeholders.
+
+## Phase 2 — Strategize
+
+Decompose toward the outcome into independent, lane-sized items (in the
+work-tracker when available — claim/heartbeat semantics are built for this).
+Collision-check like goal-batch Phase 1: two items wanting the same files
+either fold into one lane or get sole ownership. Order by dependency AND
+strategic value toward the outcome — not arrival order. Mark
+investment/speculative candidates (recon, spikes, de-risking) to backfill idle
+capacity later.
+
+**Success criteria**: a priority queue in `HIGHWAY.md` with a one-line
+rationale per item tied to the outcome/constraints.
+
+## Phase 3 — Approval gate `[human]`
+
+**Human checkpoint — the one mandatory stop. Nothing launches before the user
+says go.** Show on one screen: outcome, width, the first wave of lanes
+(lane → repo → item), the priority rationale, and watch cadence. Accept
+conversational approval ("go", "go, only ping me if it breaks"). Never infer
+approval from enthusiasm or silence.
+
+**Success criteria**: an explicit affirmative from the user.
+
+## Phase 4 — Saturate
+
+For each lane in the first wave:
+1. `load_skill("goalify")` **inline — never delegated** (goalify reads the
+   live transcript; a sub-agent cannot) and compose the lane's stop-condition
+   with a disjunctive exit and per-item residuals.
+2. `launch_lane.sh BATCH_DIR <lane> <repo> <goal-file> [base]`.
+
+Then start the watchdog. **`<BATCH_DIR>`, `<WIDTH>`, `<SESSION_ID>` below are
+documentation placeholders — substitute literal values; they do not exist as
+shell variables.** Your session ID is shown in your environment context
+(`Session ID: ...`). Persist it to disk FIRST so a later watchdog restart does
+not depend on context:
+
+```bash
+printf '%s\n' "<SESSION_ID>" > <BATCH_DIR>/.session-id
+touch <BATCH_DIR>/.manager-heartbeat   # BEFORE the watchdog starts, so it never
+                                        # sees an absent heartbeat and wakes a
+                                        # concurrent instance mid-saturation
+BATCH=$(printf '%s' "$(basename <BATCH_DIR>)" | tr -c 'A-Za-z0-9_-' '_')   # same sanitization the scripts use
+tmux new-session -d -s "hw-watchdog__${BATCH}" \
+  "<skill_directory>/scripts/highway_watchdog.sh <BATCH_DIR> <WIDTH> <SESSION_ID> 300 12 2>&1 | tee -a <BATCH_DIR>/watchdog.log"
+```
+Then touch `<BATCH_DIR>/.manager-heartbeat` again at the start of every Phase 5
+cycle (step 1) and after each merge, so the watchdog defers while your turn is
+active and only takes over once you have genuinely gone idle.
+
+Verify launch: run `highway_status.sh` once — every lane LIVE past its first
+LLM call (log growing), watchdog LIVE. Then build the **todo lane board** (see
+below).
+
+**Success criteria**: status output pasted in the transcript showing all
+launched lanes LIVE, watchdog LIVE, DEFICIT=0.
+
+## Phase 5 — Steady-state cycle (the loop)
+
+Run this on EVERY wake — a delegated watcher returning, a watchdog wake
+(`HIGHWAY WAKE:` prompt), or a user message while lanes run:
+
+**The invariant: while backlog exists, live lanes == width, continuously.** A
+drained lane is refilled the INSTANT it drains — one lane ending is one refill,
+NOT a signal to wait for the whole wave to land. Merging, verifying, reporting,
+and re-strategizing all YIELD to keeping width full. (Graded battery: the
+manager wave-batched — drain 5 → merge+re-test all 5 → then refill — idling
+capacity 135–286s while 15–20 items waited. That is the exact failure this
+invariant exists to prevent.)
+
+1. `touch $BATCH_DIR/.manager-heartbeat`.
+2. Get READY (count of ready, unblocked items) from the work queue.
+3. **Run `highway_status.sh BATCH_DIR WIDTH READY` and paste its output.**
+4. **If `DEFICIT>0`: refill FIRST** — before merging, before reporting, before
+   anything. Pick the top-priority ready items (strategist's choice), goalify
+   each inline, `launch_lane.sh` each. Under-width with ready work is allowed
+   only with an explicit one-line justification in the transcript that cycle.
+5. **Width first, then merge — never the reverse.** Step 4 (restore width)
+   always precedes this. For each ENDED lane: `verify_lane.sh`, then YOUR own
+   artifact check, then `merge --no-ff` from the main checkout, resolve the item
+   with a user-readable reason, tear down (worktree remove, branch delete, tmux
+   kill). **Do NOT serialize a full-suite rerun after every single merge** —
+   that is what idled capacity for minutes in the battery. Instead: run the
+   merged lane's OWN tests immediately (fast proof it landed), and run the FULL
+   suite on a cadence and at close (a periodic + final full sweep catches
+   cross-lane interaction without blocking refill). **If any lane drains during
+   the merge pass, jump back to step 4 and refill BEFORE continuing to merge.**
+   Repair small defects in place or file the honest negative — never let one
+   straggler block the others.
+6. Strategize: process anything new (weave-in log: now / queued / declined,
+   with reasons), re-prioritize, handle STALLED and ENDED-NO-DONE lanes
+   (inspect the lane log tail; relaunch or reassign).
+7. Update the **todo lane board** and rewrite `HIGHWAY.md`. Regenerate its
+   Landed section from git ground truth — `scripts/landed_from_git.sh <repo>
+   [base]` — so the Operating Picture can never drift from what actually merged
+   (proof-run 01: it read "Landed: none" while 10 lanes had merged). Then clear
+   the processed wake signals: `: > <BATCH_DIR>/wake-needed` (advisory file —
+   truncating it is the whole mechanism).
+8. Continue. The first time you reach this step, `load_skill("monitor")` for
+   the polling discipline. Then delegate the watch — `delegate(agent="self",
+   context_depth="none", model_role="fast")` — with an instruction that
+   includes ALL of:
+   - the exact loop: sleep `<interval>`, then ONE
+     `highway_status.sh <BATCH_DIR> <WIDTH> <READY>` call, repeat up to N times;
+   - **SEQUENTIAL-ONLY — never issue checks in parallel** (a batched watcher
+     once issued 15 simultaneous checks sampling the same instant and
+     reported success);
+   - return the moment any lane ENDs, `DEFICIT>0`, or a flag appears, reporting
+     **observations only, no verdicts**;
+   - the return message leads with a state token (`DONE:` / `NEEDS YOU:` /
+     `GAVE UP:`) in its first 100 characters;
+   - sanity check: elapsed wall time must be ≈ interval × checks —
+     suspiciously cheap means the loop lied.
+   Or, if the user needs to hear something, go to Phase 6.
+
+**Success criteria**: every cycle leaves status output in the transcript,
+DEFICIT=0 (or justified), board + `HIGHWAY.md` current, heartbeat fresh.
+
+### The todo lane board (user-facing visibility)
+
+The todo tool is the live dashboard the user watches. Maintain: one item per
+lane — `Lane <n> [<repo>]: <work item>` — `in_progress` while running,
+`completed` at merge; plus one `Highway <batch>: cycle <k> — <one-line state>`
+item. Update it in step 7 of every cycle, not sporadically. The todo board,
+the `HIGHWAY.md` lane board, and the manifest must agree at the end of every
+cycle.
+
+## Phase 6 — Talking to the human without freezing the highway
+
+The documented failure: the manager reported status and the highway froze
+until morning. Before ANY turn-ending message while lanes run:
+
+1. `highway_status.sh` must show `watchdog=LIVE` — if DEAD, start it (Phase 4
+   command; the session ID is in `<BATCH_DIR>/.session-id`) and re-check.
+   **Never end a turn with the watchdog dead while lanes are live.**
+2. The todo lane board is current.
+3. The message leads with a state token in the first 100 characters —
+   `DONE:` / `NEEDS YOU:` / `PAUSED:` / or a one-line highway status — because
+   the notification renders from those characters.
+
+The watchdog will re-wake you on lane-end, under-width, or stale heartbeat;
+each wake runs Phase 5.
+
+## Phase 7 — Close the highway
+
+Close **per the engagement's captured completion intent (Phase 1) — never
+reflexively at the first "outcome looks green."** If a deadline or expected new
+work is still live and the intent is *achieve-then-hold* or *run-to-deadline*,
+do NOT tear down capacity: keep the watchdog alive and keep polling for new
+work; put spare lanes on the next-most-valuable backlog items (harden the
+outcome, absorb injected bugs/requirements) — or, if the intent says so,
+surface to the user (Phase 6) and ask whether to continue. Tearing down the
+watchdog and lanes the moment current acceptance passes is the documented
+"coasts once it thinks it's done" failure (strategist trial 01: it closed 10
+min before the deadline and missed four injected items). **Enter the teardown
+below ONLY when the captured intent's end condition is actually met** — the
+deadline reached, the user's release given, or (for *achieve-and-close*) the
+outcome verified with nothing pending.
+
+When you close: final Phase 5 pass; merge
+or honestly disposition every open lane; kill the watchdog by the exact
+name `highway_status.sh` reports (`tmux kill-session -t <wd_name>`). **Archive
+the per-lane evidence BEFORE pruning** — pruning the lane dirs otherwise deletes
+`lane.log` and the markers with them:
+```bash
+mkdir -p <BATCH_DIR>/logs
+for d in <BATCH_DIR>/lanes/*/; do L=$(basename "$d"); \
+  cp "$d/lane.log" "<BATCH_DIR>/logs/$L.log" 2>/dev/null; \
+  cp "$d/DONE.json" "<BATCH_DIR>/logs/$L.DONE.json" 2>/dev/null; done
+```
+Then prune worktrees and branches; do a final `HIGHWAY.md` rewrite (outcome
+status, landed list from `landed_from_git.sh`, residuals with named reasons);
+report with `DONE:` or `GAVE UP:` leading.
+
+**Success criteria**: no `hw__` tmux sessions, no stray worktrees/branches,
+final report matches git facts.
+
+## Rules — each bought with a documented failure
+
+1. **The deficit is computed, not noticed.** Run the instrument first on every
+   wake; trust its number over your impression. (A real run sat at 1 lane —
+   "we want to keep all 10 going" — because fullness was prose.)
+2. **Refill before anything else when DEFICIT>0.** (Nine lanes done, one
+   straggler, two hours of idle capacity — the trail-off that named this
+   pattern.)
+3. **Never end a turn with the watchdog dead while lanes run.** (An overnight
+   status report froze the whole highway until morning.)
+4. **Watchers report observations; only your own artifact check promotes to
+   proven.** (A monitor fabricated a PASS verdict from a log fragment.)
+5. **Completion is git facts, never self-report.** Prove a merge with the merged
+   lane's OWN tests immediately; run the FULL suite on a cadence and at close —
+   NOT serialized after every single merge (that idles width; see the Phase 5
+   invariant). (Two lanes reported green honestly from a suite run that predated
+   their own last file — so verify per-lane at merge AND full-sweep before DONE.)
+6. **One instrument call per poll; delegated watchers are SEQUENTIAL-ONLY.**
+   (A child once issued 15 simultaneous checks sampling the same instant and
+   reported success.)
+7. **The approval gate is not skippable.** No launch without an explicit go.
+8. **goalify runs inline, never delegated** — it must read the live transcript.
+9. **Nothing silent in the strategy.** Every accept/defer/decline of incoming
+   work lands in the weave-in log. (The vision living only "implicitly in the
+   conversation" is the documented weakness this file exists to fix.)
+10. **The script owns the manifest. Never hand-write it.**
+11. **Speculative lanes only after the critical path is saturated, and label
+    them.** Spare capacity is an investment budget, not a reason to pad.
+12. **Lanes never merge to main; the orchestrator merges.** One repo per lane;
+    live shared services are read-only to lanes.
+13. **If `$ARGUMENTS` is empty, ask** — do not invent an outcome. (The fork
+    sibling of this failure killed a real goal-batch invocation silently.)
+
+## Known limits / v2 mechanisms (noted, not built)
+
+- A hook that injects `highway_status.sh` output into every turn (the way the
+  todo reminder does) would make drift structurally impossible to ignore —
+  requires bundle work.
+- `amplifier run --resume` wakes are best-effort against a session mid-turn;
+  the `wake-needed` file is the durable fallback signal.
+- Deeper work-tracker integration (auto-READY counts) would remove the one
+  hand-carried number in the status call.

--- a/amplifier_app_cli/data/skills/ten-lane-highway/examples/operating-picture.md
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/examples/operating-picture.md
@@ -1,0 +1,50 @@
+# HIGHWAY.md — Operating Picture (template)
+
+The strategist's externalized brain. Continually REWRITTEN (no changelog — the
+current picture, always). Lives in BATCH_DIR. This file is the answer to the
+documented weakness: "the vision exists implicitly in the conversation... not
+one continually maintained artifact describing the current end-state."
+
+```markdown
+# Highway: <batch-name>
+Updated: <UTC timestamp> (rewrite this file every cycle)
+
+## Outcome (the destination)
+<The user's defined outcome/goal, in checkable terms. What "arrived" looks like.>
+
+## Constraints
+- Deadline / time budget: <e.g. "fresh-install candidate by Friday">
+- Authority boundary: <what the manager decides alone vs. escalates>
+- Resources: width target = <N> lanes; model/rate notes; protected paths/repos.
+
+## Current state (one paragraph)
+<Where the effort stands right now, in plain language.>
+
+## Lane board (mirrors the todo list)
+| Lane | Repo | Work item | Status | Since |
+|---|---|---|---|---|
+| 1 <name> | <repo> | <item> | running / verifying / merging | <ts> |
+| ... | | | | |
+Open slots: <n>  ·  Ready queue: <n>  ·  Deficit last cycle: <n>
+
+## Priority queue + rationale (the strategy)
+1. <item> — <why it is next, tied to Outcome/Constraints>
+2. ...
+Speculative/investment lanes (only when critical path is saturated): <recon/spike items>
+
+## Weave-in log (incoming work decisions — nothing silent)
+| When | What arrived | Decision (now / queued@prio / declined) | Why |
+|---|---|---|---|
+
+## Risks / blockers / needs-user
+- <blocker> — <what would unblock it; escalated? y/n>
+
+## Landed (this highway)
+- <lane> -> <repo> @ <sha> — <verified-by-me note>
+```
+
+Rules for this file:
+- The ORCHESTRATOR writes it (scripts own manifest.tsv; this file owns strategy).
+- Rewrite, don't append — stale sections are worse than missing ones.
+- Every accept/defer/decline of new incoming work MUST land in the weave-in log.
+- The lane board here and the todo tool must agree at the end of every cycle.

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# highway_status.sh — THE instrument. One call reports every lane AND computes the deficit.
+#
+# Usage: highway_status.sh BATCH_DIR WIDTH READY
+#   WIDTH  target lane count (the number written in HIGHWAY.md)
+#   READY  count of ready, unblocked work items (read it from the work queue and pass it)
+#
+# The deficit is COMPUTED HERE, BY CODE — never "noticed" by a model.
+#   deficit = min(READY, max(0, WIDTH - live))
+# If DEFICIT > 0 the correct next action is always: refill, before anything else.
+set -euo pipefail
+
+BATCH_DIR=${1:?BATCH_DIR required}
+WIDTH=${2:?WIDTH required}
+READY=${3:?READY required (ready unblocked work item count)}
+
+MANIFEST="$BATCH_DIR/manifest.tsv"
+STALL_SECS=${HIGHWAY_STALL_SECS:-900}
+# HIGHWAY_JSON=1 -> emit ONE compact JSON line and nothing else (for the eval's
+# M1 sampler daemon: `HIGHWAY_JSON=1 highway_status.sh ... >> deficit.jsonl`).
+JSON=${HIGHWAY_JSON:-0}
+# Same sanitization as launch_lane.sh — the watchdog name must match byte-for-byte.
+# (stat -c %Y below is GNU/Linux; adjust for macOS if this ever travels.)
+BATCH=$(printf '%s' "$(basename "$BATCH_DIR")" | tr -c 'A-Za-z0-9_-' '_')
+[ -f "$MANIFEST" ] || { echo "ERROR: no manifest at $MANIFEST (launch_lane.sh creates it)" >&2; exit 1; }
+
+now=$(date +%s)
+live=0; ended=0; done_n=0; stalled=0; gone=0
+
+[ "$JSON" = 1 ] || printf '%-20s %-6s %-9s %-6s %-5s %-14s %s\n' LANE TMUX LOG_AGE AHEAD DONE FLAG WORKTREE
+while IFS=$'\t' read -r lane wt branch base tmuxn goal log ts; do
+  [ "$lane" = "lane" ] && continue
+
+  if tmux has-session -t "$tmuxn" 2>/dev/null; then st=LIVE; else st=ENDED; fi
+
+  age="-"; ahead="-"; dj="-"; wt_present=yes
+  if [ -d "$wt" ]; then
+    if [ -f "$log" ]; then age="$(( now - $(stat -c %Y "$log") ))s"; fi
+    ahead=$(git -C "$wt" rev-list --count "$base..HEAD" 2>/dev/null || echo "?")
+    if [ -f "$(dirname "$wt")/DONE.json" ]; then dj=yes; else dj=no; fi
+  else
+    wt_present=no
+  fi
+
+  flag=""
+  if [ "$st" = "LIVE" ]; then
+    # A live tmux session counts as a live lane even if its worktree vanished —
+    # that is an anomaly to flag, not a lane to ignore.
+    live=$((live+1))
+    if [ "$wt_present" = "no" ]; then flag="NO-WORKTREE"; fi
+    if [ "$age" != "-" ] && [ "${age%s}" -gt "$STALL_SECS" ]; then flag="STALLED"; stalled=$((stalled+1)); fi
+  else
+    if [ "$wt_present" = "no" ]; then
+      st="GONE"   # ended + worktree removed = normal post-teardown terminal state
+      gone=$((gone+1))
+    else
+      ended=$((ended+1))
+      if [ "$dj" = "no" ]; then flag="ENDED-NO-DONE"; fi
+    fi
+  fi
+  if [ "$dj" = "yes" ]; then done_n=$((done_n+1)); fi
+
+  [ "$JSON" = 1 ] || printf '%-20s %-6s %-9s %-6s %-5s %-14s %s\n' "$lane" "$st" "$age" "$ahead" "$dj" "$flag" "$wt"
+done < "$MANIFEST"
+
+WD="hw-watchdog__${BATCH}"
+if tmux has-session -t "$WD" 2>/dev/null; then wd_st=LIVE; else wd_st=DEAD; fi
+
+open=$(( WIDTH - live )); if [ "$open" -lt 0 ]; then open=0; fi
+if [ "$READY" -lt "$open" ]; then deficit=$READY; else deficit=$open; fi
+
+if [ "$JSON" = 1 ]; then
+  printf '{"ts":"%s","batch":"%s","live":%d,"ended":%d,"done_marker":%d,"stalled":%d,"gone":%d,"width":%d,"ready":%d,"deficit":%d,"watchdog":"%s"}\n' \
+    "$(date -u +%FT%TZ)" "$BATCH" "$live" "$ended" "$done_n" "$stalled" "$gone" "$WIDTH" "$READY" "$deficit" "$wd_st"
+  exit 0
+fi
+
+echo
+echo "SUMMARY batch=$BATCH live=$live ended=$ended done_marker=$done_n stalled=$stalled gone=$gone width=$WIDTH ready=$READY watchdog=$wd_st"
+echo "DEFICIT=$deficit"
+if [ "$deficit" -gt 0 ]; then
+  echo "ACTION: launch $deficit lane(s) NOW - refill before anything else."
+fi
+if [ "$wd_st" = "DEAD" ]; then
+  echo "WARNING: watchdog $WD is not running - do not end the turn until it is."
+fi

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_watchdog.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_watchdog.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# highway_watchdog.sh — the loop that cannot be broken by conversation.
+#
+# Keeps watching lanes while the manager's turn is ended (e.g. it stopped to
+# talk to the human). Wakes the orchestrator session when attention is needed.
+#
+# Run it DETACHED in its own tmux session (the launcher is the orchestrator):
+#   tmux new-session -d -s "hw-watchdog__<batch>" \
+#     "<skill_dir>/scripts/highway_watchdog.sh BATCH_DIR WIDTH SESSION_ID [INTERVAL] [MAX_HOURS]"
+#
+# Wake triggers: a lane ended since last poll | live < WIDTH | manager heartbeat stale.
+# Wake path: `amplifier run --resume SESSION_ID "<wake prompt>"` (verified CLI flag),
+# plus a durable `wake-needed` file in BATCH_DIR in case the resume fails.
+# The orchestrator touches BATCH_DIR/.manager-heartbeat every cycle and deletes
+# wake-needed entries it has processed.
+set -uo pipefail   # deliberately NOT -e: the watch loop must survive transient failures
+
+BATCH_DIR=${1:?BATCH_DIR required}
+WIDTH=${2:?WIDTH required}
+SESSION_ID=${3:?SESSION_ID required (the orchestrator session to wake)}
+INTERVAL=${4:-300}
+MAX_HOURS=${5:-12}
+
+MANIFEST="$BATCH_DIR/manifest.tsv"
+LOGF="$BATCH_DIR/watchdog.log"
+STATE="$BATCH_DIR/.watchdog-state"
+HB="$BATCH_DIR/.manager-heartbeat"
+HB_MAX=${HIGHWAY_HEARTBEAT_MAX:-1800}
+WAKE_GAP=${HIGHWAY_WAKE_GAP:-180}
+# If the manager's heartbeat is fresher than this, its foreground turn is still
+# active and will handle refill/merge inline. Waking then spawns a SECOND
+# concurrent instance of the same session (observed race, fix-verify run) -- so
+# defer every wake while the heartbeat is fresh.
+ACTIVE_WINDOW=${HIGHWAY_ACTIVE_WINDOW:-120}
+# stat -c %Y below is GNU/Linux; adjust for macOS if this ever travels.
+
+deadline=$(( $(date +%s) + MAX_HOURS * 3600 ))
+START_TS=$(date +%s)
+# Grace after watchdog start during which an ABSENT heartbeat means "manager
+# still warming up in Phase 4" (not "manager dead") -> defer waking. Closes the
+# pre-first-heartbeat race window (graded trial 01).
+GRACE=${HIGHWAY_HB_GRACE:-300}
+last_wake=0
+
+log() { echo "$(date -u +%FT%TZ) $*" >> "$LOGF"; }
+
+live_lanes() {
+  local n=0 lane wt branch base tmuxn rest
+  while IFS=$'\t' read -r lane wt branch base tmuxn rest; do
+    [ "$lane" = "lane" ] && continue
+    tmux has-session -t "$tmuxn" 2>/dev/null && n=$((n+1))
+  done < "$MANIFEST"
+  echo "$n"
+}
+
+ended_list() {
+  local lane wt branch base tmuxn rest
+  while IFS=$'\t' read -r lane wt branch base tmuxn rest; do
+    [ "$lane" = "lane" ] && continue
+    tmux has-session -t "$tmuxn" 2>/dev/null || echo "$lane"
+  done < "$MANIFEST"
+}
+
+wake() {
+  local reason="$1" now
+  now=$(date +%s)
+  if [ $(( now - last_wake )) -lt "$WAKE_GAP" ]; then
+    log "suppress wake (within ${WAKE_GAP}s gap): $reason"
+    return 0
+  fi
+  printf '%s\t%s\n' "$(date -u +%FT%TZ)" "$reason" >> "$BATCH_DIR/wake-needed"
+  log "WAKE: $reason"
+  if amplifier run --resume "$SESSION_ID" --output-format json \
+    "HIGHWAY WAKE (watchdog): $reason. Run one steady-state cycle now: highway_status.sh FIRST, verify+merge any landed lane, refill to width, update HIGHWAY.md and the todo lane board, touch the heartbeat, clear wake-needed. Do not end the turn while DEFICIT>0 or the watchdog is dead." \
+    >> "$LOGF" 2>&1; then
+    log "wake delivered (resume ok)"
+    last_wake=$now
+  else
+    # Deliberately NOT updating last_wake on failure: a failed wake must not
+    # suppress the retry on the next poll the way a successful one would.
+    log "wake FAILED (resume rc=$?) - wake-needed file left as the durable signal; will retry next poll"
+  fi
+}
+
+log "watchdog start batch=$BATCH_DIR width=$WIDTH session=$SESSION_ID interval=${INTERVAL}s max=${MAX_HOURS}h hb_max=${HB_MAX}s"
+touch "$STATE"
+
+while :; do
+  sleep "$INTERVAL"
+
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    wake "watchdog max runtime (${MAX_HOURS}h) reached - restart me if the highway is still open"
+    log "exit: deadline reached"
+    exit 0
+  fi
+
+  [ -f "$MANIFEST" ] || { log "no manifest yet at $MANIFEST"; continue; }
+
+  live=$(live_lanes)
+  ended_now=$(ended_list | sort)
+  ended_prev=$(sort "$STATE" 2>/dev/null || true)
+  new_ended=$(comm -13 <(printf '%s\n' "$ended_prev") <(printf '%s\n' "$ended_now") | tr '\n' ' ')
+  printf '%s\n' "$ended_now" > "$STATE"
+
+  if [ -f "$HB" ]; then
+    hb_age=$(( $(date +%s) - $(stat -c %Y "$HB") ))
+  else
+    hb_age=-1   # heartbeat not created yet
+  fi
+  wd_uptime=$(( $(date +%s) - START_TS ))
+  log "poll live=$live width=$WIDTH new_ended='${new_ended}' hb_age=${hb_age}s uptime=${wd_uptime}s"
+
+  # Manager's turn is active -> it handles refill/merge inline; do NOT wake (a
+  # second concurrent --resume instance was the proof-run-02/trial-01 race).
+  # Active = a FRESH heartbeat, OR no heartbeat yet but the watchdog only just
+  # started (manager still in Phase 4, before its first touch).
+  if { [ "$hb_age" -ge 0 ] && [ "$hb_age" -lt "$ACTIVE_WINDOW" ]; } \
+     || { [ "$hb_age" -lt 0 ] && [ "$wd_uptime" -lt "$GRACE" ]; }; then
+    log "manager active (hb_age=${hb_age}s, uptime=${wd_uptime}s) - deferring wake"
+    continue
+  fi
+  # Heartbeat absent beyond the grace window = manager never checked in =
+  # treat as stale so the safety-net wakes below still fire.
+  [ "$hb_age" -lt 0 ] && hb_age=$(( HB_MAX + 1 ))
+
+  if [ -n "${new_ended// /}" ]; then wake "lane(s) ended: ${new_ended}"; continue; fi
+  if [ "$live" -lt "$WIDTH" ]; then wake "under width: live=$live < width=$WIDTH"; continue; fi
+  if [ "$hb_age" -gt "$HB_MAX" ] && [ "$live" -gt 0 ]; then
+    wake "manager heartbeat stale (${hb_age}s) with $live live lanes"
+  fi
+done

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/landed_from_git.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/landed_from_git.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# landed_from_git.sh — regenerate the "Landed" list from git ground truth, so
+# HIGHWAY.md's Operating Picture can never drift from what actually merged
+# (proof-run 01: HIGHWAY.md said "Landed: none" while 10 lanes had merged).
+#
+# Usage: landed_from_git.sh REPO [BASE_BRANCH]
+# Emits markdown lines for the Landed section; paste into HIGHWAY.md each cycle.
+set -euo pipefail
+REPO=${1:?REPO required}
+BASE=${2:-main}
+
+n=$(git -C "$REPO" rev-list --count --merges "$BASE" 2>/dev/null || echo 0)
+echo "## Landed (git ground truth: $n merges on $BASE)"
+git -C "$REPO" log --merges --first-parent "$BASE" \
+  --pretty=format:'- %h %s (%cI)' 2>/dev/null || true
+echo

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/launch_lane.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/launch_lane.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# launch_lane.sh — start ONE highway lane: worktree + branch + tmux + autonomous /goal session.
+#
+# Usage: launch_lane.sh BATCH_DIR LANE REPO_PATH GOAL_FILE [BASE_REF]
+#   BATCH_DIR  directory holding this highway's state (manifest, logs, lanes/)
+#   LANE       kebab-case lane name (becomes branch lane/<LANE> and tmux hw__<batch>__<LANE>)
+#   REPO_PATH  path to the repo this lane owns
+#   GOAL_FILE  path to the goalify-composed goal file for this lane
+#   BASE_REF   ref to branch from (default: main)
+#
+# This script is the ONLY writer of manifest.tsv. Never hand-write the manifest.
+# Idempotent: re-running skips an existing worktree / running tmux session.
+set -euo pipefail
+
+BATCH_DIR=${1:?BATCH_DIR required}
+LANE=${2:?LANE required}
+REPO=${3:?REPO_PATH required}
+GOAL=${4:?GOAL_FILE required}
+BASE_REF=${5:-main}
+
+# tmux treats '.' and ':' specially in -t targets: a name built from a raw
+# basename may not round-trip through later has-session checks. Sanitize the
+# batch identifier and REQUIRE clean lane names, so the name we create is
+# byte-identical to the name every later check looks up.
+BATCH=$(printf '%s' "$(basename "$BATCH_DIR")" | tr -c 'A-Za-z0-9_-' '_')
+case "$LANE" in
+  ''|*[!A-Za-z0-9_-]*) echo "ERROR: LANE must match [A-Za-z0-9_-]+ (got: '$LANE')" >&2; exit 1 ;;
+esac
+MANIFEST="$BATCH_DIR/manifest.tsv"
+LANES_ROOT=${HIGHWAY_LANES_ROOT:-"$BATCH_DIR/lanes"}
+
+REPO=$(cd "$REPO" && pwd)
+[ -f "$GOAL" ] || { echo "ERROR: goal file not found: $GOAL" >&2; exit 1; }
+GOAL=$(cd "$(dirname "$GOAL")" && pwd)/$(basename "$GOAL")
+
+TMUX_NAME="hw__${BATCH}__${LANE}"
+WT="$LANES_ROOT/$LANE/$(basename "$REPO")"
+BRANCH="lane/$LANE"
+# Resolved BEFORE the worktree-exists check on purpose: a vanished/renamed
+# BASE_REF should fail loud even on an idempotent relaunch.
+BASE_SHA=$(git -C "$REPO" rev-parse "$BASE_REF")
+LANE_DIR="$LANES_ROOT/$LANE"
+# Terminal marker AND the lane log live OUTSIDE the git worktree (in the lane
+# dir), so a lane's own `git add -A` can never stage the marker and collide at
+# merge time (proof-run 01), and the log survives worktree teardown for capture
+# (graded trial 01).
+DONE_MARKER="$LANE_DIR/DONE.json"
+LOG="$LANE_DIR/lane.log"
+
+mkdir -p "$BATCH_DIR" "$LANES_ROOT/$LANE"
+[ -f "$MANIFEST" ] || printf 'lane\tworktree\tbranch\tbase_sha\ttmux\tgoal\tlog\tlaunched_at\n' > "$MANIFEST"
+
+# Worktree — idempotent (skip-if-exists, never fail-if-exists)
+if [ ! -d "$WT" ]; then
+  git -C "$REPO" worktree add -b "$BRANCH" "$WT" "$BASE_SHA" 2>/dev/null \
+    || git -C "$REPO" worktree add "$WT" "$BRANCH"
+fi
+
+# Purge inherited terminal markers (a stale marker is a false-positive machine)
+rm -f "$DONE_MARKER" "$WT/DONE.json"
+
+# Belt-and-suspenders: keep lane scaffolding out of git even if a lane tries.
+EXCL="$(git -C "$WT" rev-parse --path-format=absolute --git-common-dir)/info/exclude"
+for p in GOAL.md DONE.json lane.log; do
+  grep -qxF "$p" "$EXCL" 2>/dev/null || echo "$p" >> "$EXCL"
+done
+
+# The lane's goal rides in the worktree root; append the marker instruction so
+# the lane writes its terminal marker OUTSIDE the repo, never inside it.
+cp "$GOAL" "$WT/GOAL.md"
+cat >> "$WT/GOAL.md" <<EOF
+
+---
+LANE COMPLETION MARKER (highway): when the goal is met, write your terminal
+marker to the ABSOLUTE path below — it is OUTSIDE this repo on purpose. Do NOT
+create, stage, or commit any DONE.json inside this repository; it collides at
+merge time.
+  $DONE_MARKER
+EOF
+
+if tmux has-session -t "$TMUX_NAME" 2>/dev/null; then
+  echo "SKIP: $TMUX_NAME already running"
+else
+  tmux new-session -d -s "$TMUX_NAME" -c "$WT" \
+    "amplifier run '/goal @GOAL.md' 2>&1 | tee '$LOG'"
+  echo "LAUNCHED: $TMUX_NAME -> $WT ($BRANCH @ ${BASE_SHA:0:8})"
+fi
+
+# Manifest row — append once (this script is the manifest's only writer)
+if ! awk -F'\t' -v l="$LANE" 'NR>1 && $1==l{found=1} END{exit !found}' "$MANIFEST"; then
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+    "$LANE" "$WT" "$BRANCH" "$BASE_SHA" "$TMUX_NAME" "$GOAL" "$LOG" "$(date -u +%FT%TZ)" >> "$MANIFEST"
+fi

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/verify_lane.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/verify_lane.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# verify_lane.sh — git-facts probe for ONE lane. Reports ground truth; never merges.
+#
+# Usage: verify_lane.sh BATCH_DIR LANE
+#
+# "I need ground truth from git and the filesystem, not from what any session
+# said about itself." Lane self-reports (including DONE.json) are hints — the
+# orchestrator merges only after ITS OWN check of these facts, and re-runs the
+# suite itself after the merge.
+set -euo pipefail
+
+BATCH_DIR=${1:?BATCH_DIR required}
+LANE=${2:?LANE required}
+MANIFEST="$BATCH_DIR/manifest.tsv"
+
+row=$(awk -F'\t' -v l="$LANE" 'NR>1 && $1==l' "$MANIFEST" || true)
+[ -n "$row" ] || { echo "ERROR: lane '$LANE' not in manifest $MANIFEST" >&2; exit 1; }
+IFS=$'\t' read -r lane wt branch base tmuxn goal log ts <<< "$row"
+
+echo "== lane=$lane branch=$branch base=${base:0:8} wt=$wt"
+if tmux has-session -t "$tmuxn" 2>/dev/null; then
+  echo "TMUX: LIVE (still running - do NOT merge yet)"
+else
+  echo "TMUX: ended"
+fi
+if [ ! -d "$wt" ]; then echo "WORKTREE: GONE (already merged+removed, or never created)"; exit 0; fi
+
+echo "-- DONE.json (lane dir, OUTSIDE the repo):"
+lane_marker="$(dirname "$wt")/DONE.json"
+if [ -f "$lane_marker" ]; then cat "$lane_marker"; else echo "(absent)"; fi
+
+echo "-- uncommitted (would be LOST on worktree prune - flag loudly if non-empty):"
+git -C "$wt" status --short | head -20
+
+echo "-- commits ahead of base: $(git -C "$wt" rev-list --count "$base..HEAD")"
+mb=$(git -C "$wt" merge-base "$base" HEAD)
+echo "-- diffstat merge-base..HEAD (three-dot truth; two-dot lies after base moves):"
+git -C "$wt" diff --stat "$mb..HEAD" | tail -15
+
+echo "-- last 3 commits:"
+git -C "$wt" log --oneline -3
+
+echo "REMINDER: merge --no-ff from the MAIN checkout, ascending by churn; re-run the suite YOURSELF after EVERY merge."

--- a/amplifier_app_cli/runtime/config.py
+++ b/amplifier_app_cli/runtime/config.py
@@ -93,6 +93,13 @@ async def resolve_bundle_config(
         # always match the running CLI version.
         compose_behaviors.extend(_build_app_cli_behaviors())
 
+        # Skills system (tool-skills module + curated Microsoft skills
+        # collection + visibility config + context instructions). Always
+        # composed, regardless of base bundle, so a tool-skills entry always
+        # exists for _ensure_default_skills_dirs() to append the CLI's own
+        # packaged skills dir onto.
+        compose_behaviors.extend(_build_skills_behaviors())
+
         # Notification behaviors (desktop and push notifications). The flags
         # object is the single source of truth for "is this enabled?" — the
         # hook-override emitter in AppSettings.get_notification_hook_overrides()
@@ -901,6 +908,26 @@ def _build_modes_behaviors() -> list[str]:
     return [
         # Only load the behavior, NOT the root bundle (which includes foundation)
         "git+https://github.com/microsoft/amplifier-bundle-modes@main#subdirectory=behaviors/modes.yaml",
+    ]
+
+
+def _build_skills_behaviors() -> list[str]:
+    """Return the skills behavior URI for composition.
+
+    Always composes amplifier-bundle-skills' tool-skills module + curated
+    Microsoft skills collection + visibility config + context instructions,
+    regardless of which base bundle the user selected. This guarantees a
+    tool-skills entry always exists in the final merged tools list, so
+    _ensure_default_skills_dirs() always has an entry to append the CLI's own
+    packaged skills dir onto -- previously that depended on incidentally
+    getting tool-skills from whatever other bundle (e.g. foundation) the user
+    happened to compose.
+    """
+    return [
+        # Only the behavior, NOT the root bundle.md (which would pull foundation
+        # and could clobber the user's system prompt -- same reasoning as
+        # _build_modes_behaviors / _build_app_cli_behaviors).
+        "git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=behaviors/skills.yaml",
     ]
 
 


### PR DESCRIPTION
## What
Move the `/goal`-family skills to live beside the `/goal` command they depend on, and make app-cli always compose the shared skills behavior so a stock install still gets the full curated skills collection.

- Adds `goal-batch` and `ten-lane-highway` to `amplifier_app_cli/data/skills/` (`goalify` already shipped here).
- Adds `_build_skills_behaviors()` in `runtime/config.py` (same convention as `_build_modes_behaviors()`), so app-cli always composes `amplifier-bundle-skills`' `behaviors/skills.yaml` — tool-skills module + curated Microsoft skills collection + visibility + context instructions — regardless of the base bundle. The existing `_ensure_default_skills_dirs()` then appends app-cli's own packaged `data/skills` dir.

## Why
These skills require the `/goal` command, which lives in app-cli. Shipping them here keeps them version-locked to the CLI that provides `/goal`. Composing the skills behavior guarantees a `tool-skills` entry always exists so both app-cli's packaged skills AND the curated collection load together, and cross-source dependencies (e.g. `ten-lane-highway` → `monitor`, which stays in amplifier-bundle-skills) resolve.

## Paired change
Paired with microsoft/amplifier-bundle-skills PR that removes these `/goal`-dependent skills from the bundle (keeping `monitor`, which has no `/goal` dependency). That PR link will be added as a comment.

## Validation
Verified end-to-end in a Digital Twin Universe (modified app-cli + modified skills-bundle, url-rewritten to the modified bundle): fresh stock install loads BOTH sources, `goalify`/`goal-batch`/`ten-lane-highway` appear exactly once each (from app-cli's wheel), `monitor` + `ten-lane-highway` co-load in one session, `/highway` shortcut present. 6/6 checks passed, zero duplicates.