### PR TITLE
fix(reset): uninstall the registered uv distribution on Windows, refuse an empty --preserve

### DIFF
--- a/amplifier_app_cli/commands/reset.py
+++ b/amplifier_app_cli/commands/reset.py
@@ -65,9 +65,10 @@ DEFAULT_INSTALL_SOURCE = "git+https://github.com/microsoft/amplifier"
 
 # The current umbrella source registers `amplifier`; older installations
 # registered the CLI distribution directly. Both expose the `amplifier`
-# executable and must be removed before a reset's replacement install.
-UV_TOOL_PACKAGE = "amplifier-app-cli"
-UV_TOOL_PACKAGES = ("amplifier", UV_TOOL_PACKAGE)
+# executable and must be removed before a reset's replacement install. Neither
+# name may be hardcoded at a call site - which one is registered is a runtime
+# fact, read back via _installed_uv_tool_packages().
+UV_TOOL_PACKAGES = ("amplifier", "amplifier-app-cli")
 
 
 def _get_amplifier_dir() -> Path:
@@ -121,6 +122,18 @@ def _parse_categories(
     if value is None:
         return None
     categories = {c.strip() for c in value.split(",") if c.strip()}
+
+    # An empty --remove is a harmless no-op, but the mirrored empty --preserve
+    # means "preserve nothing" - it removes every category, projects included,
+    # and -y suppresses the confirm. That is the same blast radius as --full
+    # reached by an unset shell variable, so it has to be asked for by name.
+    if not categories and param.name == "preserve_cats":
+        raise click.BadParameter(
+            "--preserve was given an empty value, which would remove every "
+            "category including projects. Pass the categories to keep, or use "
+            "--full if removing everything is what you want."
+        )
+
     valid = set(RESET_CATEGORIES.keys())
     invalid = categories - valid
     if invalid:
@@ -239,11 +252,19 @@ def _clean_uv_cache(dry_run: bool = False) -> bool:
         return False
 
 
-def _uninstall_amplifier(dry_run: bool = False) -> bool:
-    """Uninstall amplifier via uv tool uninstall."""
-    console.print("[bold]>>>[/bold] Checking if amplifier is installed...")
+def _installed_uv_tool_packages() -> tuple[str, ...] | None:
+    """Report which known uv tool distributions are currently registered.
 
-    # Check if amplifier is installed
+    Both entries of ``UV_TOOL_PACKAGES`` expose the same ``amplifier``
+    executable, so the name to uninstall cannot be assumed - it has to be read
+    back from uv. Matching is anchored to ``"<package> "`` at the start of a
+    line so the indented ``- amplifier`` executable rows listed underneath a
+    package never count as a package of their own.
+
+    Returns:
+        The registered distribution names, possibly empty, or None when
+        ``uv tool list`` could not be consulted at all.
+    """
     try:
         result = subprocess.run(
             ["uv", "tool", "list"],
@@ -251,18 +272,27 @@ def _uninstall_amplifier(dry_run: bool = False) -> bool:
             capture_output=True,
             text=True,
         )
-        installed_packages = tuple(
-            package
-            for package in UV_TOOL_PACKAGES
-            if any(
-                line.startswith(f"{package} ") for line in result.stdout.splitlines()
-            )
-        )
-        if not installed_packages:
-            console.print("    [dim]Amplifier is not installed via uv tool[/dim]")
-            return False
     except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+
+    lines = result.stdout.splitlines()
+    return tuple(
+        package
+        for package in UV_TOOL_PACKAGES
+        if any(line.startswith(f"{package} ") for line in lines)
+    )
+
+
+def _uninstall_amplifier(dry_run: bool = False) -> bool:
+    """Uninstall amplifier via uv tool uninstall."""
+    console.print("[bold]>>>[/bold] Checking if amplifier is installed...")
+
+    installed_packages = _installed_uv_tool_packages()
+    if installed_packages is None:
         console.print("    [dim]Could not check uv tool list[/dim]")
+        return False
+    if not installed_packages:
+        console.print("    [dim]Amplifier is not installed via uv tool[/dim]")
         return False
 
     console.print("[bold]>>>[/bold] Uninstalling amplifier...")
@@ -460,14 +490,35 @@ def _windows_defer_tool_swap(no_install: bool) -> bool:
     Returns:
         True only when the deferred script was launched successfully.
     """
+    # Which distribution is registered cannot be assumed here any more than it
+    # can on POSIX: the umbrella source registers `amplifier`, older installs
+    # registered `amplifier-app-cli`, and uninstalling the name the user does
+    # *not* have is what strands them with the tool still installed.
+    detected = _installed_uv_tool_packages()
+    if detected is None:
+        # uv could not be read. Cover every known distribution best-effort
+        # rather than betting on one name; an uninstall for a distribution that
+        # is not registered is a no-op, missing the registered one is not.
+        uninstall_packages = list(UV_TOOL_PACKAGES)
+        uninstall_required = False
+    else:
+        uninstall_packages = list(detected)
+        uninstall_required = True
+
     if no_install:
+        if not uninstall_packages:
+            console.print("    [dim]Amplifier is not installed via uv tool[/dim]")
+            return True
+
         steps = [
             UvStep(
-                command=f"uv tool uninstall {UV_TOOL_PACKAGE}",
-                label="Uninstalling amplifier...",
+                command=f"uv tool uninstall {package}",
+                label=f"Uninstalling {package}...",
+                required=uninstall_required,
             )
+            for package in uninstall_packages
         ]
-        recovery = [f"uv tool uninstall {UV_TOOL_PACKAGE}"]
+        recovery = [f"uv tool uninstall {package}" for package in uninstall_packages]
         success = "Amplifier removed."
     else:
         steps = [
@@ -475,18 +526,21 @@ def _windows_defer_tool_swap(no_install: bool) -> bool:
             # `amplifier` executable if the uninstall could not complete.
             # Aborting here is what would leave the user with no amplifier.
             UvStep(
-                command=f"uv tool uninstall {UV_TOOL_PACKAGE}",
-                label="Uninstalling amplifier (best effort)...",
+                command=f"uv tool uninstall {package}",
+                label=f"Uninstalling {package} (best effort)...",
                 attempts=5,
                 required=False,
-            ),
+            )
+            for package in uninstall_packages
+        ]
+        steps.append(
             UvStep(
                 command=f"uv tool install --force {DEFAULT_INSTALL_SOURCE}",
                 label="Reinstalling amplifier...",
-            ),
-        ]
+            )
+        )
         recovery = [
-            f"uv tool uninstall {UV_TOOL_PACKAGE}",
+            *(f"uv tool uninstall {package}" for package in uninstall_packages),
             f"uv tool install --force {DEFAULT_INSTALL_SOURCE}",
         ]
         success = "Amplifier reset complete."

--- a/tests/test_reset_cleanup.py
+++ b/tests/test_reset_cleanup.py
@@ -37,7 +37,6 @@ def _invoke_dry_run(monkeypatch, args: list[str]) -> tuple[MagicMock, MagicMock]
             ["--preserve", "projects,settings,keys,other", "-y"],
             {"cache", "registry"},
         ),
-        (["--preserve", "", "-y"], set(reset_module.RESET_CATEGORIES)),
         (["--full", "-y"], set(reset_module.RESET_CATEGORIES)),
     ],
 )
@@ -46,6 +45,24 @@ def test_cli_options_resolve_to_a_removal_plan(monkeypatch, args, expected_remov
 
     assert show_plan.call_args.args[0] == expected_remove
     assert cleanup.call_args.args[0] == expected_remove
+
+
+def test_empty_preserve_is_refused_rather_than_removing_everything(monkeypatch):
+    """`--preserve "$VAR"` with VAR unset must not become a silent --full.
+
+    An empty --remove is a no-op, so the mirrored empty --preserve reaching
+    "remove every category, projects included" - with -y suppressing the
+    confirm - is a blast radius an unset shell variable should not be able to
+    select. --full is how that is asked for.
+    """
+    cleanup = MagicMock()
+    monkeypatch.setattr(reset_module, "_remove_amplifier_dir", cleanup)
+
+    result = CliRunner().invoke(reset_module.reset, ["--preserve", "", "-y"])
+
+    assert result.exit_code != 0
+    assert "--full" in result.output
+    cleanup.assert_not_called()
 
 
 def _make_amplifier_dir(tmp_path: Path) -> Path:

--- a/tests/test_windows_update_reset.py
+++ b/tests/test_windows_update_reset.py
@@ -255,24 +255,129 @@ def test_reset_force_install_still_surfaces_install_errors(monkeypatch):
     assert "Failed to install amplifier" in _console_text(fake_console)
 
 
-def test_windows_reset_finisher_uses_distribution_uninstall_and_forced_install(
-    monkeypatch,
-):
+def _stage_windows_swap(monkeypatch, tool_list: str | None, *, no_install: bool):
+    """Run the Windows deferred swap against a given `uv tool list` output.
+
+    `tool_list=None` simulates uv being unreadable.
+    """
+
+    def fake_run(argv, **kwargs):
+        if argv == ["uv", "tool", "list"]:
+            if tool_list is None:
+                raise FileNotFoundError("uv")
+            return SimpleNamespace(stdout=tool_list)
+        return SimpleNamespace()
+
     defer = MagicMock(return_value=True)
+    monkeypatch.setattr(reset_module.subprocess, "run", fake_run)
     monkeypatch.setattr(reset_module, "console", MagicMock())
     monkeypatch.setattr(reset_module, "defer_uv_tool_swap", defer)
 
-    assert reset_module._windows_defer_tool_swap(no_install=False) is True
+    staged = reset_module._windows_defer_tool_swap(no_install=no_install)
+    return staged, defer
+
+
+_MODERN = "amplifier v0.1.0\n- amplifier\n"
+_LEGACY = "amplifier-app-cli v0.1.1\n- amplifier\n"
+_BOTH = _MODERN + _LEGACY
+
+
+@pytest.mark.parametrize(
+    ("tool_list", "expected_uninstalls"),
+    [
+        (_MODERN, ["uv tool uninstall amplifier"]),
+        (_LEGACY, ["uv tool uninstall amplifier-app-cli"]),
+        (
+            _BOTH,
+            [
+                "uv tool uninstall amplifier",
+                "uv tool uninstall amplifier-app-cli",
+            ],
+        ),
+        ("", []),
+    ],
+)
+def test_windows_reset_finisher_uninstalls_the_registered_distribution(
+    monkeypatch, tool_list, expected_uninstalls
+):
+    """The name to uninstall is read back from uv, never assumed.
+
+    Hardcoding either name uninstalls the distribution the user does not have
+    and leaves the one they do have registered.
+    """
+    staged, defer = _stage_windows_swap(monkeypatch, tool_list, no_install=False)
+
+    assert staged is True
+    forced_install = f"uv tool install --force {reset_module.DEFAULT_INSTALL_SOURCE}"
+    expected = [*expected_uninstalls, forced_install]
+
+    assert [step.command for step in defer.call_args.args[0]] == expected
+    assert defer.call_args.kwargs["recovery_commands"] == expected
+
+
+def test_windows_reset_finisher_never_aborts_the_reinstall_on_uninstall_failure(
+    monkeypatch,
+):
+    """Uninstall steps stay best-effort; only the reinstall is required."""
+    _, defer = _stage_windows_swap(monkeypatch, _BOTH, no_install=False)
 
     steps = defer.call_args.args[0]
-    assert [step.command for step in steps] == [
-        "uv tool uninstall amplifier-app-cli",
-        f"uv tool install --force {reset_module.DEFAULT_INSTALL_SOURCE}",
+    assert [step.required for step in steps] == [False, False, True]
+
+
+@pytest.mark.parametrize(
+    ("tool_list", "expected_uninstalls"),
+    [
+        (_MODERN, ["uv tool uninstall amplifier"]),
+        (_LEGACY, ["uv tool uninstall amplifier-app-cli"]),
+    ],
+)
+def test_windows_no_install_uninstalls_what_is_actually_registered(
+    monkeypatch, tool_list, expected_uninstalls
+):
+    """`reset --no-install` must remove the distribution the user has.
+
+    With no reinstall behind it there is no `--force` install to paper over a
+    uninstall aimed at the wrong distribution: the step simply fails, the
+    deferred script aborts, and the tool stays installed.
+    """
+    staged, defer = _stage_windows_swap(monkeypatch, tool_list, no_install=True)
+
+    assert staged is True
+    steps = defer.call_args.args[0]
+    assert [step.command for step in steps] == expected_uninstalls
+    assert all(step.required for step in steps)
+
+
+def test_windows_no_install_stages_nothing_when_no_distribution_is_registered(
+    monkeypatch,
+):
+    staged, defer = _stage_windows_swap(monkeypatch, "", no_install=True)
+
+    assert staged is True
+    defer.assert_not_called()
+
+
+@pytest.mark.parametrize("no_install", [True, False])
+def test_windows_swap_covers_every_distribution_when_uv_cannot_be_read(
+    monkeypatch, no_install
+):
+    """An unreadable `uv tool list` must not collapse to a guessed name.
+
+    Uninstalling a distribution that is not registered is a no-op; missing the
+    one that is registered is what strands the user. Both are attempted, and
+    both are best-effort because neither is known to be present.
+    """
+    _, defer = _stage_windows_swap(monkeypatch, None, no_install=no_install)
+
+    commands = [step.command for step in defer.call_args.args[0]]
+    for package in reset_module.UV_TOOL_PACKAGES:
+        assert f"uv tool uninstall {package}" in commands
+
+    uninstall_steps = [
+        step for step in defer.call_args.args[0] if "uninstall" in step.command
     ]
-    assert defer.call_args.kwargs["recovery_commands"] == [
-        "uv tool uninstall amplifier-app-cli",
-        f"uv tool install --force {reset_module.DEFAULT_INSTALL_SOURCE}",
-    ]
+    assert not any(step.required for step in uninstall_steps)
 
 
 def test_posix_reset_reinstalls_then_fails_after_incomplete_cleanup(monkeypatch):


### PR DESCRIPTION
Review fixes for #303. Targets that PR's branch so it can be merged into it before #303 lands.

Two findings from an adversarial review of the removal-native reset work. Both were reachable from a documented command line, and both were codified as correct by tests added in #303.

## What changed

- Lift the uv-distribution detection POSIX already did into `_installed_uv_tool_packages()`, and use it on the Windows deferred swap too — the name to uninstall is a runtime fact on both platforms now, never a hardcoded guess.
- When `uv tool list` cannot be read at all, attempt every known distribution best-effort rather than collapsing back to one name.
- Refuse `--preserve` with an empty value, pointing at `--full`.
- Update the two tests that pinned the old behavior; add Windows coverage for the modern, legacy, both-registered, neither-registered, and uv-unreadable cases.

## Why

**1. Windows uninstalled the legacy distribution only.**

`UV_TOOL_PACKAGE = "amplifier-app-cli"` is the *legacy* name. The current umbrella source registers `amplifier`, and `_uninstall_amplifier` on POSIX already reads both names back from `uv tool list`. Windows bet on one name and picked the one most users do not have. `main` used `amplifier` here, so this was a regression introduced by the rename.

Resolved steps on the #303 branch:

```
no_install=True   required=True   uv tool uninstall amplifier-app-cli
no_install=False  required=False  uv tool uninstall amplifier-app-cli
                  required=True   uv tool install --force git+.../amplifier
```

`reset --no-install` is where it bites. That uninstall step is `required`, so for a modern install it fails, the deferred script aborts to the failure block, and the tool is left registered — while the recovery text hands the user the same wrong command. The reinstall path survived only because `uv tool install --force` papers over the failed uninstall.

After:

```
--no-install / modern:  uv tool uninstall amplifier (required=True)
--no-install / legacy:  uv tool uninstall amplifier-app-cli (required=True)
--no-install / both:    uv tool uninstall amplifier (required=True),
                        uv tool uninstall amplifier-app-cli (required=True)
```

**2. An empty `--preserve` silently selected `--full`'s blast radius.**

```
amplifier reset --remove   "$VAR" -y     # VAR unset -> no-op
amplifier reset --preserve "$VAR" -y     # VAR unset -> removed ~/.amplifier entirely
```

Same empty shell variable, opposite outcome, no confirm under `-y`. Verified against a real tree: session transcripts destroyed, exit 0. This predates #303, but #303's stated goal is making cleanup safe for empty selections, and it added `(["--preserve", "", "-y"], set(RESET_CATEGORIES))` asserting the behavior — so it is fixed here rather than left pinned. Removing everything is still available, by name, as `--full`.

## How to verify

- `uv run pytest -q`
  - `1713 passed, 1 skipped, 13 deselected, 1 xfailed`
  - Reverting either source change fails the tests added here.
- `git diff --check`
- `python -m compileall -q amplifier_app_cli/commands/reset.py tests/test_reset_cleanup.py tests/test_windows_update_reset.py`

## Breaking changes

`amplifier reset --preserve ""` now exits non-zero instead of removing everything. Any script relying on that spelling should use `--full`.

## Not addressed here

Two lower-severity findings from the same review, left for a separate call:

- The interactive `[a]` key flipped from `Preserve all` (safest action) to `Remove all` (most destructive) with no rename. Guarded only by `click.confirm("Proceed?")`, which does default to No.
- `_get_other_files()` sweeps internal state such as `install-state.json`, while the `other` category is described to users as "Custom files you've added".