### PR TITLE
fix: green Windows CI — POSIX display paths after `~/`, and home isolation that holds on Windows

### DIFF
--- a/amplifier_app_cli/commands/routing.py
+++ b/amplifier_app_cli/commands/routing.py
@@ -277,9 +277,18 @@ def _print_name_stem_note(mismatched: list[tuple[str, str]]) -> None:
 
 
 def _display_path(path: Path) -> str:
-    """Render a path with ``~`` for the home directory, for readable output."""
+    """Render a path with ``~`` for the home directory, for readable output.
+
+    The ``~/`` abbreviation is a POSIX-style spelling, so the remainder is
+    rendered with forward slashes on every platform (``as_posix``). Without
+    that, Windows produced the mixed form ``~/.amplifier\\routing\\openai.yaml``
+    -- the separator switched mid-path -- in `routing list`/`show` output and
+    in the JSON ``matrix_file`` field, which the CLI's own help text spells as
+    ``~/.amplifier/routing/...``. A path outside the home directory is
+    returned as-is, in its native form, because it is not being abbreviated.
+    """
     try:
-        return f"~/{path.relative_to(Path.home())}"
+        return f"~/{path.relative_to(Path.home()).as_posix()}"
     except ValueError:
         return str(path)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,3 +38,24 @@ def reset_skill_shortcuts():
     CommandProcessor.SKILL_SHORTCUTS.clear()
     yield
     CommandProcessor.SKILL_SHORTCUTS.clear()
+
+
+# ---------------------------------------------------------------------------
+# Home-directory isolation that actually holds on Windows.
+#
+# ``Path.home()`` is ``os.path.expanduser("~")``. On POSIX that reads HOME; on
+# Windows ``ntpath.expanduser`` reads USERPROFILE (then HOMEDRIVE+HOMEPATH) and
+# NEVER consults HOME. So ``monkeypatch.setenv("HOME", tmp_path)`` alone -- the
+# idiom every SessionStore-touching test used -- isolated nothing on Windows:
+# tests wrote real records into the runner's (or a developer's) actual
+# ``~/.amplifier/projects/<slug>/sessions/``, and two tests asserting that a
+# record did NOT exist found one left by a previous test. Set both.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch) -> Path:
+    """Point ``Path.home()`` at ``tmp_path`` on every platform; returns it."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    return tmp_path

--- a/tests/test_resume_preserves_provider_promotion.py
+++ b/tests/test_resume_preserves_provider_promotion.py
@@ -65,6 +65,12 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _home(isolated_home):
+    """Every test here reaches SessionStore() -> Path.home(). See conftest.isolated_home."""
+    return isolated_home
+
+
 # ---------------------------------------------------------------------------
 # Fixtures modelled on the rc0 capture
 #   20260901-rebaseline/runs/val-rb-oai-sol-xhigh-s1-01
@@ -260,7 +266,6 @@ class TestResumeRebuildsPromotion:
         resolution`` was reachable only from spawn. The resumed leg resolved
         to the settings priority-0 provider (sol), exactly as captured.
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
         store = SessionStore()
         session_id = "test-resume-keeps-promotion"
         metadata = _base_metadata(
@@ -296,7 +301,6 @@ class TestResumeRebuildsPromotion:
         The persisted promotion must survive the credential refresh on its
         own, and the credential must still be refreshed.
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
         store = SessionStore()
         session_id = "test-resume-fix-a-isolated"
         store.save(session_id, [], _base_metadata(session_id))
@@ -323,7 +327,6 @@ class TestResumeRebuildsPromotion:
         This is the hop the caller (tool-delegate's resume path) gains: it
         can now pass the same preferences it passes at spawn.
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
         store = SessionStore()
         session_id = "test-resume-explicit-prefs"
         store.save(session_id, [], _base_metadata(session_id))
@@ -350,7 +353,6 @@ class TestResumeRebuildsPromotion:
         which is what the rc0 capture observed ("still luna ... simply never
         consulted again").
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
         store = SessionStore()
         session_id = "test-resume-prefs-from-config"
         metadata = _base_metadata(session_id)
@@ -373,7 +375,6 @@ class TestResumeRebuildsPromotion:
         Settles rc0 section 4.6 from the other direction: the preference's own
         ``reasoning_effort`` -- not settings' -- governs the resumed leg.
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
         store = SessionStore()
         session_id = "test-resume-pref-config"
         metadata = _base_metadata(
@@ -405,7 +406,6 @@ class TestResumeRebuildsPromotion:
         The resumed leg's routing hook resolves roles from config; without
         this the role the delegate was spawned with never reaches it.
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
         store = SessionStore()
         session_id = "test-resume-model-role"
         store.save(session_id, [], _base_metadata(session_id))
@@ -423,7 +423,6 @@ class TestResumeRebuildsPromotion:
         leg still has to run on something -- but it must SAY so, naming the
         cause and the provider/model it actually landed on.
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
         store = SessionStore()
         session_id = "test-resume-fallback-event"
         metadata = _base_metadata(
@@ -462,7 +461,6 @@ class TestResumeRebuildsPromotion:
         resumes were affected, because a plan with no promotion has nothing
         to preserve and nothing to rebuild.
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
         store = SessionStore()
         session_id = "test-resume-no-prefs"
         metadata = _base_metadata(session_id)

--- a/tests/test_resume_system_prompt.py
+++ b/tests/test_resume_system_prompt.py
@@ -47,6 +47,12 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _home(isolated_home):
+    """Every test here reaches SessionStore() -> Path.home(). See conftest.isolated_home."""
+    return isolated_home
+
+
 class _FakeContextWithFactory:
     """Stands in for context-simple: supports the factory-based system prompt."""
 
@@ -154,7 +160,6 @@ class TestResumeSystemPromptReinjection:
         FAILS BEFORE THE FIX: resume_sub_session never calls
         set_system_prompt_factory at all, so fake_context.factory stays None.
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         store = SessionStore()
         session_id = "test-resume-system-prompt-factory"
@@ -188,7 +193,6 @@ class TestResumeSystemPromptReinjection:
         add_message() system-role message instead (mirrors the spawn path's
         own hasattr-gated fallback).
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         store = SessionStore()
         session_id = "test-resume-system-prompt-fallback"
@@ -223,7 +227,6 @@ class TestResumeSystemPromptReinjection:
         inherit-as-is overlay, or a session saved before agent_overlay
         existed), fall back to config.agents[<agent_name>].instruction.
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         store = SessionStore()
         session_id = "test-resume-system-prompt-config-fallback"
@@ -248,7 +251,6 @@ class TestResumeSystemPromptReinjection:
         succeeds. Today this failure mode is completely silent; the fix
         must surface it rather than leaving the resumed session mute.
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         store = SessionStore()
         session_id = "test-resume-system-prompt-missing"

--- a/tests/test_routing_shadowing.py
+++ b/tests/test_routing_shadowing.py
@@ -301,7 +301,11 @@ class TestRoutingListShadowed:
         assert source["matrix_name"] == "openai"
         assert source["matrix_source"] == "user"
         assert source["matrix_shadowed"] is True
-        assert source["matrix_path"].endswith("/.amplifier/routing/openai.yaml")
+        # matrix_path is a native absolute path (backslashes on Windows) --
+        # compare as a Path, not as a POSIX string.
+        assert (
+            Path(source["matrix_path"]) == tmp_path / ".amplifier/routing/openai.yaml"
+        )
         assert len(source["shadowed_paths"]) == 1
         assert "amplifier-bundle-routing-matrix-test" in source["shadowed_paths"][0]
 

--- a/tests/test_routing_winner_selection.py
+++ b/tests/test_routing_winner_selection.py
@@ -343,7 +343,12 @@ class TestSortOrderDisagreement:
         rows = _rows(tmp_path)
         source = rows["openai"]["routing_source"]
 
-        assert source["matrix_path"].endswith("/.amplifier/routing/openai.yaml")
+        # matrix_path is a native absolute path (backslashes on Windows) --
+        # compare as a Path, not as a POSIX string. matrix_file is the display
+        # form and IS POSIX-spelled on every platform (see _display_path).
+        assert (
+            Path(source["matrix_path"]) == tmp_path / ".amplifier/routing/openai.yaml"
+        )
         assert rows["openai"]["matrix_file"] == "~/.amplifier/routing/openai.yaml"
         assert len(source["shadowed_paths"]) == 1
         assert "amplifier-bundle-routing-matrix-test" in source["shadowed_paths"][0]

--- a/tests/test_session_spawner.py
+++ b/tests/test_session_spawner.py
@@ -48,6 +48,12 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _home(isolated_home):
+    """Every test here reaches SessionStore() -> Path.home(). See conftest.isolated_home."""
+    return isolated_home
+
+
 class TestGenerateSubSessionId:
     def _assert_format(
         self,
@@ -200,14 +206,12 @@ class TestResumeErrorHandling:
 
     async def test_resume_nonexistent_session_fails(self, tmp_path, monkeypatch):
         """Test that resuming non-existent session raises FileNotFoundError."""
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         with pytest.raises(FileNotFoundError, match="not found.*may have expired"):
             await resume_sub_session("fake-session-id", "Test instruction")
 
     async def test_resume_with_missing_config(self, tmp_path, monkeypatch):
         """Test that resume fails gracefully when metadata lacks config."""
-        monkeypatch.setenv("HOME", str(tmp_path))
         # Use default SessionStore (will use HOME/.amplifier/projects/...)
         store = SessionStore()
 
@@ -230,7 +234,6 @@ class TestResumeErrorHandling:
 
     async def test_resume_with_corrupted_metadata_file(self, tmp_path, monkeypatch):
         """Test that resume handles corrupted metadata.json gracefully."""
-        monkeypatch.setenv("HOME", str(tmp_path))
         # Use default SessionStore (will resolve to HOME/.amplifier/projects/...)
         store = SessionStore()
 
@@ -397,7 +400,6 @@ class TestCapabilityRegistrationIntegration:
         """
         from unittest.mock import AsyncMock, MagicMock, patch
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         # Create a valid session to resume
         store = SessionStore()
@@ -469,7 +471,6 @@ class TestCapabilityRegistrationIntegration:
         """Test that resume_sub_session restores session.working_dir from metadata."""
         from unittest.mock import AsyncMock, MagicMock, patch
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         # Create session with working_dir
         store = SessionStore()
@@ -535,7 +536,6 @@ class TestCapabilityRegistrationIntegration:
         """
         from unittest.mock import AsyncMock, MagicMock, patch
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         # Create session WITHOUT working_dir
         store = SessionStore()
@@ -613,7 +613,6 @@ class TestSpawnEnrichment:
 
         from amplifier_app_cli.session_spawner import spawn_sub_session
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         # --- parent session mock ---
         parent_coordinator = MagicMock()
@@ -738,7 +737,6 @@ class TestSpawnEnrichment:
 
         from amplifier_app_cli.session_spawner import spawn_sub_session
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         # --- parent session mock ---
         parent_coordinator = MagicMock()
@@ -833,7 +831,6 @@ class TestSpawnEnrichment:
         """Test that resume_sub_session returns status and turn_count from orchestrator:complete."""
         from unittest.mock import AsyncMock, MagicMock, patch
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         # Create a valid session to resume
         store = SessionStore()
@@ -1031,7 +1028,6 @@ class TestSessionMetadataFlow:
 
         from amplifier_app_cli.session_spawner import spawn_sub_session
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         # Track the config passed to AmplifierSession constructor
         captured_config: dict = {}
@@ -1195,7 +1191,6 @@ class TestRoutingFallbackFromAgentConfig:
 
         from amplifier_app_cli.session_spawner import spawn_sub_session
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         apply_called_with = {}
 
@@ -1314,7 +1309,6 @@ class TestRoutingFallbackFromAgentConfig:
         from amplifier_app_cli.session_spawner import spawn_sub_session
         from amplifier_foundation.spawn_utils import ProviderPreference
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         apply_called_with = {}
 
@@ -1425,7 +1419,6 @@ class TestRoutingFallbackFromAgentConfig:
 
         from amplifier_app_cli.session_spawner import spawn_sub_session
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         apply_call_count = {"n": 0}
 
@@ -1533,7 +1526,6 @@ class TestRoutingCapabilityPropagation:
 
         from amplifier_app_cli.session_spawner import spawn_sub_session
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         fake_routing = {"matrix": "balanced", "overrides": {"coding": "anthropic"}}
 
@@ -1638,7 +1630,6 @@ class TestRoutingCapabilityPropagation:
 
         from amplifier_app_cli.session_spawner import spawn_sub_session
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         registered_capabilities = {}
 
@@ -1828,7 +1819,6 @@ class TestSpawnMentionExpansion:
         from amplifier_app_cli.lib.mention_loading.app_resolver import AppMentionResolver
         from amplifier_app_cli.session_spawner import spawn_sub_session
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         FIXTURE_CONTENT = "SENTINEL_FIXTURE_SYSTEM_CONTENT_12345"
         fixture_file = tmp_path / "fixture.md"
@@ -1901,7 +1891,6 @@ class TestSpawnMentionExpansion:
         from amplifier_app_cli.lib.mention_loading.app_resolver import AppMentionResolver
         from amplifier_app_cli.session_spawner import spawn_sub_session
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         FIXTURE_CONTENT = "SENTINEL_FIXTURE_INSTRUCTION_67890"
         fixture_file = tmp_path / "task.md"
@@ -2093,7 +2082,6 @@ class TestSpawnSystemPromptFactory:
     async def test_factory_registered_when_context_supports_it(self, tmp_path, monkeypatch):
         """Context exposing set_system_prompt_factory: the factory is registered with
         the exact system_instruction; no static system message is added."""
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         context = _FactoryContext()
         parent_session, child_session = self._make_sessions(context)
@@ -2122,7 +2110,6 @@ class TestSpawnSystemPromptFactory:
         """Context exposing ONLY add_message (no set_system_prompt_factory attribute)
         falls back to the static system message -- regression guard for pre-fix
         behavior."""
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         context = _StaticOnlyContext()
         assert not hasattr(context, "set_system_prompt_factory")
@@ -2146,7 +2133,6 @@ class TestSpawnSystemPromptFactory:
     async def test_no_instruction_registers_nothing(self, tmp_path, monkeypatch):
         """No system_instruction on the agent config: neither the factory nor
         add_message should be invoked for a system message."""
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         context = _FactoryContext()
         parent_session, child_session = self._make_sessions(context)
@@ -2171,7 +2157,6 @@ class TestSpawnSystemPromptFactory:
         raw pre-expansion instruction string."""
         from amplifier_app_cli.lib.mention_loading.app_resolver import AppMentionResolver
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         FIXTURE_CONTENT = "SENTINEL_FACTORY_EXPANSION_54321"
         fixture_file = tmp_path / "fixture.md"
@@ -2276,7 +2261,6 @@ class TestResumeMentionExpansion:
 
         from amplifier_app_cli.session_spawner import resume_sub_session
 
-        monkeypatch.setenv("HOME", str(tmp_path))
 
         FIXTURE_CONTENT = "SENTINEL_FIXTURE_RESUME_CONTENT_99999"
         fixture_file = tmp_path / "resume_task.md"

--- a/tests/test_skills_cli.py
+++ b/tests/test_skills_cli.py
@@ -100,6 +100,7 @@ class TestProcessInputSkillShortcuts:
         """Discover and invoke amplifier-config from only the packaged skills dir."""
         monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("HOME", str(tmp_path / "isolated-home"))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path / "isolated-home"))
         packaged_dir = Path(config.__file__).parent.parent / "data" / "skills"
 
         shortcuts = {}

--- a/tests/test_timedout_session_resumable.py
+++ b/tests/test_timedout_session_resumable.py
@@ -52,6 +52,12 @@ def anyio_backend():
     return "asyncio"
 
 
+@pytest.fixture(autouse=True)
+def _home(isolated_home):
+    """Every test here reaches SessionStore() -> Path.home(). See conftest.isolated_home."""
+    return isolated_home
+
+
 # ---------------------------------------------------------------------------
 # Fakes
 # ---------------------------------------------------------------------------
@@ -228,7 +234,6 @@ class TestTimedOutSessionIsResumable:
         self, tmp_path, monkeypatch
     ):
         """The advertised session_id exists in SessionStore after a timeout."""
-        monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("AMPLIFIER_SPAWN_CHECKPOINT_INTERVAL_S", "0")
 
         hooks = FakeHooks()
@@ -271,7 +276,6 @@ class TestTimedOutSessionIsResumable:
         resume_sub_session(session_id) and observe the preserved messages
         restored into the resumed session's context.
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("AMPLIFIER_SPAWN_CHECKPOINT_INTERVAL_S", "0")
 
         hooks = FakeHooks()
@@ -350,8 +354,6 @@ class TestNonResumableIsStatedExplicitly:
     ):
         from amplifier_app_cli.session_spawner import resume_sub_session
 
-        monkeypatch.setenv("HOME", str(tmp_path))
-
         with pytest.raises(FileNotFoundError) as excinfo:
             await resume_sub_session("never-existed-session-id", "carry on")
 
@@ -376,7 +378,6 @@ class TestNonResumableIsStatedExplicitly:
         """
         from amplifier_app_cli.session_spawner import resume_sub_session
 
-        monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("AMPLIFIER_SPAWN_CHECKPOINT_INTERVAL_S", "-1")
 
         hooks = FakeHooks()
@@ -421,7 +422,6 @@ class TestNoUnboundedAwaitOnCancellationPath:
         accident (e.g. via a short-circuit that skipped the await for an
         unrelated reason).
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("AMPLIFIER_SPAWN_CHECKPOINT_INTERVAL_S", "0")
 
         hooks = FakeHooks()
@@ -502,7 +502,6 @@ class TestNoUnboundedAwaitOnCancellationPath:
         self, tmp_path, monkeypatch
     ):
         """Checkpointing must not swallow the timeout or skip child cleanup."""
-        monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("AMPLIFIER_SPAWN_CHECKPOINT_INTERVAL_S", "0")
 
         hooks = FakeHooks()
@@ -538,7 +537,6 @@ class TestCheckpointBoundary:
         whose tool_calls have no matching results; resuming that transcript
         reproduces "No tool call found for function call output".
         """
-        monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("AMPLIFIER_SPAWN_CHECKPOINT_INTERVAL_S", "0")
 
         hooks = FakeHooks()
@@ -565,7 +563,6 @@ class TestCheckpointIsBestEffort:
     async def test_failing_checkpoint_does_not_break_the_run(
         self, tmp_path, monkeypatch
     ):
-        monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("AMPLIFIER_SPAWN_CHECKPOINT_INTERVAL_S", "0")
 
         hooks = FakeHooks()
@@ -599,7 +596,6 @@ class TestCheckpointIsBestEffort:
         self, tmp_path, monkeypatch
     ):
         """No hooks -> no mid-run checkpoints, but the id must still resolve."""
-        monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("AMPLIFIER_SPAWN_CHECKPOINT_INTERVAL_S", "0")
 
         context = FakeContext()
@@ -624,7 +620,6 @@ class TestCheckpointIsBestEffort:
 class TestThrottleAndEscapeHatch:
     async def test_interval_throttles_mid_run_checkpoints(self, tmp_path, monkeypatch):
         """A large interval collapses N provider calls to the one pre-registration."""
-        monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("AMPLIFIER_SPAWN_CHECKPOINT_INTERVAL_S", "3600")
 
         hooks = FakeHooks()
@@ -654,7 +649,6 @@ class TestThrottleAndEscapeHatch:
         self, tmp_path, monkeypatch
     ):
         """The documented escape hatch, and its cost, pinned in one test."""
-        monkeypatch.setenv("HOME", str(tmp_path))
         monkeypatch.setenv("AMPLIFIER_SPAWN_CHECKPOINT_INTERVAL_S", "-1")
 
         hooks = FakeHooks()


### PR DESCRIPTION
## Why

Windows CI has failed on `main` for every recent run — 8 tests (e.g. run [33706023624](https://github.com/microsoft/amplifier-app-cli/actions/runs/33706023624) @ `b85867c`). Two independent root causes. One is a **real display bug**; the rest are POSIX-only assumptions in tests, one of which is also a hygiene hazard for anyone running the suite on a Windows machine.

## 1. `routing list` / `show` rendered mixed separators — **product bug, 4 tests**

`_display_path` abbreviated a home-relative path as `f"~/{path.relative_to(Path.home())}"`. On Windows the remainder stringifies with backslashes, so the separator switched mid-path — in the terminal **and** in the JSON `matrix_file` field:

```
~/.amplifier\routing\openai.yaml
~/.amplifier\cache\amplifier-bundle-routing-matrix-test\routing\balanced.yaml
```

…while the CLI's own help text spells that location `~/.amplifier/routing/...`. `~/` is a POSIX-style abbreviation, so the remainder now renders via `as_posix()` on every platform. A path outside the home directory isn't abbreviated and stays in native form — unchanged.

`test_routing_shadowing.py:249, :405` · `test_routing_winner_selection.py:323, :400`

## 2. Two `matrix_path` assertions were POSIX-specific — **test bug, 2 tests**

`matrix_path` is a native absolute path — correctly; a user or tool may open it. `.endswith("/.amplifier/routing/openai.yaml")` can never hold against `C:\...\.amplifier\routing\openai.yaml`. Now compared as a `Path`.

`test_routing_shadowing.py:304` · `test_routing_winner_selection.py:346`

## 3. `monkeypatch.setenv("HOME", tmp_path)` isolates nothing on Windows — **test bug, 2 failing tests; 47 sites in 5 files with the same latent hazard**

`Path.home()` is `os.path.expanduser("~")`. On Windows, `ntpath.expanduser` reads `USERPROFILE` (then `HOMEDRIVE`+`HOMEPATH`) and **never consults `HOME`**. So every `SessionStore`-touching test in these files wrote real records into the runner's — or a Windows developer's — *actual* `~/.amplifier/projects/<slug>/sessions/`, and the two tests asserting `not SessionStore().exists(SUB_SESSION_ID)` found the record a previous checkpointing test had left there.

Fixed once: `tests/conftest.py` gains `isolated_home` (sets `HOME` **and** `USERPROFILE`, returns `tmp_path`). Each affected module opts in with a 3-line autouse fixture; its per-test `HOME` lines are removed so there is one mechanism, not two.

| file | sites |
|---|---|
| `test_timedout_session_resumable.py` (the 2 failing) | 12 |
| `test_session_spawner.py` | 22 |
| `test_resume_preserves_provider_promotion.py` | 8 |
| `test_resume_system_prompt.py` | 4 |
| `test_skills_cli.py` (custom path; `USERPROFILE` added beside it) | 1 |

The three non-failing files had the identical defect — their assertions merely never depended on the isolation holding.

## Verification

No Windows host available, so each fix was checked against the **exact values the CI log recorded**, with Windows path semantics simulated via `PureWindowsPath` / `ntpath.expanduser`:

| | old | new |
|---|---|---|
| `_display_path` | `~/.amplifier\\routing\\openai.yaml` | `~/.amplifier/routing/openai.yaml` (both CI values; outside-home unchanged) |
| `matrix_path` assert | `.endswith(...)` → `False` on the CI value | `Path ==` → `True` (Windows **and** POSIX) |
| home isolation | `HOME` only → `expanduser('~')` = `C:\Users\runneradmin` | `HOME`+`USERPROFILE` → the tmp path |

Linux: **1647 pass** (count unchanged), deterministic and random order. Two touched test files weren't `ruff format`-clean on `main`; they were edited surgically (per-test line removals + the fixture) rather than reformatted, so the diff is the change and nothing else. `ruff check` clean on all 9 touched files; the 5 remaining repo-wide lint findings are pre-existing on `main`.

**This PR should be merged only when the Windows jobs are actually green** — that's the point of it.
