### PR TITLE
fix: prevent duplicate bundle registrations

### DIFF
--- a/amplifier_app_cli/commands/bundle.py
+++ b/amplifier_app_cli/commands/bundle.py
@@ -952,8 +952,6 @@ def bundle_add(uri: str, name_override: str | None, app: bool):
     # Use override name if provided, otherwise use name from metadata
     name = name_override or bundle_name
 
-    # All bundles are now stored in settings.yaml under bundle.added
-    # App bundles additionally go in bundle.app for composition policy
     app_settings = AppSettings()
 
     if app:
@@ -967,9 +965,8 @@ def bundle_add(uri: str, name_override: str | None, app: bool):
             console.print(f"  URI: {uri}")
             return
 
-        # Add to bundle.app (composition policy) AND bundle.added (for updates)
+        # App bundles are composition sources, not selectable registrations.
         app_settings.add_app_bundle(uri)
-        app_settings.add_bundle(name, uri)
         console.print(f"[green]✓ Added app bundle '{name}'[/green]")
         console.print(f"  URI: {uri}")
         if bundle_version:
@@ -981,6 +978,22 @@ def bundle_add(uri: str, name_override: str | None, app: bool):
     else:
         # Add to bundle.added in settings.yaml
         existing = app_settings.get_added_bundles()
+        existing_alias = next(
+            (
+                existing_name
+                for existing_name, existing_uri in existing.items()
+                if existing_name != name and existing_uri == uri
+            ),
+            None,
+        )
+        if existing_alias:
+            console.print(
+                "[yellow]Warning:[/yellow] Bundle URI already registered "
+                f"as '{existing_alias}'"
+            )
+            console.print(f"  URI: {uri}")
+            return
+
         if name in existing:
             console.print(
                 f"[yellow]Warning:[/yellow] Bundle '{name}' already registered"
@@ -1043,8 +1056,6 @@ def bundle_remove(name: str, app: bool):
         # Check if name is a URI directly in the list
         if name in app_bundles:
             app_settings.remove_app_bundle(name)
-            # Also remove from bundle.added (keeps settings in sync)
-            app_settings.remove_added_bundle(name)
             console.print("[green]✓ Removed app bundle[/green]")
             console.print(f"  URI: {name}")
             return
@@ -1058,8 +1069,6 @@ def bundle_remove(name: str, app: bool):
 
         if matching_uri:
             app_settings.remove_app_bundle(matching_uri)
-            # Also remove from bundle.added (keeps settings in sync)
-            app_settings.remove_added_bundle(name)
             console.print(f"[green]✓ Removed app bundle '{name}'[/green]")
             console.print(f"  URI: {matching_uri}")
         else:

--- a/amplifier_app_cli/commands/bundle.py
+++ b/amplifier_app_cli/commands/bundle.py
@@ -987,12 +987,20 @@ def bundle_add(uri: str, name_override: str | None, app: bool):
             None,
         )
         if existing_alias:
+            # Refusal, not a no-op: the requested alias was NOT created, so the
+            # end state does not match what was asked for. Exit non-zero -- a
+            # caller scripting `bundle add` must be able to tell "registered"
+            # from "refused", and a silent exit 0 here reads as success.
             console.print(
-                "[yellow]Warning:[/yellow] Bundle URI already registered "
-                f"as '{existing_alias}'"
+                f"[red]Error:[/red] Bundle URI already registered as '{existing_alias}'"
             )
             console.print(f"  URI: {uri}")
-            return
+            console.print(
+                f"\n[dim]Use '{existing_alias}' to refer to it, or run "
+                f"'amplifier bundle remove {existing_alias}' first to re-add "
+                "it under a different name.[/dim]"
+            )
+            sys.exit(1)
 
         if name in existing:
             console.print(

--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -378,12 +378,12 @@ async def _check_all_bundle_status() -> dict[str, "BundleStatus"]:
     checked_uris: set[str] = set()
 
     for bundle_name in bundle_names:
-        # Get URI without loading (avoids download side effect).
-        uri = registry.find(bundle_name)
-        if not uri:
-            continue
-        checked_uris.add(uri)
         try:
+            # Get URI without loading (avoids download side effect).
+            uri = registry.find(bundle_name)
+            if not uri:
+                continue
+            checked_uris.add(uri)
             results[bundle_name] = await _check_bundle_uri(bundle_name, uri)
         except Exception:
             continue  # Skip bundles that fail status check
@@ -1266,6 +1266,9 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
                 try:
                     _on_update_progress(bundle_name, "updating_bundle")
                     source_uri = bundle_results[bundle_name].bundle_source
+                    # Intentional: check_all_sources(include_all_cached=True) handles
+                    # cached modules separately. Load only the root bundle here to
+                    # prevent redundant include/module refreshes and write amplification.
                     loaded = asyncio.run(load_bundle(source_uri, auto_include=False))
                     if isinstance(loaded, dict):
                         bundle_errors[bundle_name] = "Expected single bundle, got dict"

--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -9,6 +9,7 @@ from rich.table import Table
 from rich.text import Text
 
 from ..lib.bundle_loader import AppBundleDiscovery
+from ..lib.settings import AppSettings
 from ..paths import create_bundle_registry
 from ..paths import create_config_manager
 from ..utils.display import create_sha_text
@@ -328,60 +329,74 @@ async def _check_all_bundle_status() -> dict[str, "BundleStatus"]:
     cache_dir = get_amplifier_home() / "cache"
     git_handler = GitSourceHandler()
 
-    # Use cached root bundles for update checking (all roots, not filtered user list)
-    bundle_names = discovery.list_cached_root_bundles()
-    results: dict[str, BundleStatus] = {}
+    async def _check_bundle_uri(bundle_name: str, uri: str) -> BundleStatus:
+        """Check one configured source without loading it."""
+        parsed = parse_uri(uri)
 
-    for bundle_name in bundle_names:
-        try:
-            # Get URI without loading (avoids download side effect)
-            uri = registry.find(bundle_name)
-            if not uri:
-                continue
-
-            # Check status directly from URI
-            parsed = parse_uri(uri)
-
-            # For file:// URIs (editable installs), check if this is a well-known
-            # bundle with a remote URI we can use for update checking
-            if parsed.is_file and bundle_name in WELL_KNOWN_BUNDLES:
-                well_known_info = WELL_KNOWN_BUNDLES[bundle_name]
-                remote_uri_value = well_known_info.get("remote")
-                if remote_uri_value and isinstance(remote_uri_value, str):
-                    # Use remote URI for status checking, but get local SHA from file path
-                    source_status = await _get_file_bundle_status(
-                        bundle_name, uri, remote_uri_value, git_handler, cache_dir
-                    )
-                    results[bundle_name] = BundleStatus(
-                        bundle_name=bundle_name,
-                        bundle_source=uri,
-                        sources=[source_status],
-                    )
-                    continue
-
-            if git_handler.can_handle(parsed):
-                source_status: SourceStatus = await git_handler.get_status(
-                    parsed, cache_dir
+        # For file:// URIs (editable installs), check if this is a well-known
+        # bundle with a remote URI we can use for update checking.
+        if parsed.is_file and bundle_name in WELL_KNOWN_BUNDLES:
+            well_known_info = WELL_KNOWN_BUNDLES[bundle_name]
+            remote_uri_value = well_known_info.get("remote")
+            if remote_uri_value and isinstance(remote_uri_value, str):
+                source_status = await _get_file_bundle_status(
+                    bundle_name, uri, remote_uri_value, git_handler, cache_dir
                 )
-                results[bundle_name] = BundleStatus(
+                return BundleStatus(
                     bundle_name=bundle_name,
                     bundle_source=uri,
                     sources=[source_status],
                 )
-            else:
-                # Non-git bundles - report as unknown
-                results[bundle_name] = BundleStatus(
-                    bundle_name=bundle_name,
-                    bundle_source=uri,
-                    sources=[
-                        SourceStatus(
-                            source_uri=uri,
-                            is_cached=True,
-                            has_update=None,
-                            summary="Update checking not supported for this source type",
-                        )
-                    ],
+
+        if git_handler.can_handle(parsed):
+            source_status: SourceStatus = await git_handler.get_status(
+                parsed, cache_dir
+            )
+            return BundleStatus(
+                bundle_name=bundle_name,
+                bundle_source=uri,
+                sources=[source_status],
+            )
+
+        # Non-git bundles - report as unknown.
+        return BundleStatus(
+            bundle_name=bundle_name,
+            bundle_source=uri,
+            sources=[
+                SourceStatus(
+                    source_uri=uri,
+                    is_cached=True,
+                    has_update=None,
+                    summary="Update checking not supported for this source type",
                 )
+            ],
+        )
+
+    # Use cached root bundles for update checking (all roots, not filtered user list).
+    bundle_names = discovery.list_cached_root_bundles()
+    results: dict[str, BundleStatus] = {}
+    checked_uris: set[str] = set()
+
+    for bundle_name in bundle_names:
+        # Get URI without loading (avoids download side effect).
+        uri = registry.find(bundle_name)
+        if not uri:
+            continue
+        checked_uris.add(uri)
+        try:
+            results[bundle_name] = await _check_bundle_uri(bundle_name, uri)
+        except Exception:
+            continue  # Skip bundles that fail status check
+
+    # App bundles are configured source URIs rather than registry aliases.  Use
+    # the exact URI as the result key so refs and subdirectory fragments remain
+    # separate update targets.
+    for uri in AppSettings().get_app_bundles():
+        if uri in checked_uris:
+            continue
+        checked_uris.add(uri)
+        try:
+            results[uri] = await _check_bundle_uri(uri, uri)
         except Exception:
             continue  # Skip bundles that fail status check
 
@@ -1240,9 +1255,9 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
         bundle_errors: dict[str, str] = {}
 
         if has_bundle_updates:
+            from amplifier_foundation import load_bundle
             from amplifier_foundation import update_bundle
 
-            registry = create_bundle_registry()
             bundles_to_update = [
                 name for name, status in bundle_results.items() if status.has_updates
             ]
@@ -1250,7 +1265,8 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
             for bundle_name in bundles_to_update:
                 try:
                     _on_update_progress(bundle_name, "updating_bundle")
-                    loaded = asyncio.run(registry.load(bundle_name))
+                    source_uri = bundle_results[bundle_name].bundle_source
+                    loaded = asyncio.run(load_bundle(source_uri, auto_include=False))
                     if isinstance(loaded, dict):
                         bundle_errors[bundle_name] = "Expected single bundle, got dict"
                         bundle_failed.append(bundle_name)

--- a/tests/test_bundle_commands.py
+++ b/tests/test_bundle_commands.py
@@ -230,6 +230,48 @@ async def test_global_update_checks_app_only_sources_by_exact_uri(monkeypatch):
     assert {status.bundle_source for status in results.values()} == set(app_uris)
 
 
+@pytest.mark.asyncio
+async def test_global_update_skips_bundle_when_registry_lookup_fails(monkeypatch):
+    """A failed registry lookup must not prevent later bundles from being checked."""
+    from amplifier_foundation.sources.git import GitSourceHandler
+
+    working_bundle = "working"
+    working_uri = "git+https://github.com/example/amplifier-bundle-working@main"
+    registry = MagicMock()
+
+    def find_bundle(bundle_name):
+        if bundle_name == "broken":
+            raise RuntimeError("registry unavailable")
+        assert bundle_name == working_bundle
+        return working_uri
+
+    registry.find.side_effect = find_bundle
+    monkeypatch.setattr(
+        update_module,
+        "AppBundleDiscovery",
+        lambda: SimpleNamespace(
+            list_cached_root_bundles=lambda: ["broken", working_bundle]
+        ),
+    )
+    monkeypatch.setattr(update_module, "create_bundle_registry", lambda: registry)
+    monkeypatch.setattr(
+        update_module,
+        "AppSettings",
+        lambda: SimpleNamespace(get_app_bundles=lambda: []),
+    )
+
+    async def fake_get_status(self, parsed, cache_dir):
+        return SimpleNamespace(source_uri=working_uri, has_update=False)
+
+    monkeypatch.setattr(GitSourceHandler, "get_status", fake_get_status)
+
+    results = await update_module._check_all_bundle_status()
+
+    assert set(results) == {working_bundle}
+    assert results[working_bundle].bundle_source == working_uri
+    assert registry.find.call_args_list == [(("broken",),), ((working_bundle,),)]
+
+
 def test_global_update_loads_an_app_target_by_source_uri(monkeypatch):
     """Applying a global update must load an app bundle from its URI, not an alias."""
     import amplifier_foundation

--- a/tests/test_bundle_commands.py
+++ b/tests/test_bundle_commands.py
@@ -1,0 +1,255 @@
+"""Focused regressions for bundle add/remove and global update source handling."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from amplifier_app_cli.utils.source_status import UpdateReport
+from amplifier_app_cli.utils.update_executor import ExecutionResult
+
+
+bundle_module = importlib.import_module("amplifier_app_cli.commands.bundle")
+update_module = importlib.import_module("amplifier_app_cli.commands.update")
+
+_URI = "git+https://github.com/example/amplifier-bundle-team@main"
+_OTHER_URI = "git+https://github.com/example/amplifier-bundle-team@release"
+_FRAGMENT_URI = f"{_URI}#subdirectory=behaviors/team.yaml"
+
+
+class _FakeSettings:
+    """In-memory AppSettings double with a global settings scope."""
+
+    def __init__(self, *, app_bundles=None, added_bundles=None):
+        self.app_bundles = list(app_bundles or [])
+        self.global_settings = {
+            "bundle": {
+                "added": dict(added_bundles or {}),
+            }
+        }
+        self.add_app_bundle = MagicMock(side_effect=self._add_app_bundle)
+        self.add_bundle = MagicMock(side_effect=self._add_bundle)
+
+    def get_app_bundles(self):
+        return list(self.app_bundles)
+
+    def get_added_bundles(self):
+        return dict(self.global_settings.get("bundle", {}).get("added", {}))
+
+    def _read_scope(self, scope):
+        assert scope == "global"
+        return self.global_settings
+
+    def _add_app_bundle(self, uri):
+        if uri not in self.app_bundles:
+            self.app_bundles.append(uri)
+
+    def _add_bundle(self, name, uri):
+        self.global_settings.setdefault("bundle", {}).setdefault("added", {})[name] = (
+            uri
+        )
+
+    def remove_added_bundle(self, name, scope="global"):
+        assert scope == "global"
+        added = self.global_settings.get("bundle", {}).get("added", {})
+        if name not in added:
+            return False
+        del added[name]
+        if not added:
+            self.global_settings["bundle"].pop("added")
+        return True
+
+    def remove_app_bundle(self, uri):
+        if uri not in self.app_bundles:
+            return False
+        self.app_bundles.remove(uri)
+        return True
+
+
+def _stub_bundle_load(monkeypatch, bundle_name="team"):
+    import amplifier_foundation
+
+    loaded_uris = []
+
+    async def fake_load_bundle(uri, *, auto_include):
+        assert auto_include is False
+        loaded_uris.append(uri)
+        return SimpleNamespace(name=bundle_name, version="1.2.3")
+
+    monkeypatch.setattr(amplifier_foundation, "load_bundle", fake_load_bundle)
+    return loaded_uris
+
+
+def _invoke_bundle_add(uri, *, name_override=None, app=False):
+    return bundle_module.bundle_add.callback(uri, name_override, app)
+
+
+def test_app_add_persists_only_app_source(monkeypatch):
+    """An app add must never create a selectable bundle.added registration."""
+    settings = _FakeSettings()
+    loaded_uris = _stub_bundle_load(monkeypatch)
+    monkeypatch.setattr(bundle_module, "AppSettings", lambda: settings)
+
+    _invoke_bundle_add(_URI, app=True)
+
+    assert loaded_uris == [_URI]
+    assert settings.app_bundles == [_URI]
+    settings.add_app_bundle.assert_called_once_with(_URI)
+    settings.add_bundle.assert_not_called()
+    assert settings.get_added_bundles() == {}
+
+
+def test_repeated_app_add_loads_again_without_writing_settings(monkeypatch):
+    """A retry reloads its source but does not write either bundle setting."""
+    settings = _FakeSettings(app_bundles=[_URI])
+    loaded_uris = _stub_bundle_load(monkeypatch)
+    monkeypatch.setattr(bundle_module, "AppSettings", lambda: settings)
+
+    _invoke_bundle_add(_URI, app=True)
+
+    assert loaded_uris == [_URI]
+    assert settings.app_bundles == [_URI]
+    settings.add_app_bundle.assert_not_called()
+    settings.add_bundle.assert_not_called()
+
+
+def test_app_add_preserves_same_name_standard_registration(monkeypatch):
+    """Adding an app source must not remove an indistinguishable normal mapping."""
+    settings = _FakeSettings(
+        added_bundles={"team": _URI},
+    )
+    _stub_bundle_load(monkeypatch)
+    monkeypatch.setattr(bundle_module, "AppSettings", lambda: settings)
+
+    _invoke_bundle_add(_URI, app=True)
+
+    assert settings.app_bundles == [_URI]
+    assert settings.get_added_bundles() == {"team": _URI}
+    settings.add_bundle.assert_not_called()
+
+
+def test_app_remove_preserves_same_name_standard_registration(monkeypatch):
+    """Removing an app source must not remove an indistinguishable normal mapping."""
+    settings = _FakeSettings(
+        app_bundles=[_URI],
+        added_bundles={"team": _URI},
+    )
+    monkeypatch.setattr(bundle_module, "AppSettings", lambda: settings)
+
+    bundle_module.bundle_remove.callback("team", app=True)
+
+    assert settings.app_bundles == []
+    assert settings.get_added_bundles() == {"team": _URI}
+
+
+def test_non_app_add_rejects_uri_already_registered_under_alias(monkeypatch):
+    """The same exact URI cannot be persisted under another selectable name."""
+    settings = _FakeSettings(added_bundles={"existing-alias": _URI})
+    loaded_uris = _stub_bundle_load(monkeypatch)
+    monkeypatch.setattr(bundle_module, "AppSettings", lambda: settings)
+
+    _invoke_bundle_add(_URI, name_override="new-alias")
+
+    assert loaded_uris == [_URI]
+    assert settings.get_added_bundles() == {"existing-alias": _URI}
+    settings.add_bundle.assert_not_called()
+
+
+def test_non_app_add_updates_existing_name_to_new_uri(monkeypatch):
+    """A supplied existing name still updates its mapping to a new URI."""
+    settings = _FakeSettings(added_bundles={"team": _URI})
+    loaded_uris = _stub_bundle_load(monkeypatch)
+    monkeypatch.setattr(bundle_module, "AppSettings", lambda: settings)
+
+    _invoke_bundle_add(_OTHER_URI, name_override="team")
+
+    assert loaded_uris == [_OTHER_URI]
+    assert settings.get_added_bundles() == {"team": _OTHER_URI}
+    settings.add_bundle.assert_called_once_with("team", _OTHER_URI)
+
+
+@pytest.mark.asyncio
+async def test_global_update_checks_app_only_sources_by_exact_uri(monkeypatch):
+    """Distinct app refs/fragments remain independent global-update targets."""
+    from amplifier_foundation.sources.git import GitSourceHandler
+
+    app_uris = [_URI, _OTHER_URI, _FRAGMENT_URI]
+    monkeypatch.setattr(
+        update_module,
+        "AppBundleDiscovery",
+        lambda: SimpleNamespace(list_cached_root_bundles=lambda: []),
+    )
+    monkeypatch.setattr(update_module, "create_bundle_registry", MagicMock())
+    monkeypatch.setattr(
+        update_module,
+        "AppSettings",
+        lambda: SimpleNamespace(get_app_bundles=lambda: app_uris),
+    )
+
+    async def fake_get_status(self, parsed, cache_dir):
+        return SimpleNamespace(source_uri="checked", has_update=False)
+
+    monkeypatch.setattr(GitSourceHandler, "get_status", fake_get_status)
+
+    results = await update_module._check_all_bundle_status()
+
+    assert set(results) == set(app_uris)
+    assert {status.bundle_source for status in results.values()} == set(app_uris)
+
+
+def test_global_update_loads_an_app_target_by_source_uri(monkeypatch):
+    """Applying a global update must load an app bundle from its URI, not an alias."""
+    import amplifier_foundation
+
+    status = SimpleNamespace(has_updates=True, bundle_source=_FRAGMENT_URI)
+    loaded_uris = []
+    updated_bundles = []
+
+    async def fake_check_all_sources(**kwargs):
+        return UpdateReport(local_file_sources=[], cached_git_sources=[])
+
+    async def fake_execute_updates(*args, **kwargs):
+        return ExecutionResult(
+            success=True, updated=[], failed=[], errors={}, messages=[]
+        )
+
+    async def fake_load_bundle(uri, *, auto_include):
+        assert auto_include is False
+        loaded_uris.append(uri)
+        return SimpleNamespace()
+
+    async def fake_update_bundle(bundle):
+        updated_bundles.append(bundle)
+
+    monkeypatch.setattr(update_module, "check_all_sources", fake_check_all_sources)
+
+    async def fake_check_all_bundle_status():
+        return {"app target": status}
+
+    monkeypatch.setattr(
+        update_module, "_check_all_bundle_status", fake_check_all_bundle_status
+    )
+    monkeypatch.setattr(
+        update_module,
+        "_show_concise_report",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(update_module, "execute_updates", fake_execute_updates)
+    monkeypatch.setattr(update_module, "_refresh_skills_cache", lambda console: None)
+    monkeypatch.setattr(update_module, "save_update_last_check", lambda value: None)
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.umbrella_discovery.discover_umbrella_source",
+        lambda: None,
+    )
+    monkeypatch.setattr(amplifier_foundation, "load_bundle", fake_load_bundle)
+    monkeypatch.setattr(amplifier_foundation, "update_bundle", fake_update_bundle)
+
+    result = CliRunner().invoke(update_module.update, ["--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert loaded_uris == [_FRAGMENT_URI]
+    assert len(updated_bundles) == 1

--- a/tests/test_bundle_commands.py
+++ b/tests/test_bundle_commands.py
@@ -152,11 +152,40 @@ def test_non_app_add_rejects_uri_already_registered_under_alias(monkeypatch):
     loaded_uris = _stub_bundle_load(monkeypatch)
     monkeypatch.setattr(bundle_module, "AppSettings", lambda: settings)
 
-    _invoke_bundle_add(_URI, name_override="new-alias")
+    with pytest.raises(SystemExit) as excinfo:
+        _invoke_bundle_add(_URI, name_override="new-alias")
 
+    # A refusal must be distinguishable from a successful registration by a
+    # scripted caller -- exit 0 here would read as "added under new-alias".
+    assert excinfo.value.code == 1
     assert loaded_uris == [_URI]
     assert settings.get_added_bundles() == {"existing-alias": _URI}
     settings.add_bundle.assert_not_called()
+
+
+def test_non_app_add_alias_conflict_exits_non_zero_through_cli(monkeypatch):
+    """The refusal surfaces as a non-zero process exit, not just an exception."""
+    settings = _FakeSettings(added_bundles={"existing-alias": _URI})
+    _stub_bundle_load(monkeypatch)
+    monkeypatch.setattr(bundle_module, "AppSettings", lambda: settings)
+
+    result = CliRunner().invoke(bundle_module.bundle_add, [_URI, "--name", "new-alias"])
+
+    assert result.exit_code == 1, result.output
+    assert "already registered as 'existing-alias'" in result.output
+    settings.add_bundle.assert_not_called()
+
+
+def test_repeated_non_app_add_same_name_same_uri_still_succeeds(monkeypatch):
+    """Re-adding an identical name+URI pair stays an idempotent success."""
+    settings = _FakeSettings(added_bundles={"team": _URI})
+    _stub_bundle_load(monkeypatch)
+    monkeypatch.setattr(bundle_module, "AppSettings", lambda: settings)
+
+    result = CliRunner().invoke(bundle_module.bundle_add, [_URI])
+
+    assert result.exit_code == 0, result.output
+    assert settings.get_added_bundles() == {"team": _URI}
 
 
 def test_non_app_add_updates_existing_name_to_new_uri(monkeypatch):


### PR DESCRIPTION
## What changed

- Store app bundles solely under `bundle.app` instead of also creating a selectable `bundle.added` registration.
- Make repeated additions of the same exact URI idempotent, and reject registering an exact URI under a different normal-bundle alias.
- Keep app-only sources updateable by checking and loading their exact URIs during global updates.
- Keep per-bundle registry lookup failures from aborting the global update status scan.
- Document the intentional root-only bundle load so cached modules are not refreshed redundantly.

## Why

App bundle additions were creating duplicate settings entries and app-only sources could not participate reliably in global updates. This keeps composition sources separate from selectable registrations while preserving update behavior and avoiding ambiguous URI aliases.

## Verification

- `uv run ruff check amplifier_app_cli/commands/bundle.py amplifier_app_cli/commands/update.py tests/test_bundle_commands.py`
- `uv run ruff format --check amplifier_app_cli/commands/bundle.py amplifier_app_cli/commands/update.py tests/test_bundle_commands.py`
- `uv run pytest tests/test_bundle_commands.py tests/test_get_bundle_repo_info.py tests/lib/bundle_loader/test_discovery.py tests/test_update_executor.py tests/test_windows_update_reset.py -q` (53 passed)
- `uv run pytest -q` (1693 passed, 1 skipped, 13 deselected, 1 xfailed)
- DTU validation: installed the uncommitted snapshot in an isolated DTU; app behavior add wrote only `bundle.app`; repeat remained one entry after fetching again; a duplicate normal URI alias was rejected; `amplifier update --check-only` enumerated the app-only URI. DTU `amplifier-app-cli-bundle-add-verify` and its dedicated Gitea instance were explicitly destroyed afterward.

## Breaking changes

- Newly added app bundles are now composition-only under `bundle.app` and are no longer selectable through `amplifier bundle use`; use a normal non-`--app` registration if selectability is needed.
- Registering an exact URI under a second normal bundle alias is now refused; re-use the existing name or update that name's URI.