### PR TITLE
fix(logging): resolve sys.stderr at emit time so log records stop scribbling over the prompt

### DIFF
--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -182,6 +182,72 @@ def _ensure_utf8_output() -> None:
             pass  # Not a real Windows console (e.g. some CI/test environments)
 
 
+class _LateBoundStderrHandler(logging.StreamHandler):
+    """A ``StreamHandler`` that resolves ``sys.stderr`` at emit time, not at init.
+
+    ``logging.StreamHandler.__init__`` does ``self.stream = stream`` and
+    ``emit()`` then writes to that *captured object*. That eager binding is a
+    display bug in an interactive CLI, because ``patch_stdout()`` works by
+    **rebinding the names** ``sys.stdout``/``sys.stderr`` to a ``StdoutProxy``
+    -- it cannot reach through to an object something else already grabbed.
+
+    ``_configure_console_logging()`` runs from ``main()`` at process start,
+    long before any ``patch_stdout()`` context is entered (``main.py:3853``
+    around the whole turn, ``main.py:4014`` around the REPL prompt). So the
+    handler captured the *original* ``TextIOWrapper``, and every
+    ``logger.warning(...)`` in the process wrote straight past the proxy into
+    a terminal that prompt_toolkit was actively rendering into -- injecting
+    the text at the cursor, on top of the input box, with none of the
+    erase/redraw that ``run_in_terminal`` exists to provide.
+
+    Rich never had this bug, and the reason is already documented in this
+    codebase as a load-bearing assumption -- ``steering_input.py:10-14``:
+
+        Rich's ``Console.file`` property reads ``sys.stdout`` dynamically
+        [...] so the patched proxy is picked up at write time automatically
+        -- no changes to ``console.py`` are required.
+
+    That reasoning was simply never extended to ``logging``. This class
+    extends it: ``stream`` becomes a property that returns whatever
+    ``sys.stderr`` is *right now*, so a record emitted inside a
+    ``patch_stdout()`` context goes through the proxy and gets the
+    ``run_in_terminal`` erase-prologue/redraw treatment, exactly like Rich
+    output does. Outside such a context -- non-interactive runs, piped
+    output, ``--output json`` -- ``sys.stderr`` is the ordinary stream and
+    behavior is byte-for-byte what it was before.
+
+    The setter is **required**, not decorative: ``StreamHandler.__init__``
+    assigns ``self.stream``, and ``StreamHandler.setStream()`` assigns it
+    again. A bare read-only property would raise ``AttributeError`` during
+    construction. It also preserves the escape hatch: assigning a stream that
+    is *not* the current ``sys.stderr`` pins it, so ``setStream(open(...))``
+    still behaves like a stock ``StreamHandler``; assigning the live
+    ``sys.stderr`` (which is all ``__init__`` does) leaves the handler
+    late-bound.
+    """
+
+    def __init__(self) -> None:
+        # Must exist before super().__init__() -- that assignment routes
+        # through the setter below.
+        self._pinned_stream: object | None = None
+        super().__init__()
+
+    @property
+    def stream(self):  # type: ignore[override]
+        """The stream to write to, resolved on every access."""
+        if self._pinned_stream is not None:
+            return self._pinned_stream
+        return sys.stderr
+
+    @stream.setter
+    def stream(self, value) -> None:
+        # `value is sys.stderr` is the eager capture this class exists to
+        # defeat (StreamHandler.__init__ does exactly that) -- ignore it and
+        # stay late-bound. Anything else is a deliberate redirect and is
+        # honored, so setStream()/flush()/close() keep working normally.
+        self._pinned_stream = None if value is None or value is sys.stderr else value
+
+
 def _configure_console_logging() -> None:
     """Install a minimal root logging handler if the process has none.
 
@@ -226,7 +292,7 @@ def _configure_console_logging() -> None:
         arg in ("--verbose", "-v", "--debug") for arg in sys.argv[1:]
     )
 
-    handler = logging.StreamHandler(sys.stderr)
+    handler = _LateBoundStderrHandler()
     handler.setLevel(logging.WARNING)
     handler.setFormatter(logging.Formatter("%(message)s"))
 

--- a/tests/test_log_over_prompt_integration.py
+++ b/tests/test_log_over_prompt_integration.py
@@ -1,0 +1,335 @@
+"""Real-pty A/B regression test for log records written over a live prompt.
+
+What this guards
+~~~~~~~~~~~~~~~~
+``_configure_console_logging()`` (``main.py``) installs the process's only
+root logging handler, at process start. ``main()`` calls it long before any
+``patch_stdout()`` context is entered -- ``main.py:3853`` wraps the whole turn
+(with the ``SteeringInputManager``'s anchored prompt live for its entire
+duration), ``main.py:4014`` wraps the REPL prompt between turns. In an
+interactive session a prompt_toolkit ``Application`` is therefore rendering
+essentially all of the time.
+
+``patch_stdout()`` works by rebinding the *names* ``sys.stdout`` and
+``sys.stderr`` to a ``StdoutProxy`` (prompt_toolkit 3.0.52,
+``patch_stdout.py``: ``sys.stdout = proxy`` / ``sys.stderr = proxy``). It
+cannot reach an object that something else already captured -- and
+``logging.StreamHandler.__init__`` captures eagerly (``self.stream = stream``),
+with ``emit()`` writing to that captured object. So a stock
+``StreamHandler(sys.stderr)`` built at process start writes *past* the proxy,
+straight into a terminal prompt_toolkit currently owns, injecting text at the
+cursor and scribbling over the input box.
+
+Rich never had this bug because ``Console.file`` resolves ``sys.stdout``
+lazily on every write (``rich/console.py:762``) -- reasoning this repo already
+records as load-bearing at ``steering_input.py:10-14``. It was simply never
+extended to ``logging``. ``_LateBoundStderrHandler`` extends it.
+
+Why a pty, and why assert on raw bytes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This is a *terminal rendering* defect: both variants log the same string, at
+the same level, through the same filters. Nothing about the record differs.
+The only thing that differs is where the bytes land relative to the prompt
+render -- which is observable only on a real terminal, in the raw byte
+stream. A mock, a ``StringIO``, or a captured-``stderr`` assertion would pass
+identically on the broken and the fixed build, i.e. would prove nothing.
+
+The discriminator is structural, and is the mechanism itself rather than a
+cosmetic detail: when a write reaches the proxy, prompt_toolkit routes it
+through ``run_in_terminal``, which **erases the rendered app first** (a
+cursor-left + erase-down prologue), writes the text on a clean line, and then
+redraws the prompt below. A write that bypasses the proxy has no prologue --
+the text simply appears wherever the cursor happened to be sitting.
+
+Measured on Linux (prompt_toolkit 3.0.52), bytes between the last prompt
+render and the log text::
+
+    stock   ...PROMPTBOX>\\x1b[10D\\x1b[11C\\x1b[?7h\\x1b[0m\\x1b[?12l\\x1b[?25h
+            WARNTEXT...                          <- at the cursor, no prologue
+    fixed   ...PROMPTBOX>\\x1b[10D\\x1b[11C\\x1b[?7h\\x1b[0m\\x1b[?12l\\x1b[?25h
+            \\x1b[11D\\x1b[J\\x1b[0m\\x1b[?7h\\x1b[?2004l\\x1b[?7h   <- erase prologue
+            WARNTEXT...                          <- clean line
+            \\x1b[?2004h...PROMPTBOX>...          <- prompt redrawn below
+
+The warning is emitted from a **background asyncio task**, matching the real
+trigger: ``amplifier-module-hooks-session-naming`` fires its check as a
+fire-and-forget ``asyncio.create_task`` and returns immediately, so its
+warning lands after the REPL has already re-entered ``prompt_async()``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+if sys.platform == "win32":  # pragma: no cover - see ci.yml matrix comment
+    pytest.skip(
+        "pty.fork() is POSIX-only; there is no Windows equivalent.",
+        allow_module_level=True,
+    )
+
+from pty_harness import fork_pty_child
+
+# Distinctive so it cannot collide with prompt_toolkit's own chatter (e.g. its
+# "terminal doesn't support cursor position requests (CPR)" notice).
+MARKER = "WARNTEXT_model_role_fast_resolved_to_openai"
+PROMPT = "PROMPTBOX> "
+
+ERASE_DOWN = b"\x1b[J"
+
+# Child timeline (seconds). Generous relative to a render, but every wait in
+# the parent is bounded -- a test may fail, a test may never hang.
+_WARN_AT = 1.2
+_EXIT_AT = 3.0
+_CHILD_TIMEOUT = 20.0
+
+
+def _child_body(fixed: bool) -> None:
+    """Run a live prompt and log a warning from a background task."""
+    import asyncio
+    import logging
+
+    # ``pty.fork()`` points fds 0/1/2 at the pty slave, but under pytest the
+    # inherited ``sys.stdout``/``sys.stderr`` *objects* are still the runner's
+    # capture wrappers, which write elsewhere entirely. Rebind them onto the
+    # pty fds so the child is in the same state a real CLI process is: stdio
+    # objects backed by a real terminal. Without this the child would render
+    # into pytest's capture buffer and the pty would stay empty -- a test that
+    # passes while exercising nothing.
+    # stdin matters too: pytest replaces it with a reader that immediately
+    # reports EOF, which makes ``prompt_async()`` return before the background
+    # warning ever fires -- i.e. no prompt would be live at the moment under test.
+    sys.stdin = os.fdopen(0, "r", closefd=False)
+    sys.stdout = os.fdopen(1, "w", buffering=1, closefd=False)
+    sys.stderr = os.fdopen(2, "w", buffering=1, closefd=False)
+
+    from prompt_toolkit import PromptSession
+
+    from amplifier_app_cli.stdout_offload import patch_stdout_offloaded as patch_stdout
+
+    # --- replicate _configure_console_logging(), which runs at process start,
+    # --- BEFORE any patch_stdout() context exists. Ordering is the bug.
+    root = logging.getLogger()
+    for stale in list(root.handlers):
+        root.removeHandler(stale)
+
+    handler: logging.Handler
+    if fixed:
+        from amplifier_app_cli.main import _LateBoundStderrHandler
+
+        handler = _LateBoundStderrHandler()
+    else:
+        # Exactly what main.py:229 did before this fix.
+        handler = logging.StreamHandler(sys.stderr)
+
+    handler.setLevel(logging.WARNING)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root.addHandler(handler)
+    root.setLevel(logging.WARNING)
+
+    log = logging.getLogger("amplifier_module_hooks_session_naming")
+
+    async def _main() -> None:
+        # Entered LATER than the handler was built -- as in main.py.
+        with patch_stdout(raw=True):
+            session: PromptSession = PromptSession()
+
+            async def _warn_from_background() -> None:
+                await asyncio.sleep(_WARN_AT)
+                log.warning(MARKER)
+
+            async def _quit() -> None:
+                await asyncio.sleep(_EXIT_AT)
+                os._exit(0)
+
+            asyncio.create_task(_warn_from_background())
+            asyncio.create_task(_quit())
+
+            await session.prompt_async(PROMPT)
+
+    asyncio.run(_main())
+
+
+def _capture(fixed: bool) -> bytes:
+    """Fork a pty child, let it run to completion, return everything it wrote."""
+    # The child inherits this process's stdio buffers; anything still sitting
+    # unflushed here would be flushed by the child straight into the pty and
+    # would pollute the capture.
+    sys.stdout.flush()
+    sys.stderr.flush()
+
+    child = fork_pty_child(lambda: _child_body(fixed))
+    try:
+        child.wait(_CHILD_TIMEOUT)
+        # Let the drain thread pick up whatever landed just before exit.
+        time.sleep(0.4)
+        return child.output
+    finally:
+        child.kill()
+        child.close()
+
+
+def _segment_before_marker(data: bytes) -> bytes:
+    """Bytes emitted between the last prompt render and the log text.
+
+    This is the window the prologue must appear in. Slicing from the last
+    ``PROMPT`` occurrence *before* the marker keeps the assertion insensitive
+    to unrelated chatter elsewhere in the stream.
+    """
+    marker = MARKER.encode()
+    idx = data.find(marker)
+    assert idx != -1, (
+        f"log record never reached the terminal at all; the scenario did not "
+        f"exercise what it claims to. captured={data!r}"
+    )
+    prompt_idx = data.rfind(PROMPT.strip().encode(), 0, idx)
+    assert prompt_idx != -1, (
+        f"no prompt was rendered before the log record -- the prompt_toolkit "
+        f"Application was not live, so this run proves nothing. captured={data!r}"
+    )
+    return data[prompt_idx:idx]
+
+
+def test_stock_streamhandler_injects_log_text_at_the_cursor() -> None:
+    """The defect, pinned: a stock handler writes with no erase prologue.
+
+    This asserts the *broken* behavior on purpose. If prompt_toolkit or CPython
+    ever changes such that an eagerly-bound handler stops corrupting the
+    prompt, this test fails and the fix below can be re-evaluated rather than
+    cargo-culted.
+    """
+    data = _capture(fixed=False)
+    segment = _segment_before_marker(data)
+
+    assert ERASE_DOWN not in segment, (
+        "expected the stock StreamHandler to bypass the StdoutProxy and inject "
+        "text at the cursor with no run_in_terminal erase prologue, but an "
+        f"erase-down was present. segment={segment!r}"
+    )
+
+
+def test_late_bound_handler_routes_log_text_through_run_in_terminal() -> None:
+    """The fix: the record is erased-for, written clean, and the prompt redrawn."""
+    data = _capture(fixed=True)
+    segment = _segment_before_marker(data)
+
+    assert ERASE_DOWN in segment, (
+        "expected _LateBoundStderrHandler to resolve sys.stderr at emit time and "
+        "reach the patched StdoutProxy, so prompt_toolkit's run_in_terminal "
+        "erases the rendered prompt before writing -- no erase-down found "
+        f"between the prompt render and the log text. segment={segment!r}"
+    )
+
+    marker = MARKER.encode()
+    after = data[data.find(marker) + len(marker) :]
+    assert PROMPT.strip().encode() in after, (
+        "run_in_terminal must redraw the prompt after the log text; no prompt "
+        f"render followed the record. after={after!r}"
+    )
+
+
+def test_late_bound_handler_is_transparent_without_patch_stdout() -> None:
+    """No proxy installed -> byte-identical behavior to a stock handler.
+
+    Non-interactive runs, piped output and ``--output json`` never enter a
+    ``patch_stdout()`` context. The fix must be inert there.
+    """
+    import logging
+    from io import StringIO
+
+    from amplifier_app_cli.main import _LateBoundStderrHandler
+
+    handler = _LateBoundStderrHandler()
+    handler.setLevel(logging.WARNING)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    original = sys.stderr
+    buffer = StringIO()
+    sys.stderr = buffer
+    try:
+        record = logging.LogRecord(
+            name="t",
+            level=logging.WARNING,
+            pathname=__file__,
+            lineno=1,
+            msg=MARKER,
+            args=(),
+            exc_info=None,
+        )
+        handler.emit(record)
+    finally:
+        sys.stderr = original
+
+    assert buffer.getvalue() == MARKER + "\n"
+
+
+def test_configure_console_logging_installs_the_late_bound_handler() -> None:
+    """Pins the wiring at ``main.py:229``.
+
+    The pty tests above construct the handler directly, so they would keep
+    passing even if ``_configure_console_logging()`` went back to a stock
+    ``StreamHandler``. This is the assertion that notices.
+    """
+    import logging
+
+    from amplifier_app_cli.main import (
+        _configure_console_logging,
+        _LateBoundStderrHandler,
+    )
+
+    root = logging.getLogger()
+    saved = list(root.handlers)
+    for stale in saved:
+        root.removeHandler(stale)
+    try:
+        _configure_console_logging()
+        installed = root.handlers
+        assert len(installed) == 1
+        assert isinstance(installed[0], _LateBoundStderrHandler), (
+            "the root console handler must resolve sys.stderr at emit time; a "
+            f"stock StreamHandler captures it at init. got={installed[0]!r}"
+        )
+    finally:
+        for stale in list(root.handlers):
+            root.removeHandler(stale)
+        for original in saved:
+            root.addHandler(original)
+
+
+def test_late_bound_handler_honors_an_explicit_setstream() -> None:
+    """``setStream(other)`` still pins, so the escape hatch is intact."""
+    import logging
+    from io import StringIO
+
+    from amplifier_app_cli.main import _LateBoundStderrHandler
+
+    handler = _LateBoundStderrHandler()
+    handler.setFormatter(logging.Formatter("%(message)s"))
+
+    pinned = StringIO()
+    handler.setStream(pinned)
+
+    decoy = StringIO()
+    original = sys.stderr
+    sys.stderr = decoy
+    try:
+        record = logging.LogRecord(
+            name="t",
+            level=logging.WARNING,
+            pathname=__file__,
+            lineno=1,
+            msg=MARKER,
+            args=(),
+            exc_info=None,
+        )
+        handler.emit(record)
+    finally:
+        sys.stderr = original
+
+    assert pinned.getvalue() == MARKER + "\n"
+    assert decoy.getvalue() == ""


### PR DESCRIPTION
## The defect

`_configure_console_logging()` installs the process's **only** root logging handler, and it did so with a stock `logging.StreamHandler(sys.stderr)` (`main.py:229`). CPython binds that stream **eagerly**:

```python
# logging/__init__.py
def __init__(self, stream=None):
    if stream is None:
        stream = sys.stderr
    self.stream = stream          # captured here, once

def emit(self, record):
    stream = self.stream          # ...and written to here, forever
    stream.write(msg + self.terminator)
```

`main()` calls `_configure_console_logging()` at process entry (`main.py:4621`), long before any `patch_stdout()` context exists. And `patch_stdout()` works by **rebinding the names**:

```python
# prompt_toolkit/patch_stdout.py (3.0.52)
sys.stdout = cast(TextIO, proxy)
sys.stderr = cast(TextIO, proxy)
```

Rebinding a name cannot reach an object something else already captured. So every `logger.warning(...)` in the process wrote **straight past the proxy**, into a terminal prompt_toolkit was actively rendering into — the text landed at the cursor, on top of the input box, with none of the erase/redraw that `run_in_terminal` exists to provide.

**Rich never had this bug**, and the reason is already recorded in this repo as a load-bearing assumption — `steering_input.py:10-14`:

> Rich's `Console.file` property reads `sys.stdout` dynamically (`self._file` is `None` by default in the singleton created at module import), so the patched proxy is picked up at write time automatically — no changes to `console.py` are required.

That is exactly right (`rich/console.py:762`). It was simply never extended to `logging`. This PR extends it.

## Why there is no safe window

A prompt_toolkit `Application` is live essentially all the time in an interactive session:

| Where | What holds the terminal |
|---|---|
| `main.py:3853` | `patch_stdout(raw=True)` around the **whole turn** |
| `main.py:3854` -> `steering_input.py:392` | `SteeringInputManager.run()` pins a prompt at the bottom for the turn's entire duration |
| `main.py:4014` | `patch_stdout()` around `prompt_async()` **between** turns |

There is no gap to land a log record in. Nor is there any handler-level mitigation to lean on: `logging.disable`, `NullHandler`, `removeHandler`, `QueueHandler`, `MemoryHandler` are **0 hits each** across `amplifier_app_cli/` and `tests/`, and the two existing filters act on record *content* (`ui/log_filter.py:32`) and *exception metadata* (`main.py:235`) — neither touches stream binding.

## The fix

`_LateBoundStderrHandler(logging.StreamHandler)` makes `stream` a property that resolves `sys.stderr` on every access. Five lines of behavior; the rest is the docstring explaining why.

**The setter is required, not decorative.** `StreamHandler.__init__` assigns `self.stream`, and `setStream()` assigns it again — a bare read-only property raises `AttributeError` during construction. The setter distinguishes the two cases:

| assignment | behavior |
|---|---|
| the current `sys.stderr` (all `__init__` does) | ignored — stays late-bound |
| anything else (`setStream(open(...))`) | pinned — stock `StreamHandler` semantics preserved |
| `None` | resets to late-bound |

`setLevel`, the existing `_suppress_traceback` filter and `LLMErrorLogFilter` are untouched — they act on records, not streams. No `FileHandler` path is affected: this repo constructs **exactly one** logging handler anywhere (`main.py:229`) and defines no other `logging.Handler` subclass.

This fixes **every** `logger.warning` in the process at once, not one message.

## Evidence: real pty, raw bytes

A mock, a `StringIO`, or a captured-`stderr` assertion passes identically on the broken and the fixed build — both variants log the same string, at the same level, through the same filters. The only thing that differs is *where the bytes land relative to the prompt render*, which is observable only on a real terminal. `tests/test_log_over_prompt_integration.py` drives a real pty, puts a live `prompt_async()` prompt up, and emits the warning from a **background asyncio task** (matching the real trigger — see below).

Measured on Linux, prompt_toolkit 3.0.52 — bytes between the completed prompt render and the log text:

```
stock   ...PROMPTBOX>\x1b[10D\x1b[11C\x1b[?7h\x1b[0m\x1b[?12l\x1b[?25h
        WARNTEXT_...                       <- at the cursor. no prologue.
        \x1b[11D\x1b[J...\x1b[?2004l       <- teardown only afterwards

fixed   ...PROMPTBOX>\x1b[10D\x1b[11C\x1b[?7h\x1b[0m\x1b[?12l\x1b[?25h
        \x1b[11D\x1b[J\x1b[0m\x1b[?7h\x1b[?2004l\x1b[?7h   <- erase prologue
        WARNTEXT_...                       <- clean line
        \x1b[?2004h...PROMPTBOX>...        <- prompt redrawn below
```

### The tests are not vacuous — shown by mutation

| mutation applied | which tests fail |
|---|---|
| make the `stream` property eager again (pin at `__init__`) | `test_late_bound_handler_routes_log_text_through_run_in_terminal`, `test_late_bound_handler_is_transparent_without_patch_stdout` |
| revert `main.py:229` to `logging.StreamHandler(sys.stderr)` | `test_configure_console_logging_installs_the_late_bound_handler` |
| none (this branch) | **5 passed** |

The wiring test exists specifically because the pty tests construct the handler directly and would keep passing if `_configure_console_logging()` regressed.

`test_stock_streamhandler_injects_log_text_at_the_cursor` deliberately asserts the **broken** behavior. If CPython or prompt_toolkit ever changes such that an eagerly-bound handler stops corrupting the prompt, that test fails and this fix gets re-evaluated instead of cargo-culted.

## Evidence: isolated environment, real installed wheel

Verified in an isolated Incus container (Digital Twin Universe `dtu-30bb4c32`, since destroyed) running Amplifier installed the way a user installs it — `uv tool install git+https://github.com/microsoft/amplifier` — with a URL rewrite pointing the `amplifier-app-cli` dependency at this branch. **Not** an editable install, not the working tree:

```
$ amplifier --version
amplifier, version 2026.09.04-0d00796 (core 1.6.1)

$ cat .../site-packages/amplifier_app_cli-*.dist-info/direct_url.json
{"url":"https://github.com/microsoft/amplifier-app-cli",
 "vcs_info":{"vcs":"git","commit_id":"0d0079699477bb0b8161e5d68f35b4709cc0bde2",
             "requested_revision":"main"}}

FILE            : /root/.local/share/uv/tools/amplifier/lib/python3.12/site-packages/amplifier_app_cli/main.py
HAS CLASS       : True
IS StreamHandler: True
stream is prop  : True
HANDLER CTOR    : ['handler = _LateBoundStderrHandler()']
```

**A real two-turn interactive `amplifier run --mode chat` session in that container**, configured with two different-vendor providers (anthropic at the lowest numeric priority, so it answers the session) and `routing.matrix: openai` — which makes `hooks-session-naming` emit its genuine cross-provider refusal on turn 2. Raw bytes off the pty, at the moment the warning lands:

```
\x1b[?2004h                      <- prompt_toolkit Application live
\x1b[?25l...\x1b[J...\r\r\n
\x1b[0;32;1m>\x08\x1b[2C          <- input box drawn
\x1b[?7h\x1b[0m\x1b[?12l\x1b[?25h <- cursor shown, render complete
                                    (this is where the old build injected)
\x1b[2D\x1b[A\x1b[J               <- ERASE PROLOGUE: left, up, erase-down
\x1b[0m\x1b[?7h\x1b[?2004l\x1b[?7h <- app suspended for run_in_terminal
model_role 'fast' resolved to provider 'openai', but it is a different
provider vendor than the one answering this session. REFUSING to borrow
it: session naming will run on 'anthropic', ...
\r\n
\x1b[?2004h...\x1b[J...>\x08\x1b[2C  <- prompt redrawn below
```

The input box is not touched.

## What this PR does **not** do

**The session-naming warning is correct and is deliberately left alone.** It reports a real routing misconfiguration — a `model_role` resolving to a foreign vendor, which naming correctly refuses to borrow — and `hooks-session-naming` is right to say so. Nothing here silences, filters, downgrades or defers it. That message's *content* is tracked separately as **microsoft-amplifier/amplifier-support#511**; this change is to the **display path only**, and it applies equally to every other `logger.warning` in the process.

## Honest limits

- **The A/B is within one build.** Both variants in the pty tests and in the container run against the same installed artifact, constructing the stock and fixed handler side by side. The real interactive two-turn session was captured on the **patched** build only — capturing the same session on unpatched upstream would have required a second isolated environment, which was outside the resource budget for this work. The pre-fix byte signature is nonetheless captured directly, in the same container, from the same live prompt.
- **The intended isolation used a local Gitea mirror**, per the `amplifier-user-sim` profile pattern. Docker was unavailable on the verification host, so the rewrite target was a public fork whose `main` carried this exact commit — structurally the same mechanism (same `url_rewrites` mitmproxy path, same `@main` ref), different host.
- **POSIX only.** The pty tests are `@pytest.mark.integration` and `pytest.skip` on win32, matching every other pty test here and the deliberate `matrix.os` exclusion in `ci.yml`. The fix itself is platform-independent.
- **One unrelated artifact appears in the capture:** prompt_toolkit's own "your terminal doesn't support cursor position requests (CPR)" notice. That is not a logging record — `Application.cpr_not_supported_callback` writes it via `self.output` (already wrapped in `run_in_terminal`), and it only appears because the harness's pty does not answer CPR. Out of scope, unaffected either way.

## Suite

| | before (`35ab604`) | after |
|---|---|---|
| `uv run pytest -q` | 1682 passed, 1 skipped, 13 deselected, 1 xfailed | **1682 passed**, 1 skipped, 18 deselected, 1 xfailed |
| `uv run pytest -m integration -q` | 13 passed | **18 passed** |
| failure set | *empty* | *empty* (diffed, identical) |

Pass count is unchanged; the 5 new tests are integration-marked, hence `deselected` 13 -> 18 by default and `+5` under `-m integration`. `ruff check amplifier_app_cli/main.py` produces a **byte-identical finding set** before and after this change; `ruff format` would touch the same 4 lines on both (pre-existing debt, deliberately not swept into this diff). The new test file is `ruff check` and `ruff format` clean.
