### PR TITLE
chore(context): remove legacy scaffolding shown to cause over-delegation (-27% tokens, quality preserved)

### DIFF
--- a/agents/cli-expert.md
+++ b/agents/cli-expert.md
@@ -23,13 +23,6 @@ meta:
     `--output json-trace`, output formats for automation, spawn-time
     precedence, what tools and providers a sub-agent inherits
 
-    **MUST be used for:**
-    - "How do I switch models / pin a provider / use a different model?"
-    - Any question naming a slash command or an `amplifier <subcommand>`
-    - "Why did this session load that context / where does session state live?"
-    - Scripting or automating Amplifier (output formats, exit behavior)
-    - "What does a spawned agent inherit?" / delegation precedence questions
-
     <example>
     <context>User wants a different model partway through a conversation</context>
     <user>How do I switch models without losing this conversation?</user>

--- a/context/cli-awareness.md
+++ b/context/cli-awareness.md
@@ -4,21 +4,5 @@ You are running inside the **Amplifier CLI application**. The CLI itself —
 its commands, flags, config, and session machinery — is a domain with a
 dedicated expert that carries the authoritative, version-matched docs.
 
-**Delegate to `app-cli:cli-expert`** when the user asks how the CLI itself
-behaves. Signals include:
-
-- Switching models or providers, provider pinning, `/provider`, `amplifier provider`
-- Slash commands (`/config`, `/mode`, `/goal`, `/fork`, `/skills`, `/agents`, `/status`)
-- Sessions: resuming, saving, forking, naming, where session state lives
-- Bundles and skills: what is loaded, precedence, `amplifier bundle`
-- `@mention` context loading and which files a session actually loaded
-- Output formats (`--output json`, json-trace) and automation
-- What tools/providers a spawned sub-agent inherits
-
-**Do not answer these from memory.** CLI behavior is version-specific and
-changes between releases; the expert holds the docs that shipped with *this*
-installed CLI. Guessing produces confident, wrong instructions — the exact
-failure this expert exists to prevent.
-
 If the question is about *your own task* (writing code, debugging the user's
 project), that is not this domain — handle it normally.


### PR DESCRIPTION
## Summary

Deletes legacy prompt scaffolding that a controlled A/B showed **causes** over-delegation in modern models, rather than preventing it.

## Evidence

A 5-vs-5 DTU A/B on an identical real task (same foundation commit both arms, this deletion set the only delta):

| Metric | Control | Deletion | Delta |
|---|---:|---:|---:|
| Total tree tokens (mean) | 42.5M | 31.1M | **-27%** |
| Total tree tokens (median) | -- | -- | **-26%** |
| Task correctness | 5/5 | 5/5 | unchanged |
| Delegate calls | -- | -- | **-27%** |

Captures: `.amplifier/evaluation/first-turn-ab/20260826-225820/6d6-deletion/`

**Mechanism:** modern models interpret prompt instructions literally. A 7-signal "Delegate to cli-expert" routing table plus a "MUST be used for" table in the agent catalog is read as a mandatory trigger for a domain that covers most CLI-related questions, spawning a ~26,800-token sub-agent on cases the root session could often answer directly (or that don't need the CLI-version-specific docs at all).

## Deletions applied in this repo (verbatim removals, no rewording)

| ID | File | What was removed | What was retained |
|---|---|---|---|
| D12 | `context/cli-awareness.md` | The "Delegate to `app-cli:cli-expert`" 7-signal routing block, incl. "Do not answer these from memory" | Identity statement (L1-5); "not this domain" scope-out |
| D13 | `agents/cli-expert.md` | "**MUST be used for:**" table in `meta.description` (rendered into the delegate tool's agent catalog) | "**Authoritative on:**" capability description above it |

## Testing

```
uv run pytest tests/
1469 passed, 1 skipped, 13 deselected, 1 xfailed
```
Unchanged from main — this change only touches bundle context/agent markdown, no logic.

## Not merging yet

Opened for review per the standard multi-repo push order (core → foundation → modules → bundles → apps). Do not merge without review.

🤖 Generated with [Amplifier](https://github.com/microsoft/amplifier)
