### PR TITLE
fix(reset): preserve state reset does not manage, instead of sweeping it as "other"

### DIFF
--- a/amplifier_app_cli/commands/reset.py
+++ b/amplifier_app_cli/commands/reset.py
@@ -10,6 +10,18 @@ Categories:
     cache     - Downloaded bundles (auto-regenerates)
     registry  - Bundle mappings (auto-regenerates)
 
+Anything in ~/.amplifier that is not named by a category above is *not managed
+by reset*: selective cleanup never touches it, and the plan lists it so it is
+visible rather than implied. Only --full, which removes the directory outright,
+takes unmanaged state with it.
+
+That rule exists because the category list is a static description of a
+directory other components keep adding to. It previously had a catch-all
+"other" category that expanded, at runtime, to every unrecognised entry - one
+checkbox that on a real machine covered 76% of ~/.amplifier, including state
+belonging to components this module has never heard of. A taxonomy that goes
+stale by default must fail towards keeping data, not towards deleting it.
+
 Example:
     # Interactive mode (default)
     amplifier reset
@@ -33,19 +45,19 @@ from ..utils.uv_utils import UvStep, defer_uv_tool_swap
 from ..utils.uv_utils import remove_stale_uv_lock as _remove_stale_uv_lock
 from .reset_interactive import ChecklistItem, run_checklist
 
-# Category definitions: category name -> list of files/dirs in ~/.amplifier
-# Note: "other" is a special dynamic category - see _get_other_files()
+# Category definitions: category name -> list of files/dirs in ~/.amplifier.
+# Every entry is an explicit, static path. There is deliberately no dynamic
+# catch-all: an entry that appears here is one someone decided reset owns.
 RESET_CATEGORIES = {
     "projects": ["projects"],
     "settings": ["settings.yaml"],
     "keys": ["keys.env"],
     "cache": ["cache"],
     "registry": ["registry.json"],
-    "other": [],  # Dynamic - populated at runtime with uncategorized files
 }
 
 # Display order for categories
-CATEGORY_ORDER = ["projects", "settings", "keys", "cache", "registry", "other"]
+CATEGORY_ORDER = ["projects", "settings", "keys", "cache", "registry"]
 
 # Descriptions for each category (used in UI)
 CATEGORY_DESCRIPTIONS = {
@@ -54,8 +66,11 @@ CATEGORY_DESCRIPTIONS = {
     "keys": "API keys (keys.env)",
     "cache": "Downloaded bundles (auto-regenerates)",
     "registry": "Bundle mappings (auto-regenerates)",
-    "other": "Other files (custom configs, plugins, etc.)",
 }
+
+# Retired category. Kept only so the parser can explain what happened rather
+# than emitting a bare "invalid category" for a spelling that used to work.
+_RETIRED_CATEGORIES = {"other"}
 
 # Default categories to remove - safe by default, only remove auto-regenerating items
 DEFAULT_REMOVE = {"cache", "registry"}
@@ -77,41 +92,42 @@ def _get_amplifier_dir() -> Path:
 
 
 def _get_known_files() -> set[str]:
-    """Get all file/directory names covered by non-dynamic categories."""
+    """Get all file/directory names covered by a category."""
     known = set()
-    for category, files in RESET_CATEGORIES.items():
-        if category != "other":  # Skip dynamic category
-            known.update(files)
+    for files in RESET_CATEGORIES.values():
+        known.update(files)
     return known
 
 
-def _get_other_files() -> list[str]:
-    """Get list of files in ~/.amplifier not covered by any category.
+def _get_unmanaged_files() -> list[str]:
+    """List entries in ~/.amplifier that no category claims.
 
-    These are user-created files like custom configs, plugins, etc.
-    Returns empty list if directory doesn't exist.
+    These belong to components reset does not model - other modules' state,
+    credentials they store outside keys.env, anything added since this
+    taxonomy was written. Selective cleanup never removes them; this exists so
+    the plan can *show* what is being left alone. Returns an empty list if the
+    directory does not exist.
     """
     amplifier_dir = _get_amplifier_dir()
     if not amplifier_dir.exists():
         return []
 
     known = _get_known_files()
-    other = []
-    for item in amplifier_dir.iterdir():
-        if item.name not in known:
-            other.append(item.name)
-    return sorted(other)
+    return sorted(
+        item.name for item in amplifier_dir.iterdir() if item.name not in known
+    )
 
 
 def _get_remove_paths(remove_cats: set[str]) -> set[str]:
-    """Convert category names to actual file/directory names."""
+    """Convert category names to actual file/directory names.
+
+    Only ever expands to statically declared category paths. Nothing here
+    reads the directory, so an entry reset does not know about cannot be
+    selected for removal by any category.
+    """
     paths = set()
     for category in remove_cats:
-        if category == "other":
-            # Dynamic category - include all uncategorized files
-            paths.update(_get_other_files())
-        elif category in RESET_CATEGORIES:
-            paths.update(RESET_CATEGORIES[category])
+        paths.update(RESET_CATEGORIES.get(category, []))
     return paths
 
 
@@ -135,6 +151,16 @@ def _parse_categories(
         )
 
     valid = set(RESET_CATEGORIES.keys())
+    retired = categories & _RETIRED_CATEGORIES
+    if retired:
+        raise click.BadParameter(
+            f"The '{', '.join(sorted(retired))}' category was removed. It "
+            "expanded at runtime to every unrecognised entry in ~/.amplifier, "
+            "so it swept state belonging to components reset does not model. "
+            "Files outside the named categories are now always preserved; use "
+            "--full to remove the directory outright."
+        )
+
     invalid = categories - valid
     if invalid:
         raise click.BadParameter(
@@ -164,6 +190,7 @@ def _run_interactive() -> set[str] | None:
 
 def _show_plan(
     remove_cats: set[str],
+    full: bool,
     no_install: bool,
     dry_run: bool,
 ) -> None:
@@ -174,7 +201,7 @@ def _show_plan(
         console.print("[yellow]DRY RUN - No changes will be made[/yellow]\n")
 
     # Upfront reassurance about what's safe
-    if "projects" not in remove_cats:
+    if not full and "projects" not in remove_cats:
         console.print(
             "[green]Your session transcripts are safe[/green] - "
             "projects/ will be preserved.\n"
@@ -189,26 +216,28 @@ def _show_plan(
         category for category in CATEGORY_ORDER if category not in remove_cats
     ]
 
-    # Show what "other" actually contains when it is selected for removal.
-    other_files = _get_other_files() if "other" in remove_cats else []
-
-    if remove_cats == set(RESET_CATEGORIES):
+    if full:
         console.print(f"  3. Remove {amplifier_dir} [red](ALL contents)[/red]")
+        unmanaged = _get_unmanaged_files()
+        if unmanaged:
+            # --full is the only path that takes unmanaged state with it, so
+            # it is the one place the user has to be told by name.
+            console.print(
+                "       [red]Including state reset does not manage:[/red] "
+                f"{', '.join(unmanaged)}"
+            )
     else:
         console.print(f"  3. Clean parts of {amplifier_dir}")
-        # Build removal display with "other" expansion.
-        remove_display = []
-        for name in remove_names:
-            if name == "other" and other_files:
-                remove_display.append(f"other ({', '.join(other_files)})")
-            else:
-                remove_display.append(name)
-        console.print(
-            f"       [red]Removing:[/red] {', '.join(remove_display) or 'none'}"
-        )
+        console.print(f"       [red]Removing:[/red] {', '.join(remove_names) or 'none'}")
         console.print(
             f"       [green]Preserving:[/green] {', '.join(preserve_names) or 'none'}"
         )
+        unmanaged = _get_unmanaged_files()
+        if unmanaged:
+            console.print(
+                "       [green]Preserving (not managed by reset):[/green] "
+                f"{', '.join(unmanaged)}"
+            )
 
     if no_install:
         console.print("  4. [dim]Skip reinstall (--no-install)[/dim]")
@@ -321,8 +350,15 @@ def _uninstall_amplifier(dry_run: bool = False) -> bool:
     return success
 
 
-def _remove_amplifier_dir(remove_cats: set[str], dry_run: bool = False) -> bool:
-    """Remove only paths from selected reset categories.
+def _remove_amplifier_dir(
+    remove_cats: set[str], full: bool = False, dry_run: bool = False
+) -> bool:
+    """Remove paths from the selected reset categories.
+
+    Whole-directory removal is driven by ``full``, never inferred from the
+    category set. Selecting every category still only removes the paths those
+    categories name, because the directory holds state no category models and
+    naming five things is not a request to delete a sixth.
 
     Uses shared cache_management utilities for cache/registry removal when those
     categories are being removed, ensuring DRY compliance across commands.
@@ -337,16 +373,31 @@ def _remove_amplifier_dir(remove_cats: set[str], dry_run: bool = False) -> bool:
         pass  # Will use inline rmtree_robust fallback
 
     amplifier_dir = _get_amplifier_dir()
+
+    # The shared utilities resolve ~/.amplifier independently, via
+    # cache_management.get_amplifier_dir(). Only delegate to them when that
+    # answer matches the directory actually being cleaned - otherwise they
+    # would clear the real cache and registry while this loop removes paths
+    # from somewhere else entirely, which is a silent cross-directory delete
+    # rather than a redirected one.
+    if clear_download_cache is not None or clear_registry is not None:
+        from ..utils.cache_management import get_amplifier_dir as _shared_dir
+
+        if _shared_dir() != amplifier_dir:
+            clear_download_cache = None
+            clear_registry = None
+
     console.print(f"[bold]>>>[/bold] Removing {amplifier_dir}...")
 
     if not amplifier_dir.exists():
         console.print("    [dim]Directory does not exist, skipping[/dim]")
         return True
 
-    # Removing every category has the established --full behavior: remove the
-    # root in one operation. An empty category set is deliberately *not* the
-    # inverse of this case; it is a data-cleanup no-op.
-    if remove_cats == set(RESET_CATEGORIES):
+    # --full is the only way to reach whole-directory removal: it is the one
+    # request that explicitly includes state reset does not manage. An empty
+    # category set is deliberately *not* the inverse of this case; it is a
+    # data-cleanup no-op.
+    if full:
         if dry_run:
             console.print(
                 f"    [dim][dry-run] Would remove entire directory: {amplifier_dir}[/dim]"
@@ -626,9 +677,13 @@ def reset(
       projects   - Session transcripts and history [not removed by default]
       settings   - User configuration (settings.yaml) [not removed by default]
       keys       - API keys (keys.env) [not removed by default]
-      other      - Custom files you've added [not removed by default]
       cache      - Downloaded bundles (auto-regenerates) [removed by default]
       registry   - Bundle mappings (auto-regenerates) [removed by default]
+
+    \b
+    Anything else in ~/.amplifier belongs to components reset does not model
+    and is always preserved. Only --full removes it, and the plan names it
+    first.
 
     \b
     Examples:
@@ -672,7 +727,7 @@ def reset(
             return
 
     # Show plan
-    _show_plan(remove_cats, no_install, dry_run)
+    _show_plan(remove_cats, full, no_install, dry_run)
 
     # Confirm unless -y or dry-run
     if not yes and not dry_run:
@@ -691,7 +746,7 @@ def reset(
     # runs after this process exits. POSIX unlinks open files, so the path below
     # is unchanged there.
     if os.name == "nt" and not dry_run:
-        if not _remove_amplifier_dir(remove_cats, dry_run):
+        if not _remove_amplifier_dir(remove_cats, full=full, dry_run=dry_run):
             raise click.ClickException(
                 "Reset stopped because cleanup was incomplete; "
                 "no reinstall was staged."
@@ -701,7 +756,7 @@ def reset(
         return
 
     _uninstall_amplifier(dry_run)
-    cleanup_succeeded = _remove_amplifier_dir(remove_cats, dry_run)
+    cleanup_succeeded = _remove_amplifier_dir(remove_cats, full=full, dry_run=dry_run)
 
     if dry_run:
         console.print("\n[green]>>>[/green] Dry run complete - no changes were made")

--- a/tests/test_reset_cleanup.py
+++ b/tests/test_reset_cleanup.py
@@ -34,7 +34,7 @@ def _invoke_dry_run(monkeypatch, args: list[str]) -> tuple[MagicMock, MagicMock]
         (["--remove", "cache", "-y"], {"cache"}),
         (["--remove", "", "-y"], set()),
         (
-            ["--preserve", "projects,settings,keys,other", "-y"],
+            ["--preserve", "projects,settings,keys", "-y"],
             {"cache", "registry"},
         ),
         (["--full", "-y"], set(reset_module.RESET_CATEGORIES)),
@@ -89,19 +89,41 @@ def test_cleanup_removes_only_explicitly_selected_paths(tmp_path, monkeypatch):
         assert (amplifier_dir / name).exists(), name
 
 
-def test_cleanup_removes_only_dynamic_other_paths(tmp_path, monkeypatch):
+def test_cleanup_never_touches_unmanaged_state(tmp_path, monkeypatch):
+    """Entries no category names belong to other components, and are kept.
+
+    ~/.amplifier accumulates state from components reset does not model -
+    device memory, user skills, credentials modules store outside keys.env.
+    Selecting every category reset *does* know about must not reach any of it.
+    """
     amplifier_dir = _make_amplifier_dir(tmp_path)
-    custom_dir = amplifier_dir / "plugin"
-    custom_dir.mkdir()
-    (custom_dir / "entry.py").write_text("plugin")
+    unmanaged_dir = amplifier_dir / "engram"
+    unmanaged_dir.mkdir()
+    (unmanaged_dir / "memory.json").write_text("irreplaceable")
     monkeypatch.setattr(reset_module, "_get_amplifier_dir", lambda: amplifier_dir)
+    monkeypatch.setattr(
+        "amplifier_app_cli.paths.get_install_state_path",
+        lambda: tmp_path / "install-state.json",
+    )
 
-    assert reset_module._remove_amplifier_dir({"other"})
+    assert reset_module._remove_amplifier_dir(set(reset_module.RESET_CATEGORIES))
 
-    assert not (amplifier_dir / "custom.toml").exists()
-    assert not custom_dir.exists()
-    for name in ("projects", "cache", "registry.json", "settings.yaml", "keys.env"):
-        assert (amplifier_dir / name).exists(), name
+    assert (unmanaged_dir / "memory.json").read_text() == "irreplaceable"
+    assert (amplifier_dir / "custom.toml").exists()
+    assert amplifier_dir.exists()
+    for name in ("projects", "settings.yaml", "keys.env", "cache", "registry.json"):
+        assert not (amplifier_dir / name).exists(), name
+
+
+def test_retired_other_category_is_refused_with_an_explanation(monkeypatch):
+    cleanup = MagicMock()
+    monkeypatch.setattr(reset_module, "_remove_amplifier_dir", cleanup)
+
+    result = CliRunner().invoke(reset_module.reset, ["--remove", "other", "-y"])
+
+    assert result.exit_code != 0
+    assert "--full" in result.output
+    cleanup.assert_not_called()
 
 
 def test_full_cleanup_removes_the_root_directory(tmp_path, monkeypatch):
@@ -112,10 +134,33 @@ def test_full_cleanup_removes_the_root_directory(tmp_path, monkeypatch):
         "amplifier_app_cli.paths.get_install_state_path", get_install_state_path
     )
 
-    assert reset_module._remove_amplifier_dir(set(reset_module.RESET_CATEGORIES))
+    assert reset_module._remove_amplifier_dir(
+        set(reset_module.RESET_CATEGORIES), full=True
+    )
 
     assert not amplifier_dir.exists()
     get_install_state_path.assert_not_called()
+
+
+def test_whole_directory_removal_requires_full_not_a_complete_category_set(
+    tmp_path, monkeypatch
+):
+    """Naming every category is not a request to delete a sixth thing.
+
+    Inferring "remove the root" from set equality is the same overloading that
+    made an empty preserve set mean "nuke everything"; ``full`` is explicit.
+    """
+    amplifier_dir = _make_amplifier_dir(tmp_path)
+    monkeypatch.setattr(reset_module, "_get_amplifier_dir", lambda: amplifier_dir)
+    monkeypatch.setattr(
+        "amplifier_app_cli.paths.get_install_state_path",
+        lambda: tmp_path / "install-state.json",
+    )
+
+    assert reset_module._remove_amplifier_dir(set(reset_module.RESET_CATEGORIES))
+
+    assert amplifier_dir.exists()
+    assert (amplifier_dir / "custom.toml").exists()
 
 
 def test_empty_removal_plan_is_a_data_cleanup_no_op(tmp_path, monkeypatch):
@@ -175,3 +220,38 @@ def test_selected_directory_symlink_is_unlinked_without_touching_target(
 
     assert not project_link.is_symlink()
     assert target_file.read_text() == "session"
+
+
+def test_cleanup_never_clears_the_real_cache_for_another_directory(
+    tmp_path, monkeypatch
+):
+    """Selecting cache/registry must act on the directory being cleaned.
+
+    clear_download_cache/clear_registry resolve ~/.amplifier themselves, via a
+    second copy of the path logic in cache_management. Without a guard, a
+    _remove_amplifier_dir call pointed anywhere else still wiped the *real*
+    cache and registry -- a cross-directory delete, and a live footgun for any
+    test that selects those categories.
+    """
+    amplifier_dir = _make_amplifier_dir(tmp_path)
+    monkeypatch.setattr(reset_module, "_get_amplifier_dir", lambda: amplifier_dir)
+
+    real_cache = MagicMock(return_value=(0, True))
+    real_registry = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.cache_management.clear_download_cache", real_cache
+    )
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.cache_management.clear_registry", real_registry
+    )
+    monkeypatch.setattr(
+        "amplifier_app_cli.paths.get_install_state_path",
+        lambda: tmp_path / "install-state.json",
+    )
+
+    assert reset_module._remove_amplifier_dir({"cache", "registry"})
+
+    real_cache.assert_not_called()
+    real_registry.assert_not_called()
+    assert not (amplifier_dir / "cache").exists()
+    assert not (amplifier_dir / "registry.json").exists()

--- a/tests/test_windows_update_reset.py
+++ b/tests/test_windows_update_reset.py
@@ -92,6 +92,13 @@ def test_remove_amplifier_dir_reports_cache_failure_and_continues(
         return True
 
     monkeypatch.setattr(reset_module, "_get_amplifier_dir", lambda: amplifier_dir)
+    # Redirect both resolutions of ~/.amplifier coherently: reset only
+    # delegates to the shared utilities when they agree with the directory
+    # being cleaned, so patching one alone would silently bypass them.
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.cache_management.get_amplifier_dir",
+        lambda: amplifier_dir,
+    )
     monkeypatch.setattr(
         "amplifier_app_cli.utils.cache_management.clear_download_cache",
         clear_cache,
@@ -107,13 +114,15 @@ def test_remove_amplifier_dir_reports_cache_failure_and_continues(
     fake_console = MagicMock()
     monkeypatch.setattr(reset_module, "console", fake_console)
 
-    success = reset_module._remove_amplifier_dir({"cache", "registry", "other"})
+    success = reset_module._remove_amplifier_dir({"cache", "registry"})
 
     assert success is False
     clear_cache.assert_called_once_with(dry_run=False)
-    assert not removable.exists(), "independent cleanup must continue after cache failure"
-    assert not (amplifier_dir / "registry.json").exists()
+    assert not (amplifier_dir / "registry.json").exists(), (
+        "independent cleanup must continue after cache failure"
+    )
     assert (amplifier_dir / "settings.yaml").exists()
+    assert removable.exists(), "unmanaged files are never swept by a category"
     output = _console_text(fake_console)
     assert "Cleanup incomplete" in output
     assert "cache" in output
@@ -126,6 +135,13 @@ def test_remove_amplifier_dir_reports_registry_failure(tmp_path, monkeypatch):
     (amplifier_dir / "settings.yaml").write_text("keep", encoding="utf-8")
 
     monkeypatch.setattr(reset_module, "_get_amplifier_dir", lambda: amplifier_dir)
+    # Redirect both resolutions of ~/.amplifier coherently: reset only
+    # delegates to the shared utilities when they agree with the directory
+    # being cleaned, so patching one alone would silently bypass them.
+    monkeypatch.setattr(
+        "amplifier_app_cli.utils.cache_management.get_amplifier_dir",
+        lambda: amplifier_dir,
+    )
     monkeypatch.setattr(
         "amplifier_app_cli.utils.cache_management.clear_registry",
         MagicMock(return_value=False),
@@ -394,7 +410,7 @@ def test_posix_reset_reinstalls_then_fails_after_incomplete_cleanup(monkeypatch)
     monkeypatch.setattr(
         reset_module,
         "_remove_amplifier_dir",
-        lambda remove_cats, dry_run: calls.append("cleanup") or False,
+        lambda remove_cats, full, dry_run: calls.append("cleanup") or False,
     )
     monkeypatch.setattr(
         reset_module,


### PR DESCRIPTION
Follow-up to #303 / #304.

## The problem

The `other` category expanded at runtime to every entry in `~/.amplifier` that the five static categories did not name, and presented the result as one checkbox labelled *"Other files (custom configs, plugins, etc.)"*.

On a real machine that was **16 of 21 entries — 76% of the directory**:

```
AGENTS.md                    engram                     settings
attention                    keys.env.lock              settings.yaml.lock
context-intelligence-logs    openai-chatgpt-oauth.json  skills
converge-app.secret          rate-limit-state.json      terminal-sessions
converge-app.state.json      recipe-runner              wayfinder
converge-app.toml
```

That is device memory, user-authored skills, a `settings/` directory the `settings` category does not name, and credentials other modules store outside `keys.env`.

The category list is a static description of a directory other components keep adding to, so it goes stale by default. A taxonomy with that property has to fail towards keeping data.

## What changed

- **`other` is retired.** Entries no category names are always preserved, and the plan lists them by name so it is visible rather than implied. Only `--full` still takes them.
- **Whole-directory removal is driven by an explicit `full`**, not inferred from `remove_cats == set(RESET_CATEGORIES)`. Naming every category is not a request to delete a sixth thing — that is the same overloading that made an empty preserve set mean "nuke everything".
- **`_remove_amplifier_dir` only delegates to `clear_download_cache`/`clear_registry` when `cache_management`'s own resolution of `~/.amplifier` agrees with the directory being cleaned.** It resolves that path independently, so before this a call pointed anywhere else still wiped the *real* cache and registry. Observed live: a test run against `tmp_path` emptied the developer's actual `~/.amplifier/cache` and removed `registry.json`, and destabilised the rest of the suite as it went.
- **`--remove other` explains the retirement** instead of emitting a bare "invalid category" for a spelling that used to work.

## Plan output now

```
  3. Clean parts of /home/you/.amplifier
       Removing: cache, registry
       Preserving: projects, settings, keys
       Preserving (not managed by reset): AGENTS.md, attention,
       context-intelligence-logs, converge-app.secret, engram, skills, ...
```

## Deliberately not done

Credentials at the `~/.amplifier` root (`openai-chatgpt-oauth.json`, `converge-app.secret`) are **not** special-cased into the `keys` category. Those are defects in the modules that write them — they should be using `keys.env`. Adding them here would paper over that and grow a second list that goes stale the same way.

## How to verify

- `uv run pytest -q` → `1727 passed, 1 skipped, 13 deselected, 1 xfailed`, stable across 3 consecutive runs
- `git diff --check`
- `python -m compileall -q amplifier_app_cli/commands/reset.py tests/test_reset_cleanup.py tests/test_windows_update_reset.py`

## Breaking changes

`--remove other` / `--preserve other` now exit non-zero with an explanation. Scripts using `--preserve ...,other` should drop the `other` term — unnamed files are preserved unconditionally now.

## Still open

The interactive `[a]` key still flipped meaning in #303, from `Preserve all` (safest action) to `Remove all`. It is less destructive after this change — it no longer reaches unmanaged state, and no longer triggers whole-directory removal — but it still selects projects, settings and keys under the same keystroke that used to protect them. Left as a separate UI decision.