### PR TITLE
Fix Windows update and reset recovery reporting

### DIFF
--- a/amplifier_app_cli/commands/reset.py
+++ b/amplifier_app_cli/commands/reset.py
@@ -316,6 +316,7 @@ def _remove_amplifier_dir(preserve: set[str], dry_run: bool = False) -> bool:
     # Selective removal - preserve specified paths
     removed_count = 0
     preserved_count = 0
+    failed_items: list[str] = []
     clearing_cache = "cache" not in preserve_paths
 
     try:
@@ -333,9 +334,13 @@ def _remove_amplifier_dir(preserve: set[str], dry_run: bool = False) -> bool:
                         _count, success = clear_download_cache(dry_run=False)
                         if success:
                             removed_count += 1
+                        else:
+                            failed_items.append(item.name)
                     elif clear_registry is not None and item.name == "registry.json":
                         if clear_registry(dry_run=False):
                             removed_count += 1
+                        else:
+                            failed_items.append(item.name)
                     else:
                         # Standard removal (fallback or other items)
                         if item.is_dir():
@@ -365,6 +370,12 @@ def _remove_amplifier_dir(preserve: set[str], dry_run: bool = False) -> bool:
         console.print(
             f"    {action} {removed_count} items, preserved {preserved_count}"
         )
+        if failed_items:
+            console.print(
+                "[red]Error:[/red] Cleanup incomplete; failed to remove: "
+                f"{', '.join(sorted(failed_items))}"
+            )
+            return False
         return True
     except OSError as e:
         from ..utils.error_format import format_error_message
@@ -407,11 +418,14 @@ def _install_amplifier(dry_run: bool = False) -> bool:
         return False
 
 
-def _windows_defer_tool_swap(no_install: bool) -> None:
+def _windows_defer_tool_swap(no_install: bool) -> bool:
     """Hand the uv tool uninstall/reinstall to a script that runs after we exit.
 
     See ``defer_uv_tool_swap`` for why Windows needs this at all. Reset's shape
     is an uninstall, followed (unless ``--no-install``) by a fresh install.
+
+    Returns:
+        True only when the deferred script was launched successfully.
     """
     if no_install:
         steps = [
@@ -459,10 +473,13 @@ def _windows_defer_tool_swap(no_install: bool) -> None:
         console.print("    Run these yourself once Amplifier has exited:")
         for command in recovery:
             console.print(f"      {command}")
+        console.print(
+            "\n[red]>>>[/red] Reset was not staged; no deferred tool changes will run."
+        )
+        return False
 
-    console.print(
-        "\n[green]>>>[/green] Reset staged - it will finish after this exits."
-    )
+    console.print("\n[green]>>>[/green] Reset staged - it will finish after this exits.")
+    return True
 
 
 @click.command()
@@ -587,20 +604,39 @@ def reset(
     # runs after this process exits. POSIX unlinks open files, so the path below
     # is unchanged there.
     if os.name == "nt" and not dry_run:
-        _remove_amplifier_dir(preserve, dry_run)
-        _windows_defer_tool_swap(no_install)
+        if not _remove_amplifier_dir(preserve, dry_run):
+            raise click.ClickException(
+                "Reset stopped because cleanup was incomplete; "
+                "no reinstall was staged."
+            )
+        if not _windows_defer_tool_swap(no_install):
+            raise click.ClickException("Reset could not be staged.")
         return
 
     _uninstall_amplifier(dry_run)
-    _remove_amplifier_dir(preserve, dry_run)
+    cleanup_succeeded = _remove_amplifier_dir(preserve, dry_run)
 
     if dry_run:
         console.print("\n[green]>>>[/green] Dry run complete - no changes were made")
         return
 
     # Reinstall if not skipped
+    install_succeeded = True
     if not no_install:
-        if not _install_amplifier(dry_run):
-            return
+        install_succeeded = _install_amplifier(dry_run)
+
+    if not cleanup_succeeded:
+        if no_install:
+            recovery_status = "No reinstall was requested."
+        elif install_succeeded:
+            recovery_status = "Amplifier was reinstalled for recovery."
+        else:
+            recovery_status = "The reinstall recovery also failed."
+        raise click.ClickException(
+            f"Reset cleanup was incomplete. {recovery_status}"
+        )
+
+    if not install_succeeded:
+        return
 
     console.print("\n[green]>>>[/green] Reset complete!")

--- a/amplifier_app_cli/commands/reset.py
+++ b/amplifier_app_cli/commands/reset.py
@@ -637,6 +637,12 @@ def reset(
         )
 
     if not install_succeeded:
-        return
+        # The uninstall above already ran, so a failed reinstall leaves the user
+        # with no amplifier at all. Exiting 0 here would report that as success
+        # and hide it from any script or CI step driving the reset.
+        raise click.ClickException(
+            "Reset removed Amplifier but the reinstall failed; "
+            "Amplifier is not currently installed."
+        )
 
     console.print("\n[green]>>>[/green] Reset complete!")

--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -1276,17 +1276,27 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
     # Determine overall success including bundles
     overall_success = result.success and not bundle_failed
     if overall_success:
-        console.print("[green]✓ Update complete[/green]")
+        if result.staged:
+            console.print("[yellow]→ Update staged[/yellow]")
+        else:
+            console.print("[green]✓ Update complete[/green]")
         for item in result.updated:
             console.print(f"  [green]✓[/green] {item}")
+        for item in result.staged:
+            console.print(f"  [yellow]→[/yellow] {item} [dim](staged)[/dim]")
         for bundle_name in bundle_updated:
             console.print(f"  [green]✓[/green] Bundle: {bundle_name}")
         for msg in result.messages:
             console.print(f"  {msg}")
     else:
-        console.print("[yellow]⚠ Update completed with errors[/yellow]")
+        if result.staged:
+            console.print("[yellow]⚠ Update staged with errors[/yellow]")
+        else:
+            console.print("[yellow]⚠ Update completed with errors[/yellow]")
         for item in result.updated:
             console.print(f"  [green]✓[/green] {item}")
+        for item in result.staged:
+            console.print(f"  [yellow]→[/yellow] {item} [dim](staged)[/dim]")
         for bundle_name in bundle_updated:
             console.print(f"  [green]✓[/green] Bundle: {bundle_name}")
         for item in result.failed:
@@ -1297,6 +1307,8 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
             console.print(
                 f"  [red]✗[/red] Bundle: {bundle_name}: {escape_markup(error)}"
             )
+        for msg in result.messages:
+            console.print(f"  {msg}")
 
     # Update last check timestamp
     from datetime import datetime

--- a/amplifier_app_cli/utils/update_executor.py
+++ b/amplifier_app_cli/utils/update_executor.py
@@ -33,6 +33,7 @@ class ExecutionResult:
     failed: list[str] = field(default_factory=list)
     messages: list[str] = field(default_factory=list)
     errors: dict[str, str] = field(default_factory=dict)
+    staged: list[str] = field(default_factory=list)
 
 
 async def execute_selective_module_update(
@@ -594,7 +595,7 @@ def _defer_self_update(url: str) -> ExecutionResult:
 
     return ExecutionResult(
         success=True,
-        updated=["amplifier"],
+        staged=["amplifier"],
         messages=["Amplifier update will finish in the new window after this exits"],
     )
 
@@ -797,6 +798,7 @@ async def execute_updates(
     all_messages = []
     all_errors = {}
     overall_success = True
+    all_staged = []
 
     # 1. Execute selective module update (only modules with updates)
     modules_needing_update = [s for s in report.cached_git_sources if s.has_update]
@@ -810,6 +812,7 @@ async def execute_updates(
         all_failed.extend(result.failed)
         all_messages.extend(result.messages)
         all_errors.update(result.errors)
+        all_staged.extend(result.staged)
 
         if not result.success:
             overall_success = False
@@ -827,6 +830,7 @@ async def execute_updates(
         all_failed.extend(result.failed)
         all_messages.extend(result.messages)
         all_errors.update(result.errors)
+        all_staged.extend(result.staged)
 
         if not result.success:
             overall_success = False
@@ -834,6 +838,7 @@ async def execute_updates(
     # 4. Compile final result
     return ExecutionResult(
         success=overall_success and len(all_failed) == 0,
+        staged=all_staged,
         updated=all_updated,
         failed=all_failed,
         messages=all_messages,

--- a/amplifier_app_cli/utils/uv_utils.py
+++ b/amplifier_app_cli/utils/uv_utils.py
@@ -171,9 +171,12 @@ def defer_uv_tool_swap(
         "echo(",
         f"echo Waiting for Amplifier PID {pid} to exit...",
         ":waitloop",
-        f'tasklist /FI "PID eq {pid}" 2>NUL | find "{pid}" >NUL',
+        (
+            f'"%SystemRoot%\\System32\\tasklist.exe" /FI "PID eq {pid}" 2>NUL '
+            f'| "%SystemRoot%\\System32\\find.exe" "{pid}" >NUL'
+        ),
         "if not errorlevel 1 (",
-        "    ping -n 2 127.0.0.1 >NUL",
+        '    "%SystemRoot%\\System32\\ping.exe" -n 2 127.0.0.1 >NUL',
         "    goto waitloop",
         ")",
         "echo(",
@@ -194,7 +197,9 @@ def defer_uv_tool_swap(
             lines.append(
                 f"    echo   files still locked, attempt %%i of {step.attempts}; retrying in 3s..."
             )
-            lines.append("    ping -n 4 127.0.0.1 >NUL")
+            lines.append(
+                '    "%SystemRoot%\\System32\\ping.exe" -n 4 127.0.0.1 >NUL'
+            )
             lines.append(")")
             # Out of attempts on a step we cannot skip.
             lines.append("goto locked")
@@ -203,7 +208,9 @@ def defer_uv_tool_swap(
             # exhausting attempts simply falls through to the next step.
             lines.append(f"    {step.command} >NUL 2>&1")
             lines.append(f"    if !errorlevel! EQU 0 goto {nxt}")
-            lines.append("    ping -n 3 127.0.0.1 >NUL")
+            lines.append(
+                '    "%SystemRoot%\\System32\\ping.exe" -n 3 127.0.0.1 >NUL'
+            )
             lines.append(")")
         if not is_last:
             lines.append(f":{nxt}")
@@ -238,7 +245,7 @@ def defer_uv_tool_swap(
         f"echo {success_message}",
         "echo(",
         "echo This window closes in 5 seconds.",
-        "ping -n 6 127.0.0.1 >NUL",
+        '"%SystemRoot%\\System32\\ping.exe" -n 6 127.0.0.1 >NUL',
         # Standard self-delete idiom: (goto) aborts batch parsing, releasing the
         # file handle so del can remove the script. No orphan left in %TEMP%,
         # and no keypress needed on the happy path.

--- a/amplifier_app_cli/utils/uv_utils.py
+++ b/amplifier_app_cli/utils/uv_utils.py
@@ -160,6 +160,18 @@ def defer_uv_tool_swap(
         )
         return False
 
+    # Every Windows utility below is spelled out as a full path under System32.
+    # Two distinct reasons, both real:
+    #   1. PATH shadowing. Git for Windows ships a GNU `find.exe` in `usr\bin`,
+    #      which its installer will put on PATH ("Use Git and optional Unix
+    #      tools from the Command Prompt"). GNU find reads `"<pid>"` as a path,
+    #      not a pattern, and exits 1 -- so `if not errorlevel 1` goes false and
+    #      the wait loop is skipped entirely.
+    #   2. Current-directory resolution. cmd.exe resolves a bare command name
+    #      from the current directory BEFORE consulting PATH, and this script
+    #      inherits amplifier's cwd -- typically a user's project directory. A
+    #      `ping.exe` or `tasklist.exe` sitting there would be executed instead.
+    #      Nothing shadows those two on PATH; reason 2 is why they are qualified.
     pid = os.getpid()
     lines: list[str] = [
         "@echo off",

--- a/tests/test_update_executor.py
+++ b/tests/test_update_executor.py
@@ -1,6 +1,7 @@
 """Tests for execute_self_update in update_executor."""
 
 import subprocess
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -37,12 +38,18 @@ async def test_execute_self_update_uses_upgrade_reinstall_not_force():
         "amplifier_app_cli.utils.update_executor.subprocess.Popen",
         side_effect=fake_popen,
     ):
-        with patch(
-            "amplifier_app_cli.utils.update_executor._invalidate_modules_with_missing_deps",
-            return_value=(0, 0),
+        with (
+            patch(
+                "amplifier_app_cli.utils.update_executor._invalidate_modules_with_missing_deps",
+                return_value=(0, 0),
+            ),
+            patch("amplifier_app_cli.utils.update_executor.remove_stale_uv_lock"),
+            patch(
+                "amplifier_app_cli.utils.update_executor.os",
+                SimpleNamespace(name="posix"),
+            ),
         ):
-            with patch("amplifier_app_cli.utils.update_executor.remove_stale_uv_lock"):
-                await execute_self_update(_FAKE_UMBRELLA)
+            await execute_self_update(_FAKE_UMBRELLA)
 
     assert "--force" not in captured_cmd, (
         "uv must NOT use --force (it destroys the venv unnecessarily)"
@@ -105,6 +112,10 @@ async def test_execute_self_update_force_runs_cache_clean(monkeypatch):
     monkeypatch.setattr(subprocess, "run", fake_run)
     monkeypatch.setattr(subprocess, "Popen", FakePopen)
     monkeypatch.setattr(
+        "amplifier_app_cli.utils.update_executor.os",
+        SimpleNamespace(name="posix"),
+    )
+    monkeypatch.setattr(
         "amplifier_app_cli.utils.update_executor.remove_stale_uv_lock",
         lambda: None,
     )
@@ -138,6 +149,10 @@ async def test_execute_self_update_no_force_skips_cache_clean(monkeypatch):
 
     monkeypatch.setattr(subprocess, "run", fake_run)
     monkeypatch.setattr(subprocess, "Popen", FakePopen)
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.update_executor.os",
+        SimpleNamespace(name="posix"),
+    )
     monkeypatch.setattr(
         "amplifier_app_cli.utils.update_executor.remove_stale_uv_lock",
         lambda: None,

--- a/tests/test_uv_utils.py
+++ b/tests/test_uv_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -124,7 +125,11 @@ def test_execute_self_update_calls_stale_lock_cleanup_before_popen():
                 "amplifier_app_cli.utils.update_executor._invalidate_modules_with_missing_deps",
                 return_value=(0, 0),
             ):
-                asyncio.run(execute_self_update(umbrella))
+                with patch(
+                    "amplifier_app_cli.utils.update_executor.os",
+                    SimpleNamespace(name="posix"),
+                ):
+                    asyncio.run(execute_self_update(umbrella))
 
     assert "remove_stale_uv_lock" in call_order, (
         "execute_self_update must call remove_stale_uv_lock"

--- a/tests/test_windows_update_reset.py
+++ b/tests/test_windows_update_reset.py
@@ -1,0 +1,394 @@
+"""Focused regressions for Windows reset and deferred update behavior."""
+
+from __future__ import annotations
+
+import importlib
+import tempfile
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from amplifier_app_cli.utils.source_status import UpdateReport
+from amplifier_app_cli.utils.umbrella_discovery import UmbrellaInfo
+from amplifier_app_cli.utils.update_executor import ExecutionResult
+from amplifier_app_cli.utils.update_executor import _defer_self_update
+from amplifier_app_cli.utils.update_executor import execute_updates
+from amplifier_app_cli.utils.uv_utils import UvStep, defer_uv_tool_swap
+
+
+reset_module = importlib.import_module("amplifier_app_cli.commands.reset")
+
+_FAKE_UMBRELLA = UmbrellaInfo(
+    url="https://github.com/microsoft/amplifier",
+    ref="main",
+    commit_id=None,
+)
+
+
+def _console_text(console: MagicMock) -> str:
+    return "\n".join(str(call.args[0]) for call in console.print.call_args_list)
+
+
+def _invoke_update_with_result(monkeypatch, execution_result: ExecutionResult):
+    update_module = importlib.import_module("amplifier_app_cli.commands.update")
+
+    async def fake_check_all_sources(**kwargs):
+        return UpdateReport(local_file_sources=[], cached_git_sources=[])
+
+    async def fake_check_all_bundle_status():
+        return {}
+
+    async def fake_get_umbrella_dep_details(info):
+        return []
+
+    async def fake_pypi_has_update():
+        return True
+
+    async def fake_execute_updates(*args, **kwargs):
+        return execution_result
+
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.umbrella_discovery.discover_umbrella_source",
+        lambda: _FAKE_UMBRELLA,
+    )
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.update_executor.check_pypi_packages_for_updates",
+        fake_pypi_has_update,
+    )
+    monkeypatch.setattr(update_module, "check_all_sources", fake_check_all_sources)
+    monkeypatch.setattr(
+        update_module, "_check_all_bundle_status", fake_check_all_bundle_status
+    )
+    monkeypatch.setattr(
+        update_module,
+        "_get_umbrella_dependency_details",
+        fake_get_umbrella_dep_details,
+    )
+    monkeypatch.setattr(update_module, "execute_updates", fake_execute_updates)
+    monkeypatch.setattr(update_module, "_refresh_skills_cache", lambda console: None)
+    monkeypatch.setattr(update_module, "save_update_last_check", lambda value: None)
+
+    return CliRunner().invoke(update_module.update, ["--yes"])
+
+
+def test_remove_amplifier_dir_reports_cache_failure_and_continues(
+    tmp_path, monkeypatch
+):
+    amplifier_dir = tmp_path / ".amplifier"
+    (amplifier_dir / "cache").mkdir(parents=True)
+    (amplifier_dir / "registry.json").write_text("{}", encoding="utf-8")
+    (amplifier_dir / "settings.yaml").write_text("keep", encoding="utf-8")
+    removable = amplifier_dir / "remove-me.txt"
+    removable.write_text("remove", encoding="utf-8")
+
+    clear_cache = MagicMock(return_value=(0, False))
+
+    def clear_registry(*, dry_run):
+        assert dry_run is False
+        (amplifier_dir / "registry.json").unlink()
+        return True
+
+    monkeypatch.setattr(reset_module, "_get_amplifier_dir", lambda: amplifier_dir)
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.cache_management.clear_download_cache",
+        clear_cache,
+    )
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.cache_management.clear_registry",
+        clear_registry,
+    )
+    monkeypatch.setattr(
+        "amplifier_app_cli.paths.get_install_state_path",
+        lambda: tmp_path / "install-state.json",
+    )
+    fake_console = MagicMock()
+    monkeypatch.setattr(reset_module, "console", fake_console)
+
+    success = reset_module._remove_amplifier_dir({"settings"})
+
+    assert success is False
+    clear_cache.assert_called_once_with(dry_run=False)
+    assert not removable.exists(), "independent cleanup must continue after cache failure"
+    assert not (amplifier_dir / "registry.json").exists()
+    assert (amplifier_dir / "settings.yaml").exists()
+    output = _console_text(fake_console)
+    assert "Cleanup incomplete" in output
+    assert "cache" in output
+
+
+def test_remove_amplifier_dir_reports_registry_failure(tmp_path, monkeypatch):
+    amplifier_dir = tmp_path / ".amplifier"
+    amplifier_dir.mkdir()
+    (amplifier_dir / "registry.json").write_text("{}", encoding="utf-8")
+    (amplifier_dir / "settings.yaml").write_text("keep", encoding="utf-8")
+
+    monkeypatch.setattr(reset_module, "_get_amplifier_dir", lambda: amplifier_dir)
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.cache_management.clear_registry",
+        MagicMock(return_value=False),
+    )
+    monkeypatch.setattr(
+        "amplifier_app_cli.paths.get_install_state_path",
+        lambda: tmp_path / "install-state.json",
+    )
+    fake_console = MagicMock()
+    monkeypatch.setattr(reset_module, "console", fake_console)
+
+    success = reset_module._remove_amplifier_dir({"settings", "cache"})
+
+    assert success is False
+    output = _console_text(fake_console)
+    assert "Cleanup incomplete" in output
+    assert "registry.json" in output
+
+
+def test_windows_reset_does_not_stage_after_incomplete_cleanup(monkeypatch):
+    defer = MagicMock(return_value=True)
+    monkeypatch.setattr(reset_module, "os", SimpleNamespace(name="nt"))
+    monkeypatch.setattr(reset_module, "_show_plan", MagicMock())
+    monkeypatch.setattr(reset_module, "_clean_uv_cache", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        reset_module, "_remove_amplifier_dir", MagicMock(return_value=False)
+    )
+    monkeypatch.setattr(reset_module, "_windows_defer_tool_swap", defer)
+
+    result = CliRunner().invoke(reset_module.reset, ["--yes"])
+
+    assert result.exit_code == 1
+    defer.assert_not_called()
+    assert "cleanup was incomplete" in result.output
+    assert "no reinstall was staged" in result.output
+
+
+def test_windows_reset_returns_failure_when_finisher_cannot_launch(monkeypatch):
+    monkeypatch.setattr(reset_module, "os", SimpleNamespace(name="nt"))
+    monkeypatch.setattr(reset_module, "_show_plan", MagicMock())
+    monkeypatch.setattr(reset_module, "_clean_uv_cache", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        reset_module, "_remove_amplifier_dir", MagicMock(return_value=True)
+    )
+    monkeypatch.setattr(
+        reset_module, "_windows_defer_tool_swap", MagicMock(return_value=False)
+    )
+
+    result = CliRunner().invoke(reset_module.reset, ["--yes"])
+
+    assert result.exit_code == 1
+    assert "Reset could not be staged" in result.output
+
+
+def test_posix_reset_reinstalls_then_fails_after_incomplete_cleanup(monkeypatch):
+    calls: list[str] = []
+
+    monkeypatch.setattr(reset_module, "os", SimpleNamespace(name="posix"))
+    monkeypatch.setattr(reset_module, "_show_plan", MagicMock())
+    monkeypatch.setattr(reset_module, "_clean_uv_cache", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        reset_module,
+        "_uninstall_amplifier",
+        lambda dry_run: calls.append("uninstall") or True,
+    )
+    monkeypatch.setattr(
+        reset_module,
+        "_remove_amplifier_dir",
+        lambda preserve, dry_run: calls.append("cleanup") or False,
+    )
+    monkeypatch.setattr(
+        reset_module,
+        "_install_amplifier",
+        lambda dry_run: calls.append("install") or True,
+    )
+
+    result = CliRunner().invoke(reset_module.reset, ["--yes"])
+
+    assert calls == ["uninstall", "cleanup", "install"]
+    assert result.exit_code == 1
+    assert "Reset cleanup was incomplete" in result.output
+    assert "reinstalled for recovery" in result.output
+    assert "Reset complete!" not in result.output
+
+
+def test_posix_reset_no_install_fails_after_incomplete_cleanup(monkeypatch):
+    install = MagicMock(return_value=True)
+
+    monkeypatch.setattr(reset_module, "os", SimpleNamespace(name="posix"))
+    monkeypatch.setattr(reset_module, "_show_plan", MagicMock())
+    monkeypatch.setattr(reset_module, "_clean_uv_cache", MagicMock(return_value=True))
+    monkeypatch.setattr(reset_module, "_uninstall_amplifier", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        reset_module, "_remove_amplifier_dir", MagicMock(return_value=False)
+    )
+    monkeypatch.setattr(reset_module, "_install_amplifier", install)
+
+    result = CliRunner().invoke(reset_module.reset, ["--yes", "--no-install"])
+
+    install.assert_not_called()
+    assert result.exit_code == 1
+    assert "Reset cleanup was incomplete" in result.output
+    assert "No reinstall was requested" in result.output
+    assert "Reset complete!" not in result.output
+
+
+@pytest.mark.parametrize("launched", [True, False])
+def test_windows_defer_tool_swap_reports_whether_it_launched(monkeypatch, launched):
+    fake_console = MagicMock()
+    monkeypatch.setattr(reset_module, "console", fake_console)
+    monkeypatch.setattr(reset_module, "defer_uv_tool_swap", lambda *a, **k: launched)
+
+    result = reset_module._windows_defer_tool_swap(no_install=False)
+
+    assert result is launched
+    output = _console_text(fake_console)
+    if launched:
+        assert "Reset staged" in output
+        assert "Reset was not staged" not in output
+    else:
+        assert "Reset was not staged" in output
+        assert "Reset staged -" not in output
+
+
+def test_deferred_script_qualifies_windows_utilities(tmp_path, monkeypatch):
+    real_mkstemp = tempfile.mkstemp
+
+    def temp_script(*, prefix, suffix):
+        return real_mkstemp(prefix=prefix, suffix=suffix, dir=tmp_path)
+
+    popen = MagicMock()
+    monkeypatch.setattr(tempfile, "mkstemp", temp_script)
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.uv_utils.subprocess.Popen",
+        popen,
+    )
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.uv_utils.console",
+        MagicMock(),
+    )
+
+    launched = defer_uv_tool_swap(
+        [UvStep(command="uv tool uninstall amplifier", label="Uninstalling...")],
+        operation="reset",
+        intro_lines=["Reset"],
+        success_message="Done",
+        recovery_commands=["uv tool uninstall amplifier"],
+    )
+
+    assert launched is True
+    script_path = popen.call_args.args[0][2]
+    script = tmp_path.joinpath(script_path).read_text(encoding="ascii")
+    assert '"%SystemRoot%\\System32\\tasklist.exe"' in script
+    assert '"%SystemRoot%\\System32\\find.exe"' in script
+    assert '"%SystemRoot%\\System32\\ping.exe"' in script
+    assert "\ntasklist " not in script
+    assert "| find " not in script
+    assert "\n    ping " not in script
+
+
+@pytest.mark.parametrize("launched", [True, False])
+def test_deferred_self_update_distinguishes_staged_from_failed(
+    tmp_path, monkeypatch, launched
+):
+    monkeypatch.setattr(
+        "amplifier_app_cli.paths.get_install_state_path",
+        lambda: tmp_path / "install-state.json",
+    )
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.update_executor.defer_uv_tool_swap",
+        lambda *a, **k: launched,
+    )
+
+    result = _defer_self_update(
+        "git+https://github.com/microsoft/amplifier@main"
+    )
+
+    assert result.success is launched
+    assert result.staged == (["amplifier"] if launched else [])
+    assert result.updated == []
+    if launched:
+        assert result.failed == []
+    else:
+        assert result.failed == ["amplifier"]
+
+
+@pytest.mark.asyncio
+async def test_execute_updates_aggregates_mixed_staged_and_failed_results(monkeypatch):
+    async def failed_module_update(*args, **kwargs):
+        return ExecutionResult(
+            success=False,
+            failed=["provider-example"],
+            errors={"provider-example": "fetch failed"},
+        )
+
+    async def staged_self_update(*args, **kwargs):
+        return ExecutionResult(
+            success=True,
+            staged=["amplifier"],
+            messages=["finishes after exit"],
+        )
+
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.update_executor.execute_selective_module_update",
+        failed_module_update,
+    )
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.update_executor.execute_self_update",
+        staged_self_update,
+    )
+    report = UpdateReport(
+        local_file_sources=[],
+        cached_git_sources=[SimpleNamespace(has_update=True)],
+    )
+
+    result = await execute_updates(report, umbrella_info=_FAKE_UMBRELLA)
+
+    assert result.success is False
+    assert result.staged == ["amplifier"]
+    assert result.updated == []
+    assert result.failed == ["provider-example"]
+    assert result.errors == {"provider-example": "fetch failed"}
+    assert result.messages == ["finishes after exit"]
+
+
+def test_execution_result_staged_defaults_are_compatible_and_independent():
+    first = ExecutionResult(success=True)
+    second = ExecutionResult(success=True)
+
+    assert first.staged == []
+    first.staged.append("amplifier")
+    assert second.staged == []
+
+
+def test_update_command_renders_staged_items_instead_of_complete(monkeypatch):
+    result = _invoke_update_with_result(
+        monkeypatch,
+        ExecutionResult(
+            success=True,
+            staged=["amplifier"],
+            messages=["Amplifier update will finish after this exits"],
+        ),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Update staged" in result.output
+    assert "→ amplifier (staged)" in result.output
+    assert "Update complete" not in result.output
+
+
+def test_update_command_renders_mixed_staged_failed_and_messages(monkeypatch):
+    result = _invoke_update_with_result(
+        monkeypatch,
+        ExecutionResult(
+            success=False,
+            staged=["amplifier"],
+            failed=["provider-example"],
+            errors={"provider-example": "fetch failed"},
+            messages=["Amplifier update will finish after this exits"],
+        ),
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Update staged with errors" in result.output
+    assert "→ amplifier (staged)" in result.output
+    assert "✗ provider-example: fetch failed" in result.output
+    assert "Amplifier update will finish after this exits" in result.output

--- a/tests/test_windows_update_reset.py
+++ b/tests/test_windows_update_reset.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib
 import tempfile
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from click.testing import CliRunner
@@ -231,6 +231,32 @@ def test_posix_reset_no_install_fails_after_incomplete_cleanup(monkeypatch):
     assert "Reset complete!" not in result.output
 
 
+def test_posix_reset_fails_when_reinstall_fails_after_clean_cleanup(monkeypatch):
+    """Cleanup fine, reinstall broken -- the user now has no amplifier at all.
+
+    The uninstall has already run by this point, so exiting 0 here would report
+    "no amplifier installed" as a success to whatever script drove the reset.
+    """
+    monkeypatch.setattr(reset_module, "os", SimpleNamespace(name="posix"))
+    monkeypatch.setattr(reset_module, "_show_plan", MagicMock())
+    monkeypatch.setattr(reset_module, "_clean_uv_cache", MagicMock(return_value=True))
+    monkeypatch.setattr(
+        reset_module, "_uninstall_amplifier", MagicMock(return_value=True)
+    )
+    monkeypatch.setattr(
+        reset_module, "_remove_amplifier_dir", MagicMock(return_value=True)
+    )
+    monkeypatch.setattr(
+        reset_module, "_install_amplifier", MagicMock(return_value=False)
+    )
+
+    result = CliRunner().invoke(reset_module.reset, ["--yes"])
+
+    assert result.exit_code == 1
+    assert "reinstall failed" in result.output
+    assert "Reset complete!" not in result.output
+
+
 @pytest.mark.parametrize("launched", [True, False])
 def test_windows_defer_tool_swap_reports_whether_it_launched(monkeypatch, launched):
     fake_console = MagicMock()
@@ -266,8 +292,19 @@ def test_deferred_script_qualifies_windows_utilities(tmp_path, monkeypatch):
         MagicMock(),
     )
 
+    # Both step shapes, because they emit separate `ping` retry lines: reset's
+    # real no_install=False path uses a best-effort uninstall followed by a
+    # required install, and only the required branch was covered before.
     launched = defer_uv_tool_swap(
-        [UvStep(command="uv tool uninstall amplifier", label="Uninstalling...")],
+        [
+            UvStep(
+                command="uv tool uninstall amplifier",
+                label="Uninstalling (best effort)...",
+                attempts=5,
+                required=False,
+            ),
+            UvStep(command="uv tool install amplifier", label="Reinstalling..."),
+        ],
         operation="reset",
         intro_lines=["Reset"],
         success_message="Done",
@@ -283,6 +320,11 @@ def test_deferred_script_qualifies_windows_utilities(tmp_path, monkeypatch):
     assert "\ntasklist " not in script
     assert "| find " not in script
     assert "\n    ping " not in script
+    # Every ping the script emits -- waitloop, required-step retry,
+    # best-effort-step retry, and the closing countdown -- must be qualified.
+    ping_lines = [line for line in script.splitlines() if "ping" in line]
+    assert len(ping_lines) == 4
+    assert all('"%SystemRoot%\\System32\\ping.exe"' in line for line in ping_lines)
 
 
 @pytest.mark.parametrize("launched", [True, False])
@@ -348,15 +390,6 @@ async def test_execute_updates_aggregates_mixed_staged_and_failed_results(monkey
     assert result.failed == ["provider-example"]
     assert result.errors == {"provider-example": "fetch failed"}
     assert result.messages == ["finishes after exit"]
-
-
-def test_execution_result_staged_defaults_are_compatible_and_independent():
-    first = ExecutionResult(success=True)
-    second = ExecutionResult(success=True)
-
-    assert first.staged == []
-    first.staged.append("amplifier")
-    assert second.staged == []
 
 
 def test_update_command_renders_staged_items_instead_of_complete(monkeypatch):


### PR DESCRIPTION
## Summary

Hit on a real native-Windows machine while running `amplifier update`. Fixing the
reporting there led to the same class of bug in `reset`, which shares the deferred
tool-swap machinery.

- report a detached Windows self-update as **staged**, not completed
- stop reset and exit nonzero when requested cache or registry cleanup is incomplete
- exit nonzero when reset's reinstall fails, instead of reporting success with no
  Amplifier installed
- prevent Windows reset from staging a reinstall after a failed cleanup
- fully qualify the generated finisher's Windows utilities under `System32`

## Root cause

**Windows self-update reported the wrong outcome.** On Windows, `execute_self_update`
hands the install to a deferred `.cmd` and returns immediately. It returned
`updated=["amplifier"]`, so the CLI printed `✓ Update complete` — for an install that
had not started yet. A `messages` line did say the update would finish in the new
window, so the information was present, but the headline contradicted it.

**Reset reported success after a partial cleanup.** A locked file makes
`shutil.rmtree` fail partway. `rmtree_robust` re-raises, `clear_download_cache`
catches `OSError` and returns `(0, False)` — and `_remove_amplifier_dir` had no `else`
branch on that result, so it counted nothing and still returned `True`. `reset()`
discarded the return value entirely and printed `Reset complete!` with exit 0, then
staged the reinstall.

To be precise about the blast radius: the half-deleted cache directory is **not**
left permanently broken. `amplifier-foundation` validates a cached clone before using
it (`sources/git.py` `_verify_clone_integrity`) and has no incremental-update path —
it deletes and re-clones on any integrity failure. So a cache directory that lost its
`.git` self-heals on the next load. The defect being fixed here is that **reset lies
about having succeeded**, which is invisible to the user and undetectable by any
script or CI step driving it — not that it corrupts state permanently.

**Reset also exited 0 when the reinstall failed.** On the POSIX path
`_uninstall_amplifier` runs first, so a failed `_install_amplifier` leaves the user
with no Amplifier at all — and the command returned normally, reporting that as
success. This is the same honest-exit-code defect as above, with a worse outcome.

**The deferred script relied on PATH for its utilities.** Two independent problems.
Git for Windows ships a GNU `find.exe` in `usr\bin`, which its installer will place on
PATH; GNU `find` reads `"<pid>"` as a path rather than a pattern and exits 1, so
`if not errorlevel 1` goes false and the PID wait loop is skipped. Separately,
`cmd.exe` resolves a bare command name from the **current directory** before
consulting PATH, and the finisher inherits Amplifier's cwd — typically a user's
project directory — so a stray `ping.exe` or `tasklist.exe` there would be executed.
Both are closed by spelling out `%SystemRoot%\System32\...`; the second reason is why
`ping` and `tasklist` are qualified and not just `find`.

Skipping the wait loop is partly masked today by the script's own retry-with-backoff
(the required step retries 10 times at ~3s), so this is a correctness fix rather than
a hard failure in the common case.

## Verification

- `uv run pytest -q` — 1449 passed, 13 deselected, 1 xfailed
- `uv run pytest -q tests/test_windows_update_reset.py` — 15 passed
- reproduced the partial-cleanup case against a real filesystem (a genuinely
  undeletable directory, not a mocked failure): before, `amplifier reset -y` deleted
  `.git/config` and `.git/objects/pack/*`, left the locked file, printed
  `Reset complete!` and exited **0**; after, it exits **1** and names the failure
- reproduced the reinstall-failure case: uninstall succeeds, cleanup succeeds,
  reinstall fails — exit code goes **0 → 1**
- native Windows isolated probe: locked-cache reset exited nonzero and launched no
  finisher
- native Windows isolated probe: generated finisher waited correctly with Git
  `usr/bin` first on PATH
- native Windows isolated probe: parent update reported `Update staged`, and a
  lock-release reset retry completed successfully

## Breaking changes

`amplifier reset` now exits nonzero when cleanup or reinstall fails, where it
previously always exited 0. Anything scripting `reset` that assumed a 0 exit will now
correctly see the failure.
