### PR TITLE
fix: make reset cleanup removal-native and recover installs

### DIFF
--- a/amplifier_app_cli/commands/reset.py
+++ b/amplifier_app_cli/commands/reset.py
@@ -65,9 +65,10 @@ DEFAULT_INSTALL_SOURCE = "git+https://github.com/microsoft/amplifier"
 
 # The current umbrella source registers `amplifier`; older installations
 # registered the CLI distribution directly. Both expose the `amplifier`
-# executable and must be removed before a reset's replacement install.
-UV_TOOL_PACKAGE = "amplifier-app-cli"
-UV_TOOL_PACKAGES = ("amplifier", UV_TOOL_PACKAGE)
+# executable and must be removed before a reset's replacement install. Neither
+# name may be hardcoded at a call site - which one is registered is a runtime
+# fact, read back via _installed_uv_tool_packages().
+UV_TOOL_PACKAGES = ("amplifier", "amplifier-app-cli")
 
 
 def _get_amplifier_dir() -> Path:
@@ -121,6 +122,18 @@ def _parse_categories(
     if value is None:
         return None
     categories = {c.strip() for c in value.split(",") if c.strip()}
+
+    # An empty --remove is a harmless no-op, but the mirrored empty --preserve
+    # means "preserve nothing" - it removes every category, projects included,
+    # and -y suppresses the confirm. That is the same blast radius as --full
+    # reached by an unset shell variable, so it has to be asked for by name.
+    if not categories and param.name == "preserve_cats":
+        raise click.BadParameter(
+            "--preserve was given an empty value, which would remove every "
+            "category including projects. Pass the categories to keep, or use "
+            "--full if removing everything is what you want."
+        )
+
     valid = set(RESET_CATEGORIES.keys())
     invalid = categories - valid
     if invalid:
@@ -239,11 +252,19 @@ def _clean_uv_cache(dry_run: bool = False) -> bool:
         return False
 
 
-def _uninstall_amplifier(dry_run: bool = False) -> bool:
-    """Uninstall amplifier via uv tool uninstall."""
-    console.print("[bold]>>>[/bold] Checking if amplifier is installed...")
+def _installed_uv_tool_packages() -> tuple[str, ...] | None:
+    """Report which known uv tool distributions are currently registered.
 
-    # Check if amplifier is installed
+    Both entries of ``UV_TOOL_PACKAGES`` expose the same ``amplifier``
+    executable, so the name to uninstall cannot be assumed - it has to be read
+    back from uv. Matching is anchored to ``"<package> "`` at the start of a
+    line so the indented ``- amplifier`` executable rows listed underneath a
+    package never count as a package of their own.
+
+    Returns:
+        The registered distribution names, possibly empty, or None when
+        ``uv tool list`` could not be consulted at all.
+    """
     try:
         result = subprocess.run(
             ["uv", "tool", "list"],
@@ -251,18 +272,27 @@ def _uninstall_amplifier(dry_run: bool = False) -> bool:
             capture_output=True,
             text=True,
         )
-        installed_packages = tuple(
-            package
-            for package in UV_TOOL_PACKAGES
-            if any(
-                line.startswith(f"{package} ") for line in result.stdout.splitlines()
-            )
-        )
-        if not installed_packages:
-            console.print("    [dim]Amplifier is not installed via uv tool[/dim]")
-            return False
     except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+    lines = result.stdout.splitlines()
+    return tuple(
+        package
+        for package in UV_TOOL_PACKAGES
+        if any(line.startswith(f"{package} ") for line in lines)
+    )
+
+
+def _uninstall_amplifier(dry_run: bool = False) -> bool:
+    """Uninstall amplifier via uv tool uninstall."""
+    console.print("[bold]>>>[/bold] Checking if amplifier is installed...")
+
+    installed_packages = _installed_uv_tool_packages()
+    if installed_packages is None:
         console.print("    [dim]Could not check uv tool list[/dim]")
+        return False
+    if not installed_packages:
+        console.print("    [dim]Amplifier is not installed via uv tool[/dim]")
         return False
 
     console.print("[bold]>>>[/bold] Uninstalling amplifier...")
@@ -460,14 +490,35 @@ def _windows_defer_tool_swap(no_install: bool) -> bool:
     Returns:
         True only when the deferred script was launched successfully.
     """
+    # Which distribution is registered cannot be assumed here any more than it
+    # can on POSIX: the umbrella source registers `amplifier`, older installs
+    # registered `amplifier-app-cli`, and uninstalling the name the user does
+    # *not* have is what strands them with the tool still installed.
+    detected = _installed_uv_tool_packages()
+    if detected is None:
+        # uv could not be read. Cover every known distribution best-effort
+        # rather than betting on one name; an uninstall for a distribution that
+        # is not registered is a no-op, missing the registered one is not.
+        uninstall_packages = list(UV_TOOL_PACKAGES)
+        uninstall_required = False
+    else:
+        uninstall_packages = list(detected)
+        uninstall_required = True
+
     if no_install:
+        if not uninstall_packages:
+            console.print("    [dim]Amplifier is not installed via uv tool[/dim]")
+            return True
+
         steps = [
             UvStep(
-                command=f"uv tool uninstall {UV_TOOL_PACKAGE}",
-                label="Uninstalling amplifier...",
+                command=f"uv tool uninstall {package}",
+                label=f"Uninstalling {package}...",
+                required=uninstall_required,
             )
+            for package in uninstall_packages
         ]
-        recovery = [f"uv tool uninstall {UV_TOOL_PACKAGE}"]
+        recovery = [f"uv tool uninstall {package}" for package in uninstall_packages]
         success = "Amplifier removed."
     else:
         steps = [
@@ -475,18 +526,21 @@ def _windows_defer_tool_swap(no_install: bool) -> bool:
             # `amplifier` executable if the uninstall could not complete.
             # Aborting here is what would leave the user with no amplifier.
             UvStep(
-                command=f"uv tool uninstall {UV_TOOL_PACKAGE}",
-                label="Uninstalling amplifier (best effort)...",
+                command=f"uv tool uninstall {package}",
+                label=f"Uninstalling {package} (best effort)...",
                 attempts=5,
                 required=False,
-            ),
+            )
+            for package in uninstall_packages
+        ]
+        steps.append(
             UvStep(
                 command=f"uv tool install --force {DEFAULT_INSTALL_SOURCE}",
                 label="Reinstalling amplifier...",
-            ),
-        ]
+            )
+        )
         recovery = [
-            f"uv tool uninstall {UV_TOOL_PACKAGE}",
+            *(f"uv tool uninstall {package}" for package in uninstall_packages),
             f"uv tool install --force {DEFAULT_INSTALL_SOURCE}",
         ]
         success = "Amplifier reset complete."

--- a/amplifier_app_cli/commands/reset.py
+++ b/amplifier_app_cli/commands/reset.py
@@ -1,6 +1,6 @@
 """Reset command for Amplifier CLI.
 
-Provides interactive reset with category-based preservation.
+Provides interactive reset with category-based removal selection.
 Uninstalls amplifier, clears selected data, and reinstalls fresh.
 
 Categories:
@@ -57,11 +57,17 @@ CATEGORY_DESCRIPTIONS = {
     "other": "Other files (custom configs, plugins, etc.)",
 }
 
-# Default categories to preserve - safe by default, only remove auto-regenerating items
-DEFAULT_PRESERVE = {"projects", "settings", "keys", "other"}
+# Default categories to remove - safe by default, only remove auto-regenerating items
+DEFAULT_REMOVE = {"cache", "registry"}
 
 # Default install source
 DEFAULT_INSTALL_SOURCE = "git+https://github.com/microsoft/amplifier"
+
+# The current umbrella source registers `amplifier`; older installations
+# registered the CLI distribution directly. Both expose the `amplifier`
+# executable and must be removed before a reset's replacement install.
+UV_TOOL_PACKAGE = "amplifier-app-cli"
+UV_TOOL_PACKAGES = ("amplifier", UV_TOOL_PACKAGE)
 
 
 def _get_amplifier_dir() -> Path:
@@ -96,10 +102,10 @@ def _get_other_files() -> list[str]:
     return sorted(other)
 
 
-def _get_preserve_paths(preserve: set[str]) -> set[str]:
+def _get_remove_paths(remove_cats: set[str]) -> set[str]:
     """Convert category names to actual file/directory names."""
     paths = set()
-    for category in preserve:
+    for category in remove_cats:
         if category == "other":
             # Dynamic category - include all uncategorized files
             paths.update(_get_other_files())
@@ -129,13 +135,13 @@ def _run_interactive() -> set[str] | None:
     """Run the interactive checklist for category selection.
 
     Returns:
-        Set of category names to preserve, or None if cancelled
+        Set of category names to remove, or None if cancelled
     """
     # Build checklist items with defaults
     items = []
     for category in CATEGORY_ORDER:
         description = CATEGORY_DESCRIPTIONS.get(category, "")
-        selected = category in DEFAULT_PRESERVE
+        selected = category in DEFAULT_REMOVE
         items.append(
             ChecklistItem(key=category, description=description, selected=selected)
         )
@@ -144,7 +150,7 @@ def _run_interactive() -> set[str] | None:
 
 
 def _show_plan(
-    preserve: set[str],
+    remove_cats: set[str],
     no_install: bool,
     dry_run: bool,
 ) -> None:
@@ -155,7 +161,7 @@ def _show_plan(
         console.print("[yellow]DRY RUN - No changes will be made[/yellow]\n")
 
     # Upfront reassurance about what's safe
-    if "projects" in preserve:
+    if "projects" not in remove_cats:
         console.print(
             "[green]Your session transcripts are safe[/green] - "
             "projects/ will be preserved.\n"
@@ -165,27 +171,31 @@ def _show_plan(
     console.print("  1. Clean UV cache")
     console.print("  2. Uninstall amplifier (if installed)")
 
-    preserve_names = sorted(preserve) if preserve else []
-    remove_names = sorted(set(RESET_CATEGORIES.keys()) - preserve)
+    remove_names = [category for category in CATEGORY_ORDER if category in remove_cats]
+    preserve_names = [
+        category for category in CATEGORY_ORDER if category not in remove_cats
+    ]
 
-    # Show what "other" actually contains if present
-    other_files = _get_other_files()
+    # Show what "other" actually contains when it is selected for removal.
+    other_files = _get_other_files() if "other" in remove_cats else []
 
-    if not preserve:
+    if remove_cats == set(RESET_CATEGORIES):
         console.print(f"  3. Remove {amplifier_dir} [red](ALL contents)[/red]")
     else:
         console.print(f"  3. Clean parts of {amplifier_dir}")
-        # Build preserve display with "other" expansion
-        preserve_display = []
-        for name in preserve_names:
+        # Build removal display with "other" expansion.
+        remove_display = []
+        for name in remove_names:
             if name == "other" and other_files:
-                preserve_display.append(f"other ({', '.join(other_files)})")
+                remove_display.append(f"other ({', '.join(other_files)})")
             else:
-                preserve_display.append(name)
+                remove_display.append(name)
         console.print(
-            f"       [green]Preserving:[/green] {', '.join(preserve_display)}"
+            f"       [red]Removing:[/red] {', '.join(remove_display) or 'none'}"
         )
-        console.print(f"       [red]Removing:[/red] {', '.join(remove_names)}")
+        console.print(
+            f"       [green]Preserving:[/green] {', '.join(preserve_names) or 'none'}"
+        )
 
     if no_install:
         console.print("  4. [dim]Skip reinstall (--no-install)[/dim]")
@@ -241,7 +251,14 @@ def _uninstall_amplifier(dry_run: bool = False) -> bool:
             capture_output=True,
             text=True,
         )
-        if "amplifier" not in result.stdout:
+        installed_packages = tuple(
+            package
+            for package in UV_TOOL_PACKAGES
+            if any(
+                line.startswith(f"{package} ") for line in result.stdout.splitlines()
+            )
+        )
+        if not installed_packages:
             console.print("    [dim]Amplifier is not installed via uv tool[/dim]")
             return False
     except (subprocess.CalledProcessError, FileNotFoundError):
@@ -251,25 +268,31 @@ def _uninstall_amplifier(dry_run: bool = False) -> bool:
     console.print("[bold]>>>[/bold] Uninstalling amplifier...")
 
     if dry_run:
-        console.print("    [dim][dry-run] Would run: uv tool uninstall amplifier[/dim]")
+        for package in installed_packages:
+            console.print(
+                f"    [dim][dry-run] Would run: uv tool uninstall {package}[/dim]"
+            )
         return True
 
-    try:
-        subprocess.run(
-            ["uv", "tool", "uninstall", "amplifier"],
-            check=True,
-            capture_output=True,
-        )
-        return True
-    except subprocess.CalledProcessError as e:
-        console.print(
-            f"[yellow]Warning:[/yellow] Failed to uninstall amplifier: {escape_markup(str(e))}"
-        )
-        return False
+    success = True
+    for package in installed_packages:
+        try:
+            subprocess.run(
+                ["uv", "tool", "uninstall", package],
+                check=True,
+                capture_output=True,
+            )
+        except subprocess.CalledProcessError as e:
+            console.print(
+                "[yellow]Warning:[/yellow] Failed to uninstall "
+                f"{package}: {escape_markup(str(e))}"
+            )
+            success = False
+    return success
 
 
-def _remove_amplifier_dir(preserve: set[str], dry_run: bool = False) -> bool:
-    """Remove ~/.amplifier directory contents based on category preservation.
+def _remove_amplifier_dir(remove_cats: set[str], dry_run: bool = False) -> bool:
+    """Remove only paths from selected reset categories.
 
     Uses shared cache_management utilities for cache/registry removal when those
     categories are being removed, ensuring DRY compliance across commands.
@@ -290,11 +313,10 @@ def _remove_amplifier_dir(preserve: set[str], dry_run: bool = False) -> bool:
         console.print("    [dim]Directory does not exist, skipping[/dim]")
         return True
 
-    # Convert categories to actual paths
-    preserve_paths = _get_preserve_paths(preserve)
-
-    # If nothing to preserve, remove entire directory
-    if not preserve_paths:
+    # Removing every category has the established --full behavior: remove the
+    # root in one operation. An empty category set is deliberately *not* the
+    # inverse of this case; it is a data-cleanup no-op.
+    if remove_cats == set(RESET_CATEGORIES):
         if dry_run:
             console.print(
                 f"    [dim][dry-run] Would remove entire directory: {amplifier_dir}[/dim]"
@@ -313,41 +335,49 @@ def _remove_amplifier_dir(preserve: set[str], dry_run: bool = False) -> bool:
             )
             return False
 
-    # Selective removal - preserve specified paths
+    # Expand only the selected categories. This must not iterate the root to
+    # decide what to delete; "other" is the one explicit dynamic expansion.
+    remove_paths = _get_remove_paths(remove_cats)
+
+    # Selective removal deletes only the explicit paths selected above.
     removed_count = 0
-    preserved_count = 0
     failed_items: list[str] = []
-    clearing_cache = "cache" not in preserve_paths
+    clearing_cache = "cache" in remove_cats
 
     try:
-        for item in amplifier_dir.iterdir():
-            if item.name in preserve_paths:
-                console.print(f"    [green]Preserving:[/green] {item.name}")
-                preserved_count += 1
-            else:
-                if dry_run:
-                    console.print(f"    [dim][dry-run] Would remove: {item.name}[/dim]")
+        for path_name in sorted(remove_paths):
+            item = amplifier_dir / path_name
+            if not item.exists() and not item.is_symlink():
+                continue
+
+            if dry_run:
+                console.print(f"    [dim][dry-run] Would remove: {item.name}[/dim]")
+                removed_count += 1
+                continue
+
+            # Never let rmtree follow a selected directory symlink.
+            if item.is_symlink():
+                item.unlink()
+                removed_count += 1
+            # Use shared utilities for cache and registry if available.
+            elif clear_download_cache is not None and item.name == "cache":
+                _count, success = clear_download_cache(dry_run=False)
+                if success:
                     removed_count += 1
                 else:
-                    # Use shared utilities for cache and registry if available
-                    if clear_download_cache is not None and item.name == "cache":
-                        _count, success = clear_download_cache(dry_run=False)
-                        if success:
-                            removed_count += 1
-                        else:
-                            failed_items.append(item.name)
-                    elif clear_registry is not None and item.name == "registry.json":
-                        if clear_registry(dry_run=False):
-                            removed_count += 1
-                        else:
-                            failed_items.append(item.name)
-                    else:
-                        # Standard removal (fallback or other items)
-                        if item.is_dir():
-                            rmtree_robust(item)
-                        else:
-                            item.unlink()
-                        removed_count += 1
+                    failed_items.append(item.name)
+            elif clear_registry is not None and item.name == "registry.json":
+                if clear_registry(dry_run=False):
+                    removed_count += 1
+                else:
+                    failed_items.append(item.name)
+            # Standard removal (fallback or other items).
+            elif item.is_dir():
+                rmtree_robust(item)
+                removed_count += 1
+            else:
+                item.unlink()
+                removed_count += 1
 
         # CRITICAL: Clear install-state.json when cache is being removed
         # The install state tracks module dependency fingerprints. When cache is cleared,
@@ -367,9 +397,7 @@ def _remove_amplifier_dir(preserve: set[str], dry_run: bool = False) -> bool:
             console.print("    [dim][dry-run] Would clear install-state.json[/dim]")
 
         action = "Would remove" if dry_run else "Removed"
-        console.print(
-            f"    {action} {removed_count} items, preserved {preserved_count}"
-        )
+        console.print(f"    {action} {removed_count} items")
         if failed_items:
             console.print(
                 "[red]Error:[/red] Cleanup incomplete; failed to remove: "
@@ -394,13 +422,18 @@ def _install_amplifier(dry_run: bool = False) -> bool:
 
     if dry_run:
         console.print(
-            f"    [dim][dry-run] Would run: uv tool install {DEFAULT_INSTALL_SOURCE}[/dim]"
+            f"    [dim][dry-run] Would run: uv tool install --force {DEFAULT_INSTALL_SOURCE}[/dim]"
         )
         return True
 
     try:
         subprocess.run(
-            ["uv", "tool", "install", DEFAULT_INSTALL_SOURCE],
+            # `--force` is narrowly about replacing an existing executable in
+            # uv's bin directory. Reset explicitly owns the `amplifier`
+            # executable, and this repairs an orphan left by an interrupted or
+            # historically mis-targeted uninstall; resolution/install errors
+            # still fail this command normally.
+            ["uv", "tool", "install", "--force", DEFAULT_INSTALL_SOURCE],
             check=True,
         )
         return True
@@ -411,7 +444,7 @@ def _install_amplifier(dry_run: bool = False) -> bool:
             f"[red]Error:[/red] Failed to install amplifier: {format_error_message(e)}"
         )
         console.print("\n[yellow]To recover manually:[/yellow]")
-        console.print(f"  uv tool install {DEFAULT_INSTALL_SOURCE}")
+        console.print(f"  uv tool install --force {DEFAULT_INSTALL_SOURCE}")
         return False
     except FileNotFoundError:
         console.print("[red]Error:[/red] uv not found")
@@ -430,31 +463,31 @@ def _windows_defer_tool_swap(no_install: bool) -> bool:
     if no_install:
         steps = [
             UvStep(
-                command="uv tool uninstall amplifier",
+                command=f"uv tool uninstall {UV_TOOL_PACKAGE}",
                 label="Uninstalling amplifier...",
             )
         ]
-        recovery = ["uv tool uninstall amplifier"]
+        recovery = [f"uv tool uninstall {UV_TOOL_PACKAGE}"]
         success = "Amplifier removed."
     else:
         steps = [
-            # Best effort: `uv tool install` overwrites an existing install, so
-            # a failed uninstall must not abort the reinstall that is the goal.
+            # Best effort: the forced reinstall replaces an orphaned
+            # `amplifier` executable if the uninstall could not complete.
             # Aborting here is what would leave the user with no amplifier.
             UvStep(
-                command="uv tool uninstall amplifier",
+                command=f"uv tool uninstall {UV_TOOL_PACKAGE}",
                 label="Uninstalling amplifier (best effort)...",
                 attempts=5,
                 required=False,
             ),
             UvStep(
-                command=f"uv tool install {DEFAULT_INSTALL_SOURCE}",
+                command=f"uv tool install --force {DEFAULT_INSTALL_SOURCE}",
                 label="Reinstalling amplifier...",
             ),
         ]
         recovery = [
-            "uv tool uninstall amplifier",
-            f"uv tool install {DEFAULT_INSTALL_SOURCE}",
+            f"uv tool uninstall {UV_TOOL_PACKAGE}",
+            f"uv tool install --force {DEFAULT_INSTALL_SOURCE}",
         ]
         success = "Amplifier reset complete."
 
@@ -526,22 +559,22 @@ def reset(
     dry_run: bool,
     no_install: bool,
 ) -> None:
-    """Reinstall Amplifier while preserving your data.
+    """Reinstall Amplifier and reset selected data.
 
     Safe by default: Your session transcripts, settings, API keys, and any
     custom files are preserved. Only the cache and registry are cleared
     (they auto-regenerate on next run).
 
-    Runs in interactive mode by default where you can adjust what to keep.
+    Runs in interactive mode by default where you select what to remove/reset.
 
     \b
     Categories:
-      projects   - Session transcripts and history [preserved by default]
-      settings   - User configuration (settings.yaml) [preserved by default]
-      keys       - API keys (keys.env) [preserved by default]
-      other      - Custom files you've added [preserved by default]
-      cache      - Downloaded bundles (auto-regenerates)
-      registry   - Bundle mappings (auto-regenerates)
+      projects   - Session transcripts and history [not removed by default]
+      settings   - User configuration (settings.yaml) [not removed by default]
+      keys       - API keys (keys.env) [not removed by default]
+      other      - Custom files you've added [not removed by default]
+      cache      - Downloaded bundles (auto-regenerates) [removed by default]
+      registry   - Bundle mappings (auto-regenerates) [removed by default]
 
     \b
     Examples:
@@ -564,28 +597,28 @@ def reset(
             "Options --preserve, --remove, and --full are mutually exclusive"
         )
 
-    # Determine preserve set based on arguments
-    preserve: set[str]
+    # Determine the removal plan. --preserve remains a compatibility boundary
+    # adapter; every downstream operation receives the removal set.
+    all_categories = set(RESET_CATEGORIES)
 
     if full:
-        preserve = set()
+        remove_cats = all_categories
     elif remove_cats is not None:
-        preserve = set(RESET_CATEGORIES.keys()) - remove_cats
+        pass
     elif preserve_cats is not None:
-        preserve = preserve_cats
+        remove_cats = all_categories - preserve_cats
     elif yes:
         # Non-interactive with -y but no category flags: use defaults
-        preserve = DEFAULT_PRESERVE.copy()
+        remove_cats = DEFAULT_REMOVE.copy()
     else:
         # Interactive mode
-        result = _run_interactive()
-        if result is None:
+        remove_cats = _run_interactive()
+        if remove_cats is None:
             console.print("[yellow]Cancelled.[/yellow]")
             return
-        preserve = result
 
     # Show plan
-    _show_plan(preserve, no_install, dry_run)
+    _show_plan(remove_cats, no_install, dry_run)
 
     # Confirm unless -y or dry-run
     if not yes and not dry_run:
@@ -604,7 +637,7 @@ def reset(
     # runs after this process exits. POSIX unlinks open files, so the path below
     # is unchanged there.
     if os.name == "nt" and not dry_run:
-        if not _remove_amplifier_dir(preserve, dry_run):
+        if not _remove_amplifier_dir(remove_cats, dry_run):
             raise click.ClickException(
                 "Reset stopped because cleanup was incomplete; "
                 "no reinstall was staged."
@@ -614,7 +647,7 @@ def reset(
         return
 
     _uninstall_amplifier(dry_run)
-    cleanup_succeeded = _remove_amplifier_dir(preserve, dry_run)
+    cleanup_succeeded = _remove_amplifier_dir(remove_cats, dry_run)
 
     if dry_run:
         console.print("\n[green]>>>[/green] Dry run complete - no changes were made")

--- a/amplifier_app_cli/commands/reset_interactive.py
+++ b/amplifier_app_cli/commands/reset_interactive.py
@@ -7,11 +7,11 @@ even during self-uninstall scenarios.
 Example:
     >>> from .reset_interactive import run_checklist, ChecklistItem
     >>> items = [
-    ...     ChecklistItem("projects", "Session transcripts", True),
-    ...     ChecklistItem("cache", "Downloaded bundles", False),
+    ...     ChecklistItem("projects", "Session transcripts", False),
+    ...     ChecklistItem("cache", "Downloaded bundles", True),
     ... ]
-    >>> selected = run_checklist(items, title="Select to preserve")
-    >>> print(selected)  # {"projects"}
+    >>> selected = run_checklist(items, title="Select to remove")
+    >>> print(selected)  # {"cache"}
 """
 
 from __future__ import annotations
@@ -155,10 +155,12 @@ def _render_checklist(
     lines.append(title)
     lines.append("=" * len(title))
     lines.append("")
-    lines.append("Your transcripts and settings are preserved by default.")
-    lines.append("Only cache/registry are removed (they auto-regenerate).")
+    lines.append("Checked items will be removed/reset.")
+    lines.append(
+        "Only cache and registry are selected by default (they auto-regenerate)."
+    )
     lines.append("")
-    lines.append("Adjust if needed (↑↓ navigate, space toggle, enter confirm):")
+    lines.append("Adjust what to remove (↑↓ navigate, space toggle, enter confirm):")
     lines.append("")
 
     # Items
@@ -179,7 +181,7 @@ def _render_checklist(
     lines.append(f"Will REMOVE: {remove_str}")
     lines.append(f"Will PRESERVE: {preserve_str}")
     lines.append("")
-    lines.append("[Enter] Continue  [a] Preserve all  [n] Preserve none  [q] Quit")
+    lines.append("[Enter] Continue  [a] Remove all  [n] Remove none  [q] Quit")
 
     # Print all lines
     output = "\n".join(lines)
@@ -210,9 +212,9 @@ def run_checklist(
     _hide_cursor()
     try:
         while True:
-            # Calculate what will be removed/preserved
-            will_preserve = [item.key for item in items if item.selected]
-            will_remove = [item.key for item in items if not item.selected]
+            # Selected entries are the categories that will be removed.
+            will_remove = [item.key for item in items if item.selected]
+            will_preserve = [item.key for item in items if not item.selected]
 
             # Clear previous render
             if lines_printed > 0:
@@ -237,11 +239,11 @@ def run_checklist(
                 print()  # Newline after UI
                 return {item.key for item in items if item.selected}
             elif key.lower() == "a":
-                # Select all
+                # Remove all
                 for item in items:
                     item.selected = True
             elif key.lower() == "n":
-                # Select none
+                # Remove none
                 for item in items:
                     item.selected = False
             elif key.lower() == "q" or key == "ESC":

--- a/tests/test_reset_cleanup.py
+++ b/tests/test_reset_cleanup.py
@@ -37,7 +37,6 @@ def _invoke_dry_run(monkeypatch, args: list[str]) -> tuple[MagicMock, MagicMock]
             ["--preserve", "projects,settings,keys,other", "-y"],
             {"cache", "registry"},
         ),
-        (["--preserve", "", "-y"], set(reset_module.RESET_CATEGORIES)),
         (["--full", "-y"], set(reset_module.RESET_CATEGORIES)),
     ],
 )
@@ -46,6 +45,24 @@ def test_cli_options_resolve_to_a_removal_plan(monkeypatch, args, expected_remov
 
     assert show_plan.call_args.args[0] == expected_remove
     assert cleanup.call_args.args[0] == expected_remove
+
+
+def test_empty_preserve_is_refused_rather_than_removing_everything(monkeypatch):
+    """`--preserve "$VAR"` with VAR unset must not become a silent --full.
+
+    An empty --remove is a no-op, so the mirrored empty --preserve reaching
+    "remove every category, projects included" - with -y suppressing the
+    confirm - is a blast radius an unset shell variable should not be able to
+    select. --full is how that is asked for.
+    """
+    cleanup = MagicMock()
+    monkeypatch.setattr(reset_module, "_remove_amplifier_dir", cleanup)
+
+    result = CliRunner().invoke(reset_module.reset, ["--preserve", "", "-y"])
+
+    assert result.exit_code != 0
+    assert "--full" in result.output
+    cleanup.assert_not_called()
 
 
 def _make_amplifier_dir(tmp_path: Path) -> Path:

--- a/tests/test_reset_cleanup.py
+++ b/tests/test_reset_cleanup.py
@@ -1,0 +1,160 @@
+"""Regression coverage for reset's removal-native cleanup plan."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+
+reset_module = importlib.import_module("amplifier_app_cli.commands.reset")
+
+
+def _invoke_dry_run(monkeypatch, args: list[str]) -> tuple[MagicMock, MagicMock]:
+    show_plan = MagicMock()
+    cleanup = MagicMock()
+    monkeypatch.setattr(reset_module, "_show_plan", show_plan)
+    monkeypatch.setattr(reset_module, "_clean_uv_cache", MagicMock())
+    monkeypatch.setattr(reset_module, "_uninstall_amplifier", MagicMock())
+    monkeypatch.setattr(reset_module, "_remove_amplifier_dir", cleanup)
+
+    result = CliRunner().invoke(reset_module.reset, [*args, "--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    return show_plan, cleanup
+
+
+@pytest.mark.parametrize(
+    ("args", "expected_remove"),
+    [
+        (["-y"], {"cache", "registry"}),
+        (["--remove", "cache", "-y"], {"cache"}),
+        (["--remove", "", "-y"], set()),
+        (
+            ["--preserve", "projects,settings,keys,other", "-y"],
+            {"cache", "registry"},
+        ),
+        (["--preserve", "", "-y"], set(reset_module.RESET_CATEGORIES)),
+        (["--full", "-y"], set(reset_module.RESET_CATEGORIES)),
+    ],
+)
+def test_cli_options_resolve_to_a_removal_plan(monkeypatch, args, expected_remove):
+    show_plan, cleanup = _invoke_dry_run(monkeypatch, args)
+
+    assert show_plan.call_args.args[0] == expected_remove
+    assert cleanup.call_args.args[0] == expected_remove
+
+
+def _make_amplifier_dir(tmp_path: Path) -> Path:
+    amplifier_dir = tmp_path / ".amplifier"
+    (amplifier_dir / "projects").mkdir(parents=True)
+    (amplifier_dir / "projects" / "session.json").write_text("session")
+    (amplifier_dir / "cache").mkdir()
+    (amplifier_dir / "cache" / "bundle").write_text("cache")
+    (amplifier_dir / "registry.json").write_text("{}")
+    (amplifier_dir / "settings.yaml").write_text("settings")
+    (amplifier_dir / "keys.env").write_text("keys")
+    (amplifier_dir / "custom.toml").write_text("custom")
+    return amplifier_dir
+
+
+def test_cleanup_removes_only_explicitly_selected_paths(tmp_path, monkeypatch):
+    amplifier_dir = _make_amplifier_dir(tmp_path)
+    monkeypatch.setattr(reset_module, "_get_amplifier_dir", lambda: amplifier_dir)
+
+    assert reset_module._remove_amplifier_dir({"projects"})
+
+    assert not (amplifier_dir / "projects").exists()
+    for name in ("cache", "registry.json", "settings.yaml", "keys.env", "custom.toml"):
+        assert (amplifier_dir / name).exists(), name
+
+
+def test_cleanup_removes_only_dynamic_other_paths(tmp_path, monkeypatch):
+    amplifier_dir = _make_amplifier_dir(tmp_path)
+    custom_dir = amplifier_dir / "plugin"
+    custom_dir.mkdir()
+    (custom_dir / "entry.py").write_text("plugin")
+    monkeypatch.setattr(reset_module, "_get_amplifier_dir", lambda: amplifier_dir)
+
+    assert reset_module._remove_amplifier_dir({"other"})
+
+    assert not (amplifier_dir / "custom.toml").exists()
+    assert not custom_dir.exists()
+    for name in ("projects", "cache", "registry.json", "settings.yaml", "keys.env"):
+        assert (amplifier_dir / name).exists(), name
+
+
+def test_full_cleanup_removes_the_root_directory(tmp_path, monkeypatch):
+    amplifier_dir = _make_amplifier_dir(tmp_path)
+    monkeypatch.setattr(reset_module, "_get_amplifier_dir", lambda: amplifier_dir)
+    get_install_state_path = MagicMock()
+    monkeypatch.setattr(
+        "amplifier_app_cli.paths.get_install_state_path", get_install_state_path
+    )
+
+    assert reset_module._remove_amplifier_dir(set(reset_module.RESET_CATEGORIES))
+
+    assert not amplifier_dir.exists()
+    get_install_state_path.assert_not_called()
+
+
+def test_empty_removal_plan_is_a_data_cleanup_no_op(tmp_path, monkeypatch):
+    amplifier_dir = _make_amplifier_dir(tmp_path)
+    monkeypatch.setattr(reset_module, "_get_amplifier_dir", lambda: amplifier_dir)
+
+    assert reset_module._remove_amplifier_dir(set())
+
+    for name in (
+        "projects",
+        "cache",
+        "registry.json",
+        "settings.yaml",
+        "keys.env",
+        "custom.toml",
+    ):
+        assert (amplifier_dir / name).exists(), name
+
+
+def test_install_state_is_cleared_only_when_cache_is_selected(tmp_path, monkeypatch):
+    amplifier_dir = _make_amplifier_dir(tmp_path)
+    install_state = tmp_path / "install-state.json"
+    install_state.write_text("{}")
+    monkeypatch.setattr(reset_module, "_get_amplifier_dir", lambda: amplifier_dir)
+    monkeypatch.setattr(
+        "amplifier_app_cli.paths.get_install_state_path", lambda: install_state
+    )
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.cache_management.clear_download_cache",
+        MagicMock(return_value=(1, True)),
+    )
+
+    assert reset_module._remove_amplifier_dir({"settings"})
+    assert install_state.exists()
+
+    assert reset_module._remove_amplifier_dir({"cache"})
+    assert not install_state.exists()
+
+
+def test_selected_directory_symlink_is_unlinked_without_touching_target(
+    tmp_path, monkeypatch
+):
+    amplifier_dir = tmp_path / ".amplifier"
+    amplifier_dir.mkdir()
+    target = tmp_path / "projects-target"
+    target.mkdir()
+    target_file = target / "session.json"
+    target_file.write_text("session")
+    project_link = amplifier_dir / "projects"
+    try:
+        project_link.symlink_to(target, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks are unavailable: {exc}")
+    monkeypatch.setattr(reset_module, "_get_amplifier_dir", lambda: amplifier_dir)
+
+    assert reset_module._remove_amplifier_dir({"projects"})
+
+    assert not project_link.is_symlink()
+    assert target_file.read_text() == "session"

--- a/tests/test_reset_interactive.py
+++ b/tests/test_reset_interactive.py
@@ -1,0 +1,111 @@
+"""Focused behavior tests for the interactive reset checklist."""
+
+from __future__ import annotations
+
+import importlib
+from unittest.mock import MagicMock
+
+from click.testing import CliRunner
+
+
+reset_module = importlib.import_module("amplifier_app_cli.commands.reset")
+interactive_module = importlib.import_module(
+    "amplifier_app_cli.commands.reset_interactive"
+)
+
+
+def _items_with_default_removals():
+    return [
+        interactive_module.ChecklistItem(
+            category,
+            reset_module.CATEGORY_DESCRIPTIONS[category],
+            category in reset_module.DEFAULT_REMOVE,
+        )
+        for category in reset_module.CATEGORY_ORDER
+    ]
+
+
+def _interactive_dry_run(
+    monkeypatch, remove_cats: set[str]
+) -> tuple[MagicMock, MagicMock]:
+    show_plan = MagicMock()
+    cleanup = MagicMock()
+    monkeypatch.setattr(reset_module, "_run_interactive", lambda: remove_cats)
+    monkeypatch.setattr(reset_module, "_show_plan", show_plan)
+    monkeypatch.setattr(reset_module, "_clean_uv_cache", MagicMock())
+    monkeypatch.setattr(reset_module, "_uninstall_amplifier", MagicMock())
+    monkeypatch.setattr(reset_module, "_remove_amplifier_dir", cleanup)
+
+    result = CliRunner().invoke(reset_module.reset, ["--dry-run"])
+
+    assert result.exit_code == 0, result.output
+    return show_plan, cleanup
+
+
+def test_interactive_checklist_selects_current_default_removals(monkeypatch):
+    captured = {}
+
+    def capture_items(items, title):
+        captured["items"] = items
+        captured["title"] = title
+        return set()
+
+    monkeypatch.setattr(reset_module, "run_checklist", capture_items)
+
+    reset_module._run_interactive()
+
+    selected = {item.key for item in captured["items"] if item.selected}
+    assert captured["title"] == "Amplifier Reset"
+    assert selected == {"cache", "registry"}
+    assert all(
+        not item.selected
+        for item in captured["items"]
+        if item.key in {"projects", "settings", "keys", "other"}
+    )
+
+
+def test_enter_keeps_protected_categories_and_shows_removal_wording(
+    monkeypatch, capsys
+):
+    items = _items_with_default_removals()
+    monkeypatch.setattr(interactive_module, "_get_key", lambda: "ENTER")
+
+    remove_cats = interactive_module.run_checklist(items)
+    output = capsys.readouterr().out
+
+    assert remove_cats == {"cache", "registry"}
+    assert "Checked items will be removed/reset." in output
+    assert "Will REMOVE: cache, registry" in output
+    assert "[a] Remove all  [n] Remove none" in output
+
+    show_plan, cleanup = _interactive_dry_run(monkeypatch, remove_cats)
+    assert show_plan.call_args.args[0] == reset_module.DEFAULT_REMOVE
+    assert cleanup.call_args.args[0] == reset_module.DEFAULT_REMOVE
+
+
+def test_toggling_protected_category_selects_it_for_removal(monkeypatch):
+    items = _items_with_default_removals()
+    keys = iter([" ", "ENTER"])
+    monkeypatch.setattr(interactive_module, "_get_key", lambda: next(keys))
+
+    remove_cats = interactive_module.run_checklist(items)
+
+    assert remove_cats == {"projects", "cache", "registry"}
+
+    show_plan, cleanup = _interactive_dry_run(monkeypatch, remove_cats)
+    assert "projects" in show_plan.call_args.args[0]
+    assert "projects" in cleanup.call_args.args[0]
+
+
+def test_remove_all_and_remove_none_shortcuts(monkeypatch):
+    all_items = _items_with_default_removals()
+    all_keys = iter(["a", "ENTER"])
+    monkeypatch.setattr(interactive_module, "_get_key", lambda: next(all_keys))
+    assert interactive_module.run_checklist(all_items) == set(
+        reset_module.RESET_CATEGORIES
+    )
+
+    no_items = _items_with_default_removals()
+    no_keys = iter(["n", "ENTER"])
+    monkeypatch.setattr(interactive_module, "_get_key", lambda: next(no_keys))
+    assert interactive_module.run_checklist(no_items) == set()

--- a/tests/test_windows_update_reset.py
+++ b/tests/test_windows_update_reset.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import subprocess
 import tempfile
 from types import SimpleNamespace
 from unittest.mock import MagicMock
@@ -106,7 +107,7 @@ def test_remove_amplifier_dir_reports_cache_failure_and_continues(
     fake_console = MagicMock()
     monkeypatch.setattr(reset_module, "console", fake_console)
 
-    success = reset_module._remove_amplifier_dir({"settings"})
+    success = reset_module._remove_amplifier_dir({"cache", "registry", "other"})
 
     assert success is False
     clear_cache.assert_called_once_with(dry_run=False)
@@ -136,7 +137,7 @@ def test_remove_amplifier_dir_reports_registry_failure(tmp_path, monkeypatch):
     fake_console = MagicMock()
     monkeypatch.setattr(reset_module, "console", fake_console)
 
-    success = reset_module._remove_amplifier_dir({"settings", "cache"})
+    success = reset_module._remove_amplifier_dir({"registry"})
 
     assert success is False
     output = _console_text(fake_console)
@@ -179,6 +180,101 @@ def test_windows_reset_returns_failure_when_finisher_cannot_launch(monkeypatch):
     assert "Reset could not be staged" in result.output
 
 
+@pytest.mark.parametrize(
+    ("tool_list", "expected_uninstalls"),
+    [
+        (
+            "amplifier-app-cli v0.1.1\n- amplifier\n",
+            [["uv", "tool", "uninstall", "amplifier-app-cli"]],
+        ),
+        (
+            "amplifier v0.1.0\n- amplifier\n",
+            [["uv", "tool", "uninstall", "amplifier"]],
+        ),
+        (
+            "amplifier v0.1.0\n- amplifier\namplifier-app-cli v0.1.1\n- amplifier\n",
+            [
+                ["uv", "tool", "uninstall", "amplifier"],
+                ["uv", "tool", "uninstall", "amplifier-app-cli"],
+            ],
+        ),
+    ],
+)
+def test_reset_uninstalls_current_and_legacy_tool_distributions(
+    monkeypatch, tool_list, expected_uninstalls
+):
+    calls: list[list[str]] = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(argv)
+        if argv == ["uv", "tool", "list"]:
+            return SimpleNamespace(stdout=tool_list)
+        return SimpleNamespace()
+
+    monkeypatch.setattr(reset_module.subprocess, "run", fake_run)
+
+    assert reset_module._uninstall_amplifier() is True
+    assert calls == [["uv", "tool", "list"], *expected_uninstalls]
+
+
+def test_reset_force_installs_to_repair_an_orphaned_executable(monkeypatch):
+    run = MagicMock()
+    monkeypatch.setattr(reset_module.subprocess, "run", run)
+
+    assert reset_module._install_amplifier() is True
+    run.assert_called_once_with(
+        [
+            "uv",
+            "tool",
+            "install",
+            "--force",
+            reset_module.DEFAULT_INSTALL_SOURCE,
+        ],
+        check=True,
+    )
+
+
+def test_reset_force_install_still_surfaces_install_errors(monkeypatch):
+    run = MagicMock(
+        side_effect=subprocess.CalledProcessError(
+            1,
+            [
+                "uv",
+                "tool",
+                "install",
+                "--force",
+                reset_module.DEFAULT_INSTALL_SOURCE,
+            ],
+        )
+    )
+    fake_console = MagicMock()
+    monkeypatch.setattr(reset_module.subprocess, "run", run)
+    monkeypatch.setattr(reset_module, "console", fake_console)
+
+    assert reset_module._install_amplifier() is False
+    assert "Failed to install amplifier" in _console_text(fake_console)
+
+
+def test_windows_reset_finisher_uses_distribution_uninstall_and_forced_install(
+    monkeypatch,
+):
+    defer = MagicMock(return_value=True)
+    monkeypatch.setattr(reset_module, "console", MagicMock())
+    monkeypatch.setattr(reset_module, "defer_uv_tool_swap", defer)
+
+    assert reset_module._windows_defer_tool_swap(no_install=False) is True
+
+    steps = defer.call_args.args[0]
+    assert [step.command for step in steps] == [
+        "uv tool uninstall amplifier-app-cli",
+        f"uv tool install --force {reset_module.DEFAULT_INSTALL_SOURCE}",
+    ]
+    assert defer.call_args.kwargs["recovery_commands"] == [
+        "uv tool uninstall amplifier-app-cli",
+        f"uv tool install --force {reset_module.DEFAULT_INSTALL_SOURCE}",
+    ]
+
+
 def test_posix_reset_reinstalls_then_fails_after_incomplete_cleanup(monkeypatch):
     calls: list[str] = []
 
@@ -193,7 +289,7 @@ def test_posix_reset_reinstalls_then_fails_after_incomplete_cleanup(monkeypatch)
     monkeypatch.setattr(
         reset_module,
         "_remove_amplifier_dir",
-        lambda preserve, dry_run: calls.append("cleanup") or False,
+        lambda remove_cats, dry_run: calls.append("cleanup") or False,
     )
     monkeypatch.setattr(
         reset_module,

--- a/tests/test_windows_update_reset.py
+++ b/tests/test_windows_update_reset.py
@@ -255,24 +255,129 @@ def test_reset_force_install_still_surfaces_install_errors(monkeypatch):
     assert "Failed to install amplifier" in _console_text(fake_console)
 
 
-def test_windows_reset_finisher_uses_distribution_uninstall_and_forced_install(
-    monkeypatch,
-):
+def _stage_windows_swap(monkeypatch, tool_list: str | None, *, no_install: bool):
+    """Run the Windows deferred swap against a given `uv tool list` output.
+
+    `tool_list=None` simulates uv being unreadable.
+    """
+
+    def fake_run(argv, **kwargs):
+        if argv == ["uv", "tool", "list"]:
+            if tool_list is None:
+                raise FileNotFoundError("uv")
+            return SimpleNamespace(stdout=tool_list)
+        return SimpleNamespace()
+
     defer = MagicMock(return_value=True)
+    monkeypatch.setattr(reset_module.subprocess, "run", fake_run)
     monkeypatch.setattr(reset_module, "console", MagicMock())
     monkeypatch.setattr(reset_module, "defer_uv_tool_swap", defer)
 
-    assert reset_module._windows_defer_tool_swap(no_install=False) is True
+    staged = reset_module._windows_defer_tool_swap(no_install=no_install)
+    return staged, defer
+
+
+_MODERN = "amplifier v0.1.0\n- amplifier\n"
+_LEGACY = "amplifier-app-cli v0.1.1\n- amplifier\n"
+_BOTH = _MODERN + _LEGACY
+
+
+@pytest.mark.parametrize(
+    ("tool_list", "expected_uninstalls"),
+    [
+        (_MODERN, ["uv tool uninstall amplifier"]),
+        (_LEGACY, ["uv tool uninstall amplifier-app-cli"]),
+        (
+            _BOTH,
+            [
+                "uv tool uninstall amplifier",
+                "uv tool uninstall amplifier-app-cli",
+            ],
+        ),
+        ("", []),
+    ],
+)
+def test_windows_reset_finisher_uninstalls_the_registered_distribution(
+    monkeypatch, tool_list, expected_uninstalls
+):
+    """The name to uninstall is read back from uv, never assumed.
+
+    Hardcoding either name uninstalls the distribution the user does not have
+    and leaves the one they do have registered.
+    """
+    staged, defer = _stage_windows_swap(monkeypatch, tool_list, no_install=False)
+
+    assert staged is True
+    forced_install = f"uv tool install --force {reset_module.DEFAULT_INSTALL_SOURCE}"
+    expected = [*expected_uninstalls, forced_install]
+
+    assert [step.command for step in defer.call_args.args[0]] == expected
+    assert defer.call_args.kwargs["recovery_commands"] == expected
+
+
+def test_windows_reset_finisher_never_aborts_the_reinstall_on_uninstall_failure(
+    monkeypatch,
+):
+    """Uninstall steps stay best-effort; only the reinstall is required."""
+    _, defer = _stage_windows_swap(monkeypatch, _BOTH, no_install=False)
 
     steps = defer.call_args.args[0]
-    assert [step.command for step in steps] == [
-        "uv tool uninstall amplifier-app-cli",
-        f"uv tool install --force {reset_module.DEFAULT_INSTALL_SOURCE}",
+    assert [step.required for step in steps] == [False, False, True]
+
+
+@pytest.mark.parametrize(
+    ("tool_list", "expected_uninstalls"),
+    [
+        (_MODERN, ["uv tool uninstall amplifier"]),
+        (_LEGACY, ["uv tool uninstall amplifier-app-cli"]),
+    ],
+)
+def test_windows_no_install_uninstalls_what_is_actually_registered(
+    monkeypatch, tool_list, expected_uninstalls
+):
+    """`reset --no-install` must remove the distribution the user has.
+
+    With no reinstall behind it there is no `--force` install to paper over a
+    uninstall aimed at the wrong distribution: the step simply fails, the
+    deferred script aborts, and the tool stays installed.
+    """
+    staged, defer = _stage_windows_swap(monkeypatch, tool_list, no_install=True)
+
+    assert staged is True
+    steps = defer.call_args.args[0]
+    assert [step.command for step in steps] == expected_uninstalls
+    assert all(step.required for step in steps)
+
+
+def test_windows_no_install_stages_nothing_when_no_distribution_is_registered(
+    monkeypatch,
+):
+    staged, defer = _stage_windows_swap(monkeypatch, "", no_install=True)
+
+    assert staged is True
+    defer.assert_not_called()
+
+
+@pytest.mark.parametrize("no_install", [True, False])
+def test_windows_swap_covers_every_distribution_when_uv_cannot_be_read(
+    monkeypatch, no_install
+):
+    """An unreadable `uv tool list` must not collapse to a guessed name.
+
+    Uninstalling a distribution that is not registered is a no-op; missing the
+    one that is registered is what strands the user. Both are attempted, and
+    both are best-effort because neither is known to be present.
+    """
+    _, defer = _stage_windows_swap(monkeypatch, None, no_install=no_install)
+
+    commands = [step.command for step in defer.call_args.args[0]]
+    for package in reset_module.UV_TOOL_PACKAGES:
+        assert f"uv tool uninstall {package}" in commands
+
+    uninstall_steps = [
+        step for step in defer.call_args.args[0] if "uninstall" in step.command
     ]
-    assert defer.call_args.kwargs["recovery_commands"] == [
-        "uv tool uninstall amplifier-app-cli",
-        f"uv tool install --force {reset_module.DEFAULT_INSTALL_SOURCE}",
-    ]
+    assert not any(step.required for step in uninstall_steps)
 
 
 def test_posix_reset_reinstalls_then_fails_after_incomplete_cleanup(monkeypatch):


### PR DESCRIPTION
## What changed

- Make reset's internal plan removal-native: checked categories are removed, with `cache` and `registry` selected by default.
- Keep `--preserve` as a compatibility boundary adapter while passing one removal plan through cleanup and display logic.
- Make selected-path cleanup safe for empty selections, dynamically discovered `other` files, and directory symlinks.
- Preserve the existing full-reset behavior and clear install state only when cache removal is selected.
- Repair reinstall recovery for both current `amplifier` and legacy `amplifier-app-cli` uv tool registrations.
- Use `uv tool install --force` for POSIX and Windows recovery paths so stale executables do not block reinstall.
- Add focused regression coverage for reset planning, cleanup, interactive behavior, uv registration handling, forced installs, and Windows recovery.

## Why

The reset UI previously modeled selections as categories to preserve, which made cleanup behavior and empty selections easy to invert. Interrupted or historically mis-targeted installs could also leave an `amplifier` executable registered under the legacy `amplifier-app-cli` distribution, causing reinstall collisions. This change makes the removal contract explicit and repairs both known uv registration shapes.

## How to verify

- `uv run pytest -q`
  - `1704 passed, 1 skipped, 13 deselected, 1 xfailed`
- `git diff --check`
- `python -m compileall -q amplifier_app_cli tests/test_reset_cleanup.py tests/test_reset_interactive.py tests/test_windows_update_reset.py`
- Prior DTU validation of the refreshed local snapshot:
  - `1702 passed, 3 skipped, 13 deselected, 1 xfailed`
  - A real reset completed successfully, reinstalling the CLI and preserving the selected fixture data.

## Breaking changes

The interactive reset checklist now treats checked categories as items to remove; this is intentional and is reflected in the prompt text. The existing `--preserve` option remains supported as a compatibility boundary.