### PR TITLE
feat(session): record invocation provenance on the root session's mount plan

### DIFF
--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -3480,6 +3480,10 @@ async def interactive_chat(
         bundle_name=bundle_name,
         initial_transcript=initial_transcript,
         prepared_bundle=prepared_bundle,
+        # Resolved mode: reaching interactive_chat() IS the resolution -- run.py
+        # dispatches here only after collapsing --mode, prompt presence, and pipe
+        # presence into "chat".
+        invocation_mode="chat",
     )
 
     # Create fully initialized session (handles all setup including resume)
@@ -4146,6 +4150,10 @@ async def execute_single(
         initial_transcript=initial_transcript,
         prepared_bundle=prepared_bundle,
         output_format=output_format,
+        # Resolved mode: reaching execute_single() IS the resolution -- run.py
+        # dispatches here for an explicit --mode single, and for a prompt or a
+        # pipe arriving with no --mode at all.
+        invocation_mode="single",
     )
 
     # Create fully initialized session (handles all setup including resume)

--- a/amplifier_app_cli/session_runner.py
+++ b/amplifier_app_cli/session_runner.py
@@ -26,6 +26,7 @@ Philosophy:
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import uuid
 from collections import Counter
@@ -82,6 +83,13 @@ class SessionConfig:
 
     # Execution mode
     output_format: str = "text"  # text | json | json-trace
+
+    # Resolved execution mode ("chat" | "single"), recorded as invocation
+    # provenance on session:start.  This is the value AFTER prompt- and
+    # pipe-presence inference (commands/run.py), not the raw --mode flag: an
+    # interactive session launched without --mode would otherwise be recorded
+    # as "single".  None => recorded as "unknown", never guessed.
+    invocation_mode: str | None = None
 
     @property
     def is_resume(self) -> bool:
@@ -360,6 +368,93 @@ def _inject_observability_events(prepared_bundle: "PreparedBundle") -> None:
     inject_additional_events(prepared_bundle.mount_plan, _CLEANUP_EVENTS)
 
 
+# Names the session that launched this OS process, when the launcher is a
+# *different* process (an agent shelling out `amplifier run`, or foundation's
+# subprocess spawn).  In-process lineage is already carried end-to-end by
+# ``parent_id``; this covers only the cross-process case ``parent_id`` cannot
+# see.  The ``AMPLIFIER_`` prefix is on foundation's subprocess env allowlist,
+# so it propagates to children for free.  Unset => null, never a fabricated id.
+LAUNCHER_SESSION_ID_ENV = "AMPLIFIER_LAUNCHED_BY_SESSION_ID"
+
+# Bump only on a breaking change to the meaning of the fields below.
+INVOCATION_SCHEMA = 1
+
+
+def _fd_isatty(fd: int) -> bool:
+    """``os.isatty`` that cannot take a session down.
+
+    fd-level rather than ``sys.stdin.isatty()`` -- see dedicated_tty_input.py,
+    which already reasoned about this distinction: the fd is the thing that
+    actually matters, since sys.stdin can be swapped in-process.  A closed or
+    invalid fd (daemonised harness) reads as "not a tty", which is the truth.
+    """
+    try:
+        return os.isatty(fd)
+    except (OSError, ValueError):
+        return False
+
+
+def _build_invocation_metadata(mode: str | None) -> dict[str, Any]:
+    """Describe HOW this session was invoked, for provenance consumers.
+
+    Deliberately NOT recorded: argv / the full command line.  Prompt text,
+    ``--api-key ...``, and ``"$(cat token)"`` all land in argv, while
+    events.jsonl is a long-lived, greppable, exported artifact.  Raw config was
+    already moved *off* ``session:start`` onto the separate, redacted
+    ``session:config`` event -- adding an unredactable free-text field here
+    would reverse that.  The fields below answer the provenance question
+    without opening that hole.
+
+    This is a self-report, not a security control.  A harness that fills these
+    in dishonestly will be believed, exactly as one that declines to pass
+    ``parent_id`` is believed.  It defends against the overwhelmingly common
+    case -- a harness that never thought about provenance at all.
+
+    Args:
+        mode: The *resolved* execution mode ("chat" / "single"), i.e. the value
+            after prompt- and pipe-presence inference, not the raw ``--mode``
+            flag.  ``None`` when a caller did not state one -- recorded as
+            "unknown" rather than guessed, since a wrong mode is worse than an
+            absent one.
+    """
+    return {
+        "schema": INVOCATION_SCHEMA,
+        "mode": mode or "unknown",
+        "stdin_isatty": _fd_isatty(0),
+        "stdout_isatty": _fd_isatty(1),
+        "launched_by": "cli",
+        "launched_by_session_id": os.environ.get(LAUNCHER_SESSION_ID_ENV) or None,
+    }
+
+
+def _inject_invocation_metadata(
+    prepared_bundle: "PreparedBundle", *, mode: str | None
+) -> None:
+    """Record invocation provenance on the root session's mount plan.
+
+    Rides the kernel's existing ``session.metadata`` passthrough channel
+    (amplifier-core ``docs/specs/CONTRIBUTION_CHANNELS.md``), so this surfaces
+    at ``session:start`` as ``metadata.invocation`` and lands in events.jsonl
+    at ``data.metadata.invocation``.  No new event, no schema change, and no
+    change required in hooks-logging (``metadata`` is not a promoted key, so it
+    nests under ``data`` automatically).
+
+    Merges under the ``invocation`` key only: any other metadata a bundle or
+    caller already placed on the mount plan is left exactly as it was.
+
+    Args:
+        prepared_bundle: The PreparedBundle whose mount_plan will be updated
+            in-place.  Same ordering constraint as
+            ``_inject_observability_events``: must run after
+            inject_user_providers() (step 4b) and before create_session()
+            (step 4c), which is when the kernel reads session.metadata.
+        mode: Resolved execution mode -- see ``_build_invocation_metadata``.
+    """
+    session_section = prepared_bundle.mount_plan.setdefault("session", {})
+    metadata = session_section.setdefault("metadata", {})
+    metadata["invocation"] = _build_invocation_metadata(mode)
+
+
 async def _create_bundle_session(
     config: SessionConfig,
     session_id: str,
@@ -399,6 +494,12 @@ async def _create_bundle_session(
     # This MUST run before create_session() (which calls mount() internally) so the
     # config dict is populated when each hook module is mounted.
     _inject_observability_events(prepared_bundle)
+
+    # Step 4b-post: Record how this session was invoked, on the same mount plan
+    # and under the same ordering constraint. The kernel reads session.metadata
+    # when it builds the session:start payload, so this must land before
+    # create_session() below.
+    _inject_invocation_metadata(prepared_bundle, mode=config.invocation_mode)
 
     # Step 4c: Create session (foundation handles init internally)
     # Self-healing: The kernel intentionally swallows module load errors to be resilient.

--- a/tests/test_invocation_metadata.py
+++ b/tests/test_invocation_metadata.py
@@ -1,0 +1,334 @@
+"""Tests for invocation-provenance metadata on the root session's mount plan.
+
+app-cli records HOW a session was invoked (resolved mode, tty-ness of stdin and
+stdout, launching component, cross-process launcher session id) under
+``mount_plan["session"]["metadata"]["invocation"]``.  The kernel's CP-SM
+passthrough channel carries it to ``session:start``, where it persists as
+``data.metadata.invocation`` in events.jsonl.
+
+What these tests pin down:
+  * the exact field set -- notably that argv is NOT among it
+  * the *resolved* mode, per entry point (chat vs single)
+  * both tty flags, mocked both ways
+  * pre-existing metadata is never clobbered
+  * an unset launcher env var yields null, never a fabricated id
+  * the mount plan is mutated BEFORE create_session() reads it
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from amplifier_app_cli.session_runner import (
+    INVOCATION_SCHEMA,
+    LAUNCHER_SESSION_ID_ENV,
+    SessionConfig,
+    _build_invocation_metadata,
+    _inject_invocation_metadata,
+)
+
+_MODULE = "amplifier_app_cli.session_runner"
+_MAIN = "amplifier_app_cli.main"
+
+EXPECTED_FIELDS = {
+    "schema",
+    "mode",
+    "stdin_isatty",
+    "stdout_isatty",
+    "launched_by",
+    "launched_by_session_id",
+}
+
+
+def _prepared_bundle(mount_plan=None):
+    """A PreparedBundle stand-in carrying a real (mutable) mount plan dict."""
+    bundle = MagicMock()
+    bundle.mount_plan = mount_plan if mount_plan is not None else {}
+    return bundle
+
+
+def _invocation(bundle) -> dict:
+    return bundle.mount_plan["session"]["metadata"]["invocation"]
+
+
+# ---------------------------------------------------------------------------
+# Field set and shape
+# ---------------------------------------------------------------------------
+
+
+class TestInvocationShape:
+    def test_field_set_is_exactly_the_designed_one(self, monkeypatch):
+        monkeypatch.delenv(LAUNCHER_SESSION_ID_ENV, raising=False)
+        assert set(_build_invocation_metadata("single")) == EXPECTED_FIELDS
+
+    def test_no_argv_or_command_line_is_recorded(self, monkeypatch):
+        """argv is a live secrets surface -- it must never reach events.jsonl.
+
+        `amplifier run "$(cat prod-token.txt)"` and `--api-key ...` both land in
+        argv, and events.jsonl is long-lived, greppable, and exported.  This
+        test exists so a future 'just add argv, it's useful' change has to
+        delete an explicit assertion rather than quietly widen the record.
+        """
+        invocation = _build_invocation_metadata("single")
+        forbidden = ("argv", "cmd", "command", "args", "prompt", "env")
+        for key in invocation:
+            assert not any(bad in key.lower() for bad in forbidden), (
+                f"Field {key!r} looks like a raw command-line/environment dump. "
+                f"Invocation provenance is deliberately limited to "
+                f"{sorted(EXPECTED_FIELDS)}."
+            )
+
+    def test_schema_is_versioned(self, monkeypatch):
+        monkeypatch.delenv(LAUNCHER_SESSION_ID_ENV, raising=False)
+        assert _build_invocation_metadata("single")["schema"] == INVOCATION_SCHEMA
+        assert isinstance(INVOCATION_SCHEMA, int)
+
+    def test_launched_by_is_cli_from_this_construction_site(self):
+        assert _build_invocation_metadata("single")["launched_by"] == "cli"
+
+
+# ---------------------------------------------------------------------------
+# Resolved mode
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedMode:
+    @pytest.mark.parametrize("mode", ["chat", "single"])
+    def test_mode_recorded_verbatim(self, mode):
+        bundle = _prepared_bundle()
+        _inject_invocation_metadata(bundle, mode=mode)
+        assert _invocation(bundle)["mode"] == mode
+
+    def test_absent_mode_is_unknown_not_guessed(self):
+        """A wrong mode is worse than an absent one (absent => UNKNOWN)."""
+        bundle = _prepared_bundle()
+        _inject_invocation_metadata(bundle, mode=None)
+        assert _invocation(bundle)["mode"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# tty matrix
+# ---------------------------------------------------------------------------
+
+
+class TestTtyFlags:
+    @pytest.mark.parametrize(
+        ("stdin_tty", "stdout_tty"),
+        [(True, True), (True, False), (False, True), (False, False)],
+    )
+    def test_isatty_matrix(self, stdin_tty, stdout_tty):
+        fds = {0: stdin_tty, 1: stdout_tty}
+        with patch(f"{_MODULE}.os.isatty", side_effect=lambda fd: fds[fd]):
+            invocation = _build_invocation_metadata("single")
+        assert invocation["stdin_isatty"] is stdin_tty
+        assert invocation["stdout_isatty"] is stdout_tty
+
+    def test_closed_fd_reads_as_not_a_tty_instead_of_raising(self):
+        """A daemonised harness with a closed stdin must not fail to start."""
+        with patch(f"{_MODULE}.os.isatty", side_effect=OSError("Bad file descriptor")):
+            invocation = _build_invocation_metadata("single")
+        assert invocation["stdin_isatty"] is False
+        assert invocation["stdout_isatty"] is False
+
+
+# ---------------------------------------------------------------------------
+# Cross-process launcher id
+# ---------------------------------------------------------------------------
+
+
+class TestLauncherSessionId:
+    def test_unset_env_var_yields_null_never_a_fabricated_id(self, monkeypatch):
+        monkeypatch.delenv(LAUNCHER_SESSION_ID_ENV, raising=False)
+        assert _build_invocation_metadata("single")["launched_by_session_id"] is None
+
+    def test_empty_env_var_is_also_null(self, monkeypatch):
+        monkeypatch.setenv(LAUNCHER_SESSION_ID_ENV, "")
+        assert _build_invocation_metadata("single")["launched_by_session_id"] is None
+
+    def test_set_env_var_is_recorded(self, monkeypatch):
+        monkeypatch.setenv(LAUNCHER_SESSION_ID_ENV, "launcher-session-abc")
+        assert (
+            _build_invocation_metadata("single")["launched_by_session_id"]
+            == "launcher-session-abc"
+        )
+
+    def test_env_var_uses_the_amplifier_prefix(self):
+        """foundation's subprocess env allowlist forwards AMPLIFIER_* for free."""
+        assert LAUNCHER_SESSION_ID_ENV.startswith("AMPLIFIER_")
+
+
+# ---------------------------------------------------------------------------
+# Merge behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestMergeSemantics:
+    def test_existing_session_metadata_is_preserved(self):
+        bundle = _prepared_bundle(
+            {"session": {"metadata": {"agent_name": "kept", "run_id": "also-kept"}}}
+        )
+        _inject_invocation_metadata(bundle, mode="single")
+
+        metadata = bundle.mount_plan["session"]["metadata"]
+        assert metadata["agent_name"] == "kept"
+        assert metadata["run_id"] == "also-kept"
+        assert set(metadata) == {"agent_name", "run_id", "invocation"}
+
+    def test_existing_session_section_keys_are_preserved(self):
+        bundle = _prepared_bundle(
+            {"session": {"orchestrator": "loop-basic", "context": "context-simple"}}
+        )
+        _inject_invocation_metadata(bundle, mode="chat")
+
+        session = bundle.mount_plan["session"]
+        assert session["orchestrator"] == "loop-basic"
+        assert session["context"] == "context-simple"
+        assert "invocation" in session["metadata"]
+
+    def test_rest_of_mount_plan_is_untouched(self):
+        bundle = _prepared_bundle({"providers": [{"id": "anthropic"}], "tools": []})
+        _inject_invocation_metadata(bundle, mode="single")
+
+        assert bundle.mount_plan["providers"] == [{"id": "anthropic"}]
+        assert bundle.mount_plan["tools"] == []
+
+    def test_missing_session_section_is_created(self):
+        bundle = _prepared_bundle({})
+        _inject_invocation_metadata(bundle, mode="single")
+        assert set(_invocation(bundle)) == EXPECTED_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# Ordering -- the mount plan must be mutated before create_session() reads it
+# ---------------------------------------------------------------------------
+
+
+class TestOrdering:
+    @pytest.mark.anyio
+    async def test_mount_plan_carries_invocation_when_create_session_is_called(
+        self, tmp_path: Path
+    ):
+        """The kernel reads session.metadata during create_session().
+
+        Injecting after that call would be a silent no-op, so this asserts on
+        the mount plan as observed *at the moment* create_session() runs, not
+        afterwards.
+        """
+        from amplifier_app_cli.session_runner import _create_bundle_session
+
+        seen: dict = {}
+
+        prepared_bundle = MagicMock()
+        prepared_bundle.mount_plan = {"providers": [], "tools": []}
+
+        async def _capture_mount_plan(**_kwargs):
+            # Deep-ish copy of just what we assert on, captured at call time.
+            seen["invocation"] = dict(
+                prepared_bundle.mount_plan["session"]["metadata"]["invocation"]
+            )
+            return MagicMock()
+
+        prepared_bundle.create_session = AsyncMock(side_effect=_capture_mount_plan)
+
+        cfg = SessionConfig(
+            config={},
+            search_paths=[tmp_path],
+            verbose=False,
+            prepared_bundle=prepared_bundle,
+            bundle_name="test-bundle",
+            invocation_mode="single",
+        )
+
+        console = MagicMock()
+        console.status = MagicMock()
+        console.status.return_value.__enter__ = MagicMock()
+        console.status.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(f"{_MODULE}.inject_user_providers", create=True),
+            patch(f"{_MODULE}._inject_observability_events"),
+            patch(f"{_MODULE}._should_attempt_self_healing", return_value=False),
+            patch("amplifier_app_cli.runtime.config.inject_user_providers"),
+            patch("amplifier_app_cli.lib.bundle_loader.AppModuleResolver"),
+            patch("amplifier_app_cli.paths.create_foundation_resolver"),
+        ):
+            await _create_bundle_session(
+                cfg,
+                session_id="test-session-id",
+                approval_system=MagicMock(),
+                display_system=MagicMock(),
+                console=console,
+            )
+
+        assert seen["invocation"]["mode"] == "single"
+        assert set(seen["invocation"]) == EXPECTED_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# Entry points -- the two resolved-mode paths run.py dispatches to
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPointsRecordResolvedMode:
+    """interactive_chat() => "chat"; execute_single() => "single".
+
+    Reaching one of these functions IS the mode resolution: run.py collapses
+    --mode, prompt presence, and pipe presence before dispatching, so the raw
+    --mode flag (which defaults to "single") is never what gets recorded.
+    """
+
+    @pytest.mark.asyncio
+    async def test_execute_single_records_single(self, tmp_path: Path):
+        from amplifier_app_cli.main import execute_single
+
+        captured: list[SessionConfig] = []
+
+        async def _capture(session_config, _console):
+            captured.append(session_config)
+            raise SystemExit(0)  # stop before the rest of the session machinery
+
+        with (
+            patch(
+                f"{_MAIN}.create_initialized_session",
+                new=AsyncMock(side_effect=_capture),
+            ),
+            patch(f"{_MAIN}.console"),
+            pytest.raises(SystemExit),
+        ):
+            await execute_single(
+                prompt="Hi",
+                config={},
+                search_paths=[tmp_path],
+                verbose=False,
+                bundle_name="test-bundle",
+            )
+
+        assert captured[0].invocation_mode == "single"
+
+    @pytest.mark.asyncio
+    async def test_interactive_chat_records_chat(self, tmp_path: Path):
+        from amplifier_app_cli.main import interactive_chat
+
+        captured: list[SessionConfig] = []
+
+        async def _capture(session_config, _console):
+            captured.append(session_config)
+            raise SystemExit(0)
+
+        with (
+            patch(
+                f"{_MAIN}.create_initialized_session",
+                new=AsyncMock(side_effect=_capture),
+            ),
+            patch(f"{_MAIN}.console"),
+            pytest.raises(SystemExit),
+        ):
+            await interactive_chat(
+                config={},
+                search_paths=[tmp_path],
+                verbose=False,
+                bundle_name="test-bundle",
+            )
+
+        assert captured[0].invocation_mode == "chat"


### PR DESCRIPTION
## What

Record **how a session was invoked** on the root session's mount plan, so downstream tooling
can tell a human at a terminal from a script.

```jsonc
mount_plan["session"]["metadata"]["invocation"] = {
  "schema": 1,                    // bump only on a breaking meaning change
  "mode": "single",               // RESOLVED mode: "chat" | "single"
  "stdin_isatty": false,          // os.isatty(0)
  "stdout_isatty": false,         // os.isatty(1)
  "launched_by": "cli",           // which construction site built this
  "launched_by_session_id": null  // cross-PROCESS launcher, or null
}
```

Surfaces at `session:start` as `metadata.invocation`; persists at
`data.metadata.invocation` in `events.jsonl`.

## Why

A script firing `amplifier run --mode single "..."` produces a `session:start` record that is
byte-identical — modulo ids and timestamps — to a human typing interactively. Forensic
consumers therefore have to guess from working-dir shape, prompt length, and inter-prompt
pacing. On one real corpus of 2,299 prompt-carrying root sessions, only **17.4%** could be
called human with any confidence and **37.4%** landed in an honest `UNKNOWN`. Six recorded
fields collapse most of that guesswork into a read.

## Companion PR — merge order matters

**microsoft/amplifier-core#103 lands first.** The kernel's `session.metadata` passthrough
channel is specified, tested, and implemented in the Python kernel — but the Rust bindings
emit (which is what actually runs) drops it on `session:start` / `session:resume`. Until that
parity fix ships, this change is **inert but harmless**: the mount plan carries the object,
the kernel ignores it, and the persisted payload is byte-identical to today. Verified below.

`pyproject.toml` currently floats `amplifier-core>=1.5.3`; the floor should be bumped to
whatever release carries #103, but that is a separate one-line change once #103 is released.

## How — the existing seam, not a new one

`_inject_observability_events()` already exists in `session_runner.py` with exactly this job:
mutate the root mount plan in place, after `inject_user_providers()` and strictly before
`create_session()`. `_inject_invocation_metadata()` lands beside it, under the same ordering
constraint, and is called on the next line. That is the whole integration.

No new event, no schema change, and **zero changes needed in hooks-logging** — `metadata` is
not one of its promoted top-level keys, so it nests under `data` automatically.

### Decisions worth reviewing

- **`mode` is the *resolved* mode.** `--mode` defaults to `"single"`, so recording the raw
  flag would label an interactive session `"single"`. Reaching `interactive_chat()` /
  `execute_single()` *is* the resolution — `run.py` collapses the flag, prompt presence, and
  pipe presence before dispatching. A caller that states no mode gets `"unknown"`, never a
  guess.
- **`stdout_isatty` is included** and is the cheap discriminator: a harness that fakes
  tty-ish pacing still almost always redirects stdout. `stdin` alone is spoofed by a PTY
  wrapper; both being ttys is a much narrower claim.
- **fd-level `os.isatty(0)`**, not `sys.stdin.isatty()`, matching `dedicated_tty_input.py`'s
  existing reasoning that the fd is the thing that actually matters. Wrapped so a closed fd
  reads as "not a tty" rather than taking the session down.
- **`launched_by_session_id` is cross-*process* only**, sourced from
  `AMPLIFIER_LAUNCHED_BY_SESSION_ID`. In-process lineage is already carried end-to-end by
  `parent_id`; duplicating it would create a second source of truth for the same fact. The
  `AMPLIFIER_` prefix is already on foundation's subprocess env allowlist, so it propagates
  to children for free. Unset ⇒ `null`, never a fabricated id.
- **`launched_by` exists because `launched_by_session_id: null` is ambiguous** — it means
  both "a human at a terminal" and "an agent that never set the env var". A separate coarse
  enum lets each construction site say which, and lets consumers treat an unrecognized value
  as UNKNOWN rather than as human.
- **Merged under the `invocation` key only.** Any other metadata a bundle or caller already
  placed on the mount plan is left exactly as it was. Tested.

### Explicitly NOT recorded: argv

No `argv`, no command line, no environment dump — and there is a comment in the code saying
so, so a future "argv would be useful" change has to delete an explicit assertion rather than
quietly widen the record.

`amplifier run "$(cat prod-token.txt)"`, `--api-key …`, and prompt text pasted on the command
line all land in argv, while `events.jsonl` is a long-lived, greppable, exported artifact.
This ecosystem has been moving *away* from that: raw config was already split off
`session:start` onto the separate, redacted `session:config` event. An unredactable free-text
field here would reverse that direction for no additional classification power.

### Honest limit

This is a **self-report, not a security control.** A harness that sets `launched_by: "cli"`
and runs under a PTY will be classified as human — exactly as a caller that declines to pass
`parent_id` is believed today. It defends against the overwhelmingly common case (a harness
that never thought about provenance) and claims nothing more. Please don't let a reader infer
a security property that isn't there.

## Tests

`tests/test_invocation_metadata.py` — 23 new tests:

- exact field set; **argv/command-line/env keys explicitly asserted absent**
- resolved mode per entry point: `execute_single()` ⇒ `"single"`, `interactive_chat()` ⇒
  `"chat"` (asserted on the real `SessionConfig` those functions build), plus `None ⇒
  "unknown"`
- full isatty matrix, mocked both ways (4 combinations) + closed-fd survival
- launcher env var: unset ⇒ `null`, empty ⇒ `null`, set ⇒ recorded, prefix on the allowlist
- merge semantics: existing `session.metadata` keys preserved, existing `session` section
  keys preserved, rest of the mount plan untouched, missing section created
- ordering: the mount plan is asserted to carry `invocation` **at the moment
  `create_session()` runs**, not merely afterwards — injecting after that call would be a
  silent no-op

```
uv run pytest -q                  1456 passed, 1 skipped, 13 deselected, 1 xfailed
uv run pytest -m integration -q     13 passed, 1458 deselected
```

CI on this PR (`.github/workflows/ci.yml`): `test` on {ubuntu, macos, windows} ×
{py3.11, py3.12}, and `integration` on {ubuntu, macos}.

## Live proof

Scratch venv with **both** patches active (amplifier-core built from
microsoft/amplifier-core#103, this branch installed editable), one real
`amplifier run --mode single "..."`. The persisted
`~/.amplifier/projects/<slug>/sessions/<id>/events.jsonl` `session:start` line:

```json
{"ts":"...","lvl":"INFO","schema":{"name":"amplifier.log","ver":"1.0.0"},
 "event":"session:start","redaction":{"applied":true,"rules":["secrets","pii-basic"]},
 "session_id":"a0122cbb-6438-4014-99cb-c63fefef9985",
 "data":{"metadata":{"invocation":{"launched_by":"cli","launched_by_session_id":null,
 "mode":"single","schema":1,"stdin_isatty":false,"stdout_isatty":false}},"parent_id":null}}
```

Same stack, chat path (`--mode chat` with a piped initial prompt) — note `"mode":"chat"`,
i.e. the resolved mode, not the `--mode` default:

```json
{"ts":"...","event":"session:start","session_id":"b266f380-25e6-4fb8-b9d2-1990db8e4ba6",
 "data":{"metadata":{"invocation":{"launched_by":"cli","launched_by_session_id":null,
 "mode":"chat","schema":1,"stdin_isatty":false,"stdout_isatty":false}},"parent_id":null}}
```

**Negative control / "inert before core lands"** — this branch unchanged, released
`amplifier-core==1.6.0` swapped back in, same command. The mount plan still carries the
object; the payload is byte-identical to today:

```json
{"ts":"...","lvl":"INFO","schema":{"name":"amplifier.log","ver":"1.0.0"},
 "event":"session:start","redaction":{"applied":true,"rules":["secrets","pii-basic"]},
 "session_id":"bbbbd7c4-8a1b-4b26-ba73-edfcbf9dc577","data":{"parent_id":null}}
```

## Deliberately out of scope

`launched_by: "spawn"` / `"subprocess"` at the existing child-metadata write in
`session_spawner.py` is left as follow-up. Child sessions already carry `parent_id`, which is
definitive lineage; root sessions are where the gap actually is. Adding it there is a small,
separable change once this field set is agreed.

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
