### PR TITLE
feat: auto-compose the public wayfinder channel on every session

### DIFF
--- a/amplifier_app_cli/runtime/config.py
+++ b/amplifier_app_cli/runtime/config.py
@@ -100,6 +100,15 @@ async def resolve_bundle_config(
         # packaged skills dir onto.
         compose_behaviors.extend(_build_skills_behaviors())
 
+        # Wayfinder (in-session guidance channel). Always composed so every
+        # user gets the public wayfinder channel by default -- not just those
+        # who add an internal app bundle (e.g. made-support) that also brings
+        # it. Only the PUBLIC behavior is composed here; internal content packs
+        # ride separately via made-support's own hooks-wayfinder content_sources
+        # config, which layers on AFTER this (app bundles compose last), so no
+        # internal content leaks into the public default.
+        compose_behaviors.extend(_build_wayfinder_behaviors())
+
         # Notification behaviors (desktop and push notifications). The flags
         # object is the single source of truth for "is this enabled?" — the
         # hook-override emitter in AppSettings.get_notification_hook_overrides()
@@ -928,6 +937,30 @@ def _build_skills_behaviors() -> list[str]:
         # and could clobber the user's system prompt -- same reasoning as
         # _build_modes_behaviors / _build_app_cli_behaviors).
         "git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=behaviors/skills.yaml",
+    ]
+
+
+def _build_wayfinder_behaviors() -> list[str]:
+    """Return the wayfinder behavior URI for composition.
+
+    Wayfinder is an in-session guidance channel: it surfaces one authored,
+    curated tip per session and offers capabilities the user already has,
+    always behind an explicit propose -> show -> ack -> act gate. Composed on
+    every session so the PUBLIC channel reaches every user by default --
+    previously it only reached users who had added an internal app bundle
+    (made-support) that happened to bring it.
+
+    Only the PUBLIC behavior is composed here. Internal/team content packs
+    (e.g. amplifier-online) are NOT included: they ride separately through
+    made-support's own hooks-wayfinder ``content_sources`` config, which
+    composes AFTER app bundles and deep-merges its extra content source onto
+    this hook -- so nothing internal leaks into the public default.
+    """
+    return [
+        # Only the behavior, NOT the root bundle.md (which would pull foundation
+        # and could clobber the user's system prompt -- same reasoning as
+        # _build_modes_behaviors / _build_skills_behaviors).
+        "git+https://github.com/microsoft/amplifier-bundle-wayfinder@main#subdirectory=behaviors/wayfinder.yaml",
     ]
 
 


### PR DESCRIPTION
## What

Makes the **public wayfinder** in-session guidance channel a shipped default for **every** Amplifier CLI user — not just those who have the internal `made-support` bundle in their `bundle.app` settings.

Adds `_build_wayfinder_behaviors()` and wires it into `resolve_bundle_config()` alongside the existing `modes` / `skills` / `cli-expertise` Tier-A defaults, so every session composes:

```
git+https://github.com/microsoft/amplifier-bundle-wayfinder@main#subdirectory=behaviors/wayfinder.yaml
```

## Why

Wayfinder surfaces one authored, curated tip per session and offers capabilities the user already has, always behind an explicit propose → show → ack → act gate. It previously only reached users who had added the internal `made-support` app bundle. This makes the public channel reach everyone by default, matching how `modes` and `skills` already ship.

## No internal content leaks

Only the **PUBLIC** behavior is composed here. Internal/team content packs (e.g. `amplifier-online`) are **not** included — they ride separately through `made-support`'s own `hooks-wayfinder` `content_sources` config, which composes **after** app bundles and deep-merges its extra content source onto the hook. Composing wayfinder twice (this app default + `made-support`) is idempotent: foundation merges modules by id, so the internal `content_sources.made` still layers on top for internal users, and nothing internal appears for public users.

## Validation

Verified in a Digital Twin Universe representing a **made-support-free public user** (no `bundle.app`), with the CLI built from this branch's source:

- **Auto-inclusion:** `amplifier run "Hi"` auto-surfaces a wayfinder offer with no config.
- **Menu works:** the full wayfinder offer menu renders (goal, goal-batch, monitor, switch-models, review-councils, …).
- **No leak:** `amplifier-online` is **absent** from the public menu (0 matches).

`pyright` clean on the modified file.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>