### PR TITLE
fix(highway): watchdog re-arms at its runtime cap instead of dying silently (6c3y)

### DIFF
--- a/amplifier_app_cli/data/skills/ten-lane-highway/SKILL.md
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/SKILL.md
@@ -88,7 +88,7 @@ repo** (a real run left `.amplifier/bin/` behind as untracked pollution).
 | `highway_status.sh BATCH_DIR WIDTH READY` | ONE call reports every lane + watchdog liveness and **computes DEFICIT by code** | "Keep lanes full" stopped being prose the day a run sat at 1 lane with work for 10 |
 | `launch_lane.sh BATCH_DIR LANE REPO GOAL [BASE_REF]` | Worktree + branch + tmux + `/goal` session, idempotent; the ONLY writer of `manifest.tsv` | Hand-written manifests diverged on column count and broke a real batch |
 | `verify_lane.sh BATCH_DIR LANE` | Git-facts probe for one landed lane (DONE.json, ahead-count, three-dot diffstat, uncommitted work) | "Ground truth from git and the filesystem, not from what any session said about itself" |
-| `highway_watchdog.sh BATCH_DIR WIDTH SESSION_ID [INTERVAL] [MAX_HOURS]` | Detached tmux loop that re-wakes THIS session (`amplifier run --resume`) on lane-end / under-width / stale heartbeat | The highway once froze overnight because the manager stopped monitoring the moment it reported status |
+| `highway_watchdog.sh BATCH_DIR WIDTH SESSION_ID [INTERVAL] [MAX_HOURS]` | Detached tmux loop that re-wakes THIS session (`amplifier run --resume`) on lane-end / under-width / stale heartbeat; **re-arms itself at its runtime cap while the batch is open** | The highway once froze overnight because the manager stopped monitoring the moment it reported status — then froze ~34h more when the watchdog hit its own cap |
 | `infra_ledger.sh BATCH_DIR add TYPE ID DESTROY_CMD...` / `infra_ledger.sh BATCH_DIR sweep --all-owners` | Records any infrastructure a lane OR the manager stands up (DTU, gitea instance, container, service, background process) into `infra.tsv` at creation, each with its teardown command; `sweep` runs those commands and exits non-zero until nothing is left standing | A run closed with a DTU and a gitea container still live — nothing the highway stands up should outlive it (Rule 14) |
 
 **`sweep` is the MANAGER's batch-close verb, never a lane's.** It runs EVERY
@@ -113,11 +113,41 @@ perform that teardown. A REAL teardown failure still exits non-zero and leaves
 the row open; the already-gone signature is deliberately narrow, so the signal
 that a teardown genuinely failed is never lost.
 
+**The watchdog's runtime cap re-arms; it does not silently stop.** `MAX_HOURS`
+(default 12) exists so an orphaned watchdog cannot outlive its batch. It used to
+be enforced by exiting — and on 2026-09-03 that exit put the highway to sleep for
+~34 hours, because the only channel a dying watchdog had left was a `wake-needed`
+file read by the thing it was supervising. At the cap it now:
+
+- **re-execs itself** (same arguments, generation counter bumped in
+  `watchdog.log`) while the batch is **open** — `BATCH_DIR/lanes/` exists AND the
+  manager touched `.manager-heartbeat` within `HIGHWAY_ABANDON_MAX` (default
+  21600s / 6h). A re-arm costs you nothing: no wake, no `wake-needed` entry;
+- **winds down** otherwise, so the cap's original purpose survives — an orphan
+  can now outlive its batch by at most one cap period, never indefinitely.
+
+On wind-down it writes the `wake-needed` line **and** dispatches
+`amplifier run --resume` **detached** (`setsid`), never as its own child. That
+detail is load-bearing: in the measured outage the manager answered the death
+notice from inside the watchdog's own tmux session, ran
+`tmux kill-session -t hw-watchdog__<batch>` to clear the "expired" watchdog, and
+killed itself mid-restart before it reached the line that starts the replacement.
+**Never `kill-session` a watchdog that told you it is exiting — it has already
+gone; just start a fresh one.** Escape hatches, all env vars:
+`HIGHWAY_ABANDON_MAX` (how long a silent manager means "abandoned"),
+`HIGHWAY_MAX_SECONDS` (second-resolution cap, overrides `MAX_HOURS`).
+
+The watchdog also touches `BATCH_DIR/.watchdog-heartbeat` every poll, and
+`highway_status.sh` reports `watchdog_hb_age` (`-1` = never ran here) plus
+`SUPERVISION LAPSED <n>s ago` when it is DEAD — so a lapse is read off an
+instrument, never inferred from a wake that never came.
+
 State lives in `BATCH_DIR` (create one per highway, e.g. `~/dev/hw-<name>`):
 `manifest.tsv` (scripts write), `HIGHWAY.md` (you write), `goals/` (pre-composed
 goal files), `lanes/` (worktrees), `.width` (authoritative width), `infra.tsv`
 (the infra ledger), `infra.owners.tsv` (which lane claimed which row),
-`.manager-heartbeat`, `wake-needed`, `watchdog.log`.
+`.manager-heartbeat`, `.watchdog-heartbeat` (the watchdog's own proof of life),
+`wake-needed`, `watchdog.log`.
 
 ## Phase 1 — Intake
 
@@ -308,7 +338,12 @@ The documented failure: the manager reported status and the highway froze
 until morning. Before ANY turn-ending message while lanes run:
 
 1. `highway_status.sh` must show `watchdog=LIVE` — if DEAD, start it (Phase 4
-   command; the session ID is in `<BATCH_DIR>/.session-id`) and re-check.
+   command; the session ID is in `<BATCH_DIR>/.session-id`) and re-check. Read
+   `SUPERVISION LAPSED <n>s ago` in the same output as the size of the blind
+   spot you are re-opening. **Do NOT `tmux kill-session` the dead watchdog
+   first** — if it exited on its own it is already gone, and if you are reading
+   its death notice you are running *inside* that session; killing it kills you
+   (measured, 2026-09-03, ~34h idle). Start the new one directly.
    **Never end a turn with the watchdog dead while lanes are live.**
 2. The todo lane board is current.
 3. The message leads with a state token in the first 100 characters —

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh
@@ -77,22 +77,32 @@ done < "$MANIFEST"
 
 WD="hw-watchdog__${BATCH}"
 if tmux -L "${HIGHWAY_TMUX_SOCKET:-hw}" has-session -t "$WD" 2>/dev/null; then wd_st=LIVE; else wd_st=DEAD; fi
+# SUPERVISION HEARTBEAT (model_performance-6c3y): the watchdog touches
+# .watchdog-heartbeat every poll, so a lapse is reported with a DURATION rather
+# than inferred from a wake that never came. -1 = no heartbeat file at all
+# (watchdog never started here, or predates the heartbeat).
+WD_HB="$BATCH_DIR/.watchdog-heartbeat"
+if [ -f "$WD_HB" ]; then wd_hb_age=$(( now - $(stat -c %Y "$WD_HB") )); else wd_hb_age=-1; fi
 
 open=$(( WIDTH - live )); if [ "$open" -lt 0 ]; then open=0; fi
 if [ "$READY" -lt "$open" ]; then deficit=$READY; else deficit=$open; fi
 
 if [ "$JSON" = 1 ]; then
-  printf '{"ts":"%s","batch":"%s","live":%d,"ended":%d,"done_marker":%d,"stalled":%d,"gone":%d,"width":%d,"width_source":"%s","ready":%d,"deficit":%d,"watchdog":"%s"}\n' \
-    "$(date -u +%FT%TZ)" "$BATCH" "$live" "$ended" "$done_n" "$stalled" "$gone" "$WIDTH" "$width_source" "$READY" "$deficit" "$wd_st"
+  printf '{"ts":"%s","batch":"%s","live":%d,"ended":%d,"done_marker":%d,"stalled":%d,"gone":%d,"width":%d,"width_source":"%s","ready":%d,"deficit":%d,"watchdog":"%s","watchdog_hb_age":%d}\n' \
+    "$(date -u +%FT%TZ)" "$BATCH" "$live" "$ended" "$done_n" "$stalled" "$gone" "$WIDTH" "$width_source" "$READY" "$deficit" "$wd_st" "$wd_hb_age"
   exit 0
 fi
 
 echo
-echo "SUMMARY batch=$BATCH live=$live ended=$ended done_marker=$done_n stalled=$stalled gone=$gone width=$WIDTH width_source=$width_source ready=$READY watchdog=$wd_st"
+echo "SUMMARY batch=$BATCH live=$live ended=$ended done_marker=$done_n stalled=$stalled gone=$gone width=$WIDTH width_source=$width_source ready=$READY watchdog=$wd_st watchdog_hb_age=${wd_hb_age}s"
 echo "DEFICIT=$deficit"
 if [ "$deficit" -gt 0 ]; then
   echo "ACTION: launch $deficit lane(s) NOW - refill before anything else."
 fi
 if [ "$wd_st" = "DEAD" ]; then
-  echo "WARNING: watchdog $WD is not running - do not end the turn until it is."
+  if [ "$wd_hb_age" -ge 0 ]; then
+    echo "WARNING: watchdog $WD is not running - SUPERVISION LAPSED ${wd_hb_age}s ago (last .watchdog-heartbeat) - do not end the turn until it is."
+  else
+    echo "WARNING: watchdog $WD is not running - lapse duration unknown (no .watchdog-heartbeat) - do not end the turn until it is."
+  fi
 fi

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_watchdog.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_watchdog.sh
@@ -13,7 +13,20 @@
 # plus a durable `wake-needed` file in BATCH_DIR in case the resume fails.
 # The orchestrator touches BATCH_DIR/.manager-heartbeat every cycle and deletes
 # wake-needed entries it has processed.
+#
+# AT THE RUNTIME CAP the loop does NOT simply exit (model_performance-6c3y):
+#   batch still open  -> re-exec itself with the same arguments (CAP RE-ARM GUARD)
+#   batch not open    -> deliver a final notice OUT OF BAND and exit (the cap's
+#                        original purpose -- no orphan outliving its batch)
+# It also touches BATCH_DIR/.watchdog-heartbeat every poll (SUPERVISION
+# HEARTBEAT), so highway_status.sh can report not just THAT supervision lapsed
+# but for HOW LONG, without anyone inferring it from a wake that never came.
 set -uo pipefail   # deliberately NOT -e: the watch loop must survive transient failures
+# A FAILED `exec` kills a non-interactive bash outright -- which would turn the
+# re-arm below into the silent stop this whole guard exists to remove. execfail
+# makes exec return instead, so the fallback path can run. (Caught by
+# test_cap_rearms_even_when_the_exec_bit_is_stripped, not by reading the manual.)
+shopt -s execfail
 
 BATCH_DIR=${1:?BATCH_DIR required}
 WIDTH=${2:?WIDTH required}
@@ -26,6 +39,11 @@ LOGF="$BATCH_DIR/watchdog.log"
 STATE="$BATCH_DIR/.watchdog-state"
 HB="$BATCH_DIR/.manager-heartbeat"
 HB_MAX=${HIGHWAY_HEARTBEAT_MAX:-1800}
+# SUPERVISION HEARTBEAT: proof-of-life this process writes for the MANAGER to
+# read. The manager touches $HB so the watchdog can tell it is alive; until now
+# nothing ran the other way, so "the watchdog stopped" was only ever visible to
+# whoever happened to run highway_status.sh.
+WD_HB="$BATCH_DIR/.watchdog-heartbeat"
 WAKE_GAP=${HIGHWAY_WAKE_GAP:-180}
 # If the manager's heartbeat is fresher than this, its foreground turn is still
 # active and will handle refill/merge inline. Waking then spawns a SECOND
@@ -61,7 +79,38 @@ prev_live=-1        # -1 so the very first poll never looks like a non-increase
 ineffective=0       # consecutive ineffective (under-width, non-recovering) polls
 escalate=0          # 1 while the ineffective count is at/over the threshold
 
-deadline=$(( $(date +%s) + MAX_HOURS * 3600 ))
+# CAP: MAX_HOURS is the documented knob. HIGHWAY_MAX_SECONDS overrides it with a
+# second-resolution cap -- the escape hatch for short-lived batches and for the
+# tests, which cannot wait 12h to observe what happens at the boundary.
+MAX_SECONDS=${HIGHWAY_MAX_SECONDS:-$(( MAX_HOURS * 3600 ))}
+deadline=$(( $(date +%s) + MAX_SECONDS ))
+# Which run of this process we are on. Bumped across every re-exec, so the log
+# reads as one continuous supervision record rather than N unexplained starts.
+GENERATION=${HIGHWAY_WATCHDOG_GENERATION:-1}
+# CAP RE-ARM GUARD: "still open" = the lanes directory exists AND the manager
+# has checked in within HIGHWAY_ABANDON_MAX. Deliberately much looser than
+# HB_MAX (a manager idle for 30 min is normal and gets woken; one that has not
+# touched its heartbeat in 6h has gone home). Re-arming ONLY while both hold is
+# what preserves the cap's original purpose -- an orphaned watchdog can now
+# outlive its batch by at most one cap period, never indefinitely.
+LANES_DIR="$BATCH_DIR/lanes"
+ABANDON_MAX=${HIGHWAY_ABANDON_MAX:-21600}
+batch_state=""
+batch_open() {
+  if [ ! -d "$LANES_DIR" ]; then
+    batch_state="no lanes dir at $LANES_DIR"; return 1
+  fi
+  if [ ! -f "$HB" ]; then
+    batch_state="manager heartbeat $HB never created"; return 1
+  fi
+  local age
+  age=$(( $(date +%s) - $(stat -c %Y "$HB") ))
+  if [ "$age" -gt "$ABANDON_MAX" ]; then
+    batch_state="manager heartbeat ancient (${age}s > ${ABANDON_MAX}s)"; return 1
+  fi
+  batch_state="lanes dir present, manager heartbeat ${age}s old"
+  return 0
+}
 START_TS=$(date +%s)
 # Grace after watchdog start during which an ABSENT heartbeat means "manager
 # still warming up in Phase 4" (not "manager dead") -> defer waking. Closes the
@@ -117,15 +166,62 @@ wake() {
   fi
 }
 
-log "watchdog start batch=$BATCH_DIR width=$WIDTH session=$SESSION_ID interval=${INTERVAL}s max=${MAX_HOURS}h hb_max=${HB_MAX}s"
+# The death notice. NOT wake(): it must never be suppressed by WAKE_GAP (the
+# one message that matters most is the one most likely to land inside the gap),
+# and it must NOT run as a child of this process inside this process's own tmux
+# session. On 2026-09-03 it did: the resumed manager was told "restart me",
+# reasonably ran `tmux kill-session -t hw-watchdog__<batch>` -- and killed
+# ITSELF, because it was running inside that very session. It never reached the
+# line that starts the replacement, and the highway sat idle ~34h. So the notice
+# is dispatched detached (setsid/nohup), this process exits immediately, and the
+# prompt says outright that killing the session is unnecessary.
+final_notice() {
+  local reason="$1" batch wd prompt body
+  batch=$(printf '%s' "$(basename "$BATCH_DIR")" | tr -c 'A-Za-z0-9_-' '_')
+  wd="hw-watchdog__${batch}"
+  # Durable signal first: a file survives every delivery failure below.
+  printf '%s\t%s\n' "$(date -u +%FT%TZ)" "$reason" >> "$BATCH_DIR/wake-needed"
+  prompt="HIGHWAY WATCHDOG STOPPED (watchdog): $reason. Supervision of $BATCH_DIR has ENDED - no further wakes will arrive from me. If the highway is still open, start a fresh watchdog (Phase 4 command; session id in $BATCH_DIR/.session-id) and re-check highway_status.sh. The old watchdog process has ALREADY exited: do NOT run 'tmux kill-session -t $wd' first - on 2026-09-03 a responder did exactly that while running inside that session, killed itself mid-restart, and the highway sat idle ~34h."
+  body='if amplifier run --resume "$1" --output-format json "$2" >> "$3" 2>&1; then
+          printf "%s final notice delivered (resume ok)\n" "$(date -u +%FT%TZ)" >> "$3"
+        else
+          printf "%s final notice FAILED (resume rc=%s) - wake-needed is the durable signal\n" "$(date -u +%FT%TZ)" "$?" >> "$3"
+        fi'
+  if command -v setsid >/dev/null 2>&1; then
+    setsid bash -c "$body" _ "$SESSION_ID" "$prompt" "$LOGF" >/dev/null 2>&1 &
+    log "final notice dispatched detached (setsid pid=$!): $reason"
+  else
+    nohup bash -c "$body" _ "$SESSION_ID" "$prompt" "$LOGF" >/dev/null 2>&1 &
+    log "final notice dispatched detached (nohup pid=$!): $reason"
+  fi
+}
+
+log "watchdog start batch=$BATCH_DIR width=$WIDTH session=$SESSION_ID interval=${INTERVAL}s max=${MAX_SECONDS}s generation=$GENERATION hb_max=${HB_MAX}s"
 touch "$STATE"
+touch "$WD_HB"
 
 while :; do
   sleep "$INTERVAL"
+  touch "$WD_HB"   # SUPERVISION HEARTBEAT: written every poll, read by highway_status.sh
 
   if [ "$(date +%s)" -ge "$deadline" ]; then
-    wake "watchdog max runtime (${MAX_HOURS}h) reached - restart me if the highway is still open"
-    log "exit: deadline reached"
+    if batch_open; then
+      # CAP RE-ARM GUARD: supervision continues past the cap while the batch is
+      # open. No wake, no wake-needed line -- a re-arm costs the manager nothing
+      # and needs nothing from it. The re-exec resets the deadline.
+      log "CAP RE-ARM: cap (${MAX_SECONDS}s) reached but batch is still open ($batch_state) - re-exec as generation $(( GENERATION + 1 ))"
+      export HIGHWAY_WATCHDOG_GENERATION=$(( GENERATION + 1 ))
+      exec "$0" "$@"
+      # Reached only if that exec failed (exec bit stripped by a packaging step,
+      # noexec mount). Re-exec through the interpreter already running us before
+      # giving up -- a re-arm that silently degrades to an exit is the very
+      # failure this item exists to close.
+      log "CAP RE-ARM: exec '$0' failed - retrying through ${BASH:-bash}"
+      exec "${BASH:-bash}" "$0" "$@"
+      log "CAP RE-ARM FAILED: could not re-exec '$0' - falling back to the wind-down path"
+    fi
+    final_notice "watchdog max runtime (${MAX_SECONDS}s, generation $GENERATION) reached and the batch is not open ($batch_state) - supervision has stopped"
+    log "exit: deadline reached, batch not open ($batch_state)"
     exit 0
   fi
 

--- a/docs/lanes/6c3y-watchdog-selfrestart/DONE-NOTE.md
+++ b/docs/lanes/6c3y-watchdog-selfrestart/DONE-NOTE.md
@@ -1,0 +1,155 @@
+# Lane 6c3y — the highway watchdog dies at its own cap and nobody is told
+
+Item: `model_performance-6c3y` · Repo: `microsoft/amplifier-app-cli` · Branch:
+`lane/6c3y-watchdog-selfrestart` · Outcome: **A. RESOLVED** (all deliverables DONE;
+none hit the cap).
+
+## What was measured, before anything was changed
+
+The item's account is right about the symptom and **incomplete about the
+mechanism**. Reading the live batch's `watchdog.log` (read-only) turned up the
+part that matters:
+
+```
+line     1:  2026-09-02T14:04:27Z watchdog start ... max=12h     (generation 1)
+line 33456:  2026-09-03T02:10:29Z watchdog start ... max=12h     (generation 2)
+line 50060:  2026-09-03T14:14:05Z WAKE: watchdog max runtime (12h) reached - restart me...
+line 50274:  2026-09-06T00:26:06Z watchdog start ...             (~34h later)
+```
+
+Between 50060 and 50274 the log carries **neither `wake delivered (resume ok)`
+nor `exit: deadline reached`** — the two lines the existing code writes on every
+other path. So the watchdog did not exit at its cap. It was *killed*.
+
+The transcript in between says why. The final wake **was delivered**: the resumed
+manager's own reasoning is in the log — *"The watchdog has died after hitting its
+12-hour max runtime … I need to … critically restart the watchdog before doing
+anything else"* — and it then ran:
+
+```
+=== killing expired watchdog (12h04m) ===; tmux -L hw kill-session -t "hw-watchdog__hw-model-performance"
+```
+
+**It was running inside that session.** `wake()` calls `amplifier run --resume`
+synchronously, so the responder was a child of the very watchdog it was clearing
+away. Killing the session killed the responder mid-restart, before it reached the
+line that starts the replacement. Hence no further log lines, and ~34h of idle.
+
+Consequences for the fix, all three tested:
+
+1. Option 3 in the item ("make the final message reach something that is not the
+   patient") was **already implemented** — the deadline path already called
+   `wake()`, which already calls `amplifier run --resume`. Delivery was never the
+   problem. *Where the responder was standing* was the problem.
+2. A restart that depends on someone answering a message is one participant away
+   from failing. Re-arm (option 1) removes the participant.
+3. `wake()` can drop the message entirely: a wake inside `WAKE_GAP` (180s)
+   returns early **before** the `wake-needed` write. The one message with no next
+   poll behind it must never be gappable.
+
+## What changed
+
+`amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_watchdog.sh`
+
+- **`CAP RE-ARM GUARD`** — at the deadline, if the batch is open, `exec "$0" "$@"`
+  with `HIGHWAY_WATCHDOG_GENERATION` bumped; the deadline resets. *Open* =
+  `BATCH_DIR/lanes/` exists **AND** `.manager-heartbeat` is younger than
+  `HIGHWAY_ABANDON_MAX` (default 21600s / 6h — deliberately far looser than
+  `HB_MAX`'s 1800s, which describes a manager that is merely idle). A re-arm
+  writes a log line and nothing else: no wake, no `wake-needed` entry.
+- **`shopt -s execfail`** — a failed `exec` kills a non-interactive bash outright,
+  which would have converted the re-arm into a silent stop by another name. With
+  `execfail` the failure falls through to `exec "${BASH:-bash}" "$0" "$@"`. This
+  was **found by the test, not by reading the manual**: the exec-bit-stripped case
+  failed on first run.
+- **`final_notice()`** replaces `wake()` on the wind-down path: writes
+  `wake-needed` unconditionally (not gappable), then dispatches
+  `amplifier run --resume` **detached** via `setsid` (falling back to `nohup`), and
+  exits immediately. The prompt names the trap outright — *"The old watchdog has
+  ALREADY exited: do NOT run `tmux kill-session -t hw-watchdog__<batch>` first"*.
+- **`SUPERVISION HEARTBEAT`** — `.watchdog-heartbeat` touched at start and every
+  poll.
+- `HIGHWAY_MAX_SECONDS` — second-resolution cap override (documented escape
+  hatch; also what lets the tests observe a cap boundary without waiting 12h).
+
+`.../scripts/highway_status.sh`
+
+- Reports `watchdog_hb_age` (JSON + `SUMMARY` line; `-1` = no heartbeat file at
+  all) and, when the watchdog is DEAD, `SUPERVISION LAPSED <n>s ago`. JSON gained
+  one **additive** field; existing consumers read by name and are unaffected.
+
+`.../SKILL.md` — the cap's new behaviour, both branches, both env knobs, the
+`.watchdog-heartbeat` state file, and the do-NOT-`kill-session` rule in Phase 6
+step 1 where a manager will actually hit it.
+
+`docs/lanes/6c3y-watchdog-selfrestart/check_skill_guards.6c3y.patch` — four
+proposed `check` lines for the manager's `BATCH_DIR/check_skill_guards.sh`,
+including the **docs half** (2nz's transferable finding: a partial re-apply is
+more dangerous than a total revert). That file lives outside this repo and
+outside this lane's ownership, so it is shipped as a patch, not applied.
+
+## Deliverables
+
+| Deliverable | State |
+|---|---|
+| Supervision CONTINUES past the cap while the batch is open | **DONE** — `test_cap_rearms_while_batch_is_open` asserts generation 3 from one spawned process; re-arm also proven to survive a stripped exec bit |
+| Cap's original purpose preserved; a test proves BOTH branches | **DONE** — open → re-arms; no lanes dir → winds down rc=0; ancient heartbeat → winds down; widened `HIGHWAY_ABANDON_MAX` → re-arms again (proves the wind-down is the window's doing). The cap was **not** removed or raised |
+| Final message reaches something that is not the patient | **DONE** — forced past `WAKE_GAP` and dispatched detached; asserted via a PATH-stubbed `amplifier` that records argv |
+| Say plainly whether a manager-side inverse check is still needed | **DONE** — see below |
+| Documentation ships in the same change | **DONE** — SKILL.md + drift-check patch in the same commit |
+| Full suite green, pasted in the PR body | **DONE** — 1740 passed / 1 skipped / 13 deselected / 1 xfailed |
+| DRAFT PR on origin | **DONE** — see `publication` in `DONE.json` |
+| DONE-NOTE at the lane artifact root | **DONE** — this file |
+
+Nothing was recorded NOT-POSSIBLE; the cap never bound (see Spend).
+
+## Is a manager-side inverse check still needed? — **No, and I recommend against adding one**
+
+Rejected, with the cheap half kept:
+
+- **The expensive half is redundant.** Option 2 asks the manager to check its
+  supervisor's freshness at the top of every cycle. The manager *already* runs
+  `highway_status.sh` first on every wake (Phase 5 step 1, and again as the Phase 6
+  turn-ending gate), and that instrument already printed `watchdog=DEAD`. A second
+  manager-side check adds a second thing to remember and no new signal.
+- **It would not have caught this outage**, as the item itself notes: the manager
+  was idle *because* no wake arrived. Any check that runs "next cycle" is dead
+  code when there is no next cycle. Re-arm needs no manager at all.
+- **The cheap half is kept and is what makes acceptance criterion 3 checkable.**
+  `.watchdog-heartbeat` + `watchdog_hb_age` turns "supervision lapsed" from an
+  inference into a measured duration, for a stop from *any* cause — cap, crash, or
+  kill — at zero cost to the manager's attention.
+
+## Deviations and residual risk
+
+- **Bound, honestly stated:** an orphaned watchdog can now outlive its batch by
+  at most one cap period (≤12h at defaults) rather than being bounded at 12h from
+  start. Abandonment is only evaluated at the cap boundary. Tightening it to
+  every poll would wind down a healthy batch whose manager is legitimately quiet,
+  so the looser bound is the deliberate trade. Documented in SKILL.md.
+- `setsid` is util-linux; on a host without it the notice is dispatched with
+  `nohup` instead. The script was already GNU/Linux-only (`stat -c %Y`).
+- The item's option 3 was already present in the code. Reporting it as newly
+  added would have been false; what was added is *forced* and *detached*.
+- **`MAX_HOURS` was neither removed nor raised**, per the scope-out.
+- Untouched, per the scope-out: `infra_ledger.sh`, `lane_teardown.sh`, every
+  sweep/teardown path. `grep -c 'sweep\|teardown\|incus\|dtu'` on the two edited
+  scripts: `highway_watchdog.sh` 0, `highway_status.sh` 1 — and that one is a
+  pre-existing comment word (`# ended + worktree removed = normal post-teardown
+  terminal state`, line 66), not code and not a line this branch changed.
+- **The live watchdog was not disturbed.** Interaction with the running batch was
+  read-only (`grep`/`sed` on `watchdog.log`, `ls`). Every test runs against a
+  `tmp_path` batch dir on tmux socket `hw-test-6c3y`, never the default `hw`.
+- Suite baseline: the goal quotes 1682 passed at `395fa68`. Re-measured on this
+  host in a clean worktree at that commit: **1727 passed**, 1 skipped, 13
+  deselected, 1 xfailed. With this branch: **1740 passed** — +13, exactly the new
+  tests, zero regressions. The goal's figure appears stale; the +13 delta is the
+  honest comparison.
+
+## Spend
+
+**$0.00 against an authority of $0.00** (`0 runs x 0 arms x $0 / 1.00 = $0.00`).
+No API calls, no DTUs, no infrastructure created, nothing to register in the infra
+ledger and nothing to tear down. The authority's arithmetic closes for a pure
+shell/source change. Residue: $0.00; smallest useful purchase it could not buy:
+none — this deliverable needed no purchase.

--- a/docs/lanes/6c3y-watchdog-selfrestart/check_skill_guards.6c3y.patch
+++ b/docs/lanes/6c3y-watchdog-selfrestart/check_skill_guards.6c3y.patch
@@ -1,0 +1,19 @@
+# PROPOSED ADDITION to the manager's BATCH_DIR/check_skill_guards.sh
+# (model_performance-6c3y). That file lives in the highway BATCH_DIR, which is
+# OUTSIDE this repo and outside this lane's ownership -- so this lane ships the
+# patch rather than applying it. Append these four `check` lines next to the
+# existing 0rg/bqu ones.
+#
+# The fourth line is the 2nz lesson applied to this fix: a guard and the
+# documentation of its escape hatch are ONE artifact. Cycle 49 restored 0rg's
+# guard but not its --all-owners docs and this very script certified the
+# half-restored state as OK.
+
+check scripts/highway_watchdog.sh "CAP RE-ARM GUARD" "model_performance-6c3y" \
+  "re-apply the cap re-arm (re-exec at the cap while the batch is open; wind down when it is not)"
+check scripts/highway_watchdog.sh "SUPERVISION HEARTBEAT" "model_performance-6c3y" \
+  "re-apply the watchdog's own .watchdog-heartbeat touch on every poll"
+check scripts/highway_status.sh "SUPERVISION HEARTBEAT" "model_performance-6c3y (instrument half)" \
+  "re-apply watchdog_hb_age + 'SUPERVISION LAPSED <n>s ago' reporting in highway_status.sh"
+check SKILL.md "re-arms itself at its runtime cap" "model_performance-6c3y (docs half)" \
+  "restore SKILL.md's cap re-arm text: re-arm-while-open, wind-down-when-abandoned, HIGHWAY_ABANDON_MAX, and the do-NOT-kill-session rule"

--- a/tests/test_ten_lane_highway_watchdog.py
+++ b/tests/test_ten_lane_highway_watchdog.py
@@ -46,8 +46,12 @@ import pytest
 # POSIX shell (exec, setsid, stat -c, tab-delimited read loops), only ever run on
 # the POSIX hosts that run a highway -- same module-level skip as the ledger tests.
 pytestmark = pytest.mark.skipif(
-    sys.platform == "win32" or shutil.which("bash") is None,
-    reason="highway_watchdog.sh is a POSIX shell script; requires bash",
+    sys.platform != "linux" or shutil.which("bash") is None,
+    reason=(
+        "highway_watchdog.sh is a GNU/Linux shell script: it uses `stat -c %Y`, a GNU "
+        "coreutils flag with no BSD/macOS equivalent -- the script documents "
+        "this itself at highway_status.sh:53. Requires Linux + bash."
+    ),
 )
 
 SCRIPTS = (

--- a/tests/test_ten_lane_highway_watchdog.py
+++ b/tests/test_ten_lane_highway_watchdog.py
@@ -1,0 +1,437 @@
+"""Guards on the shipped ten-lane-highway ``highway_watchdog.sh`` runtime cap.
+
+model_performance-6c3y. The supervisor that exists to catch stalled lanes
+stopped itself and nothing caught THAT. Measured, from ``watchdog.log`` of the
+run that filed the item:
+
+    2026-09-02T14:04:27Z watchdog start ... max=12h
+    2026-09-03T02:10:29Z watchdog start ... max=12h      (second generation)
+    2026-09-03T14:14:05Z WAKE: watchdog max runtime (12h) reached - restart me
+    2026-09-06T00:26:06Z watchdog start ...              (~34h later)
+
+Between those last two lines the highway sat at live=0 with four lanes ENDED and
+unverified. The final wake DID reach the manager -- the resumed session's own
+reasoning is in the log ("restart the watchdog before doing anything else") --
+and then it ran ``tmux kill-session -t hw-watchdog__<batch>``. It was running
+*inside* that session, as a child of the very watchdog it was killing, so it
+killed itself mid-restart. That is why the log carries neither ``wake delivered``
+nor ``exit: deadline reached`` for that generation: the process was killed, not
+exited. Three properties follow, and each has a test below:
+
+1. supervision CONTINUES past the cap while the batch is open (re-exec), so the
+   restart never depends on a human or a model doing anything at all;
+2. an abandoned batch STILL winds down -- the cap's original purpose, an orphan
+   never outliving its batch, is preserved rather than traded away;
+3. the death notice is forced (never eaten by WAKE_GAP) and dispatched DETACHED,
+   so whoever answers it is not living inside the process group they are being
+   asked to replace.
+
+Every case runs the real script as a subprocess and asserts a real outcome. The
+``amplifier`` on PATH is a stub that records its argv, so "no wake was sent" is
+proven by an absent record rather than inferred from an exit code -- the same
+standard ``test_ten_lane_highway_infra_ledger.py`` set for the sweep guards.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+# POSIX shell (exec, setsid, stat -c, tab-delimited read loops), only ever run on
+# the POSIX hosts that run a highway -- same module-level skip as the ledger tests.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="highway_watchdog.sh is a POSIX shell script; requires bash",
+)
+
+SCRIPTS = (
+    Path(__file__).resolve().parent.parent
+    / "amplifier_app_cli"
+    / "data"
+    / "skills"
+    / "ten-lane-highway"
+    / "scripts"
+)
+WATCHDOG = SCRIPTS / "highway_watchdog.sh"
+STATUS = SCRIPTS / "highway_status.sh"
+
+MANIFEST_HEADER = "lane\twt\tbranch\tbase\ttmux\tgoal\tlog\tts\n"
+
+
+def write_manifest(batch: Path, *lanes: str) -> None:
+    """Manifest rows whose tmux sessions deliberately do not exist (= ENDED)."""
+    rows = [MANIFEST_HEADER]
+    for lane in lanes:
+        rows.append(
+            f"{lane}\t{batch}/lanes/{lane}/repo\tlane/{lane}\torigin/main\t"
+            f"hw__test__{lane}\t{batch}/goals/{lane}.md\t{batch}/lanes/{lane}/lane.log\t2026-09-05T00:00:00Z\n"
+        )
+    (batch / "manifest.tsv").write_text("".join(rows), encoding="utf-8")
+
+
+@pytest.fixture
+def stub_bin(tmp_path: Path) -> Path:
+    """A PATH shim whose `amplifier` records every invocation to amplifier-calls."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    record = tmp_path / "amplifier-calls"
+    stub = bin_dir / "amplifier"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$*" >> {record}\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    return bin_dir
+
+
+def calls(tmp_path: Path) -> list[str]:
+    record = tmp_path / "amplifier-calls"
+    if not record.exists():
+        return []
+    return [line for line in record.read_text(encoding="utf-8").splitlines() if line.strip()]
+
+
+def watchdog_env(stub_bin: Path, **overrides: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env["PATH"] = f"{stub_bin}{os.pathsep}{env['PATH']}"
+    # NEVER the default `hw` socket: a test must not read (or race) the tmux
+    # server of a highway that is actually running on this host.
+    env["HIGHWAY_TMUX_SOCKET"] = "hw-test-6c3y"
+    env.update(overrides)
+    return env
+
+
+def spawn_watchdog(
+    batch: Path,
+    stub_bin: Path,
+    *,
+    interval: str = "1",
+    argv0: Path = WATCHDOG,
+    via_bash: bool = True,
+    **env_overrides: str,
+) -> subprocess.Popen:
+    cmd = ["bash", str(argv0)] if via_bash else [str(argv0)]
+    return subprocess.Popen(
+        [*cmd, str(batch), "3", "sess-6c3y", interval],
+        env=watchdog_env(stub_bin, **env_overrides),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.STDOUT,
+    )
+
+
+@pytest.fixture
+def reaper() -> Iterator[list[subprocess.Popen]]:
+    """Guarantees no watchdog survives a failing assertion."""
+    procs: list[subprocess.Popen] = []
+    yield procs
+    for proc in procs:
+        if proc.poll() is None:
+            proc.kill()
+            proc.wait(timeout=10)
+
+
+def log_of(batch: Path) -> str:
+    logf = batch / "watchdog.log"
+    return logf.read_text(encoding="utf-8") if logf.exists() else ""
+
+
+def wait_for(predicate, timeout: float = 20.0, poll: float = 0.2) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(poll)
+    return False
+
+
+# ---------------------------------------------------------------------------
+# The guards must remain FINDABLE by marker, not merely present in spirit.
+#
+# The manager's drift check (BATCH_DIR/check_skill_guards.sh) greps the
+# INSTALLED tree for named strings and reports which fix is missing. A renamed
+# marker makes that check go quietly blind -- the 2nz failure mode.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("script", "marker"),
+    [
+        (WATCHDOG, "CAP RE-ARM GUARD"),
+        (WATCHDOG, "SUPERVISION HEARTBEAT"),
+        (STATUS, "SUPERVISION HEARTBEAT"),
+    ],
+)
+def test_guard_markers_are_greppable(script: Path, marker: str) -> None:
+    text = script.read_text(encoding="utf-8")
+    assert marker in text, f"drift-check marker '{marker}' (model_performance-6c3y) missing from {script.name}"
+
+
+# ---------------------------------------------------------------------------
+# BRANCH 1 -- batch still open: supervision continues past the cap.
+# ---------------------------------------------------------------------------
+
+
+def test_cap_rearms_while_batch_is_open(tmp_path: Path, stub_bin: Path, reaper: list) -> None:
+    """The fix. At the cap, with the batch open, the process re-execs itself.
+
+    Asserted on the log's own generation counter: >= 2 `watchdog start` lines
+    from ONE spawned process is only possible through the re-exec path.
+    """
+    batch = tmp_path
+    (batch / "lanes").mkdir()
+    (batch / ".manager-heartbeat").touch()
+    write_manifest(batch, "aaa")
+
+    proc = spawn_watchdog(batch, stub_bin, HIGHWAY_MAX_SECONDS="0")
+    reaper.append(proc)
+
+    assert wait_for(lambda: "generation=3" in log_of(batch)), (
+        f"watchdog did not re-arm past its cap; log was:\n{log_of(batch)}"
+    )
+    assert proc.poll() is None, "watchdog exited at the cap despite the batch being open"
+
+    log = log_of(batch)
+    assert "CAP RE-ARM:" in log
+    assert "lanes dir present, manager heartbeat" in log
+    # A re-arm needs NOTHING from the manager: no wake, no wake-needed entry.
+    assert not (batch / "wake-needed").exists(), "re-arm cost the manager an interrupt"
+    assert calls(tmp_path) == [], f"re-arm woke the session: {calls(tmp_path)}"
+
+
+def test_cap_rearms_even_when_the_exec_bit_is_stripped(tmp_path: Path, stub_bin: Path, reaper: list) -> None:
+    """`exec "$0"` is not the only path; a non-executable copy still re-arms.
+
+    A packaging step that drops the exec bit would otherwise turn the re-arm
+    into a silent exit -- the exact class of failure this item closes.
+    """
+    batch = tmp_path
+    (batch / "lanes").mkdir()
+    (batch / ".manager-heartbeat").touch()
+    write_manifest(batch, "aaa")
+    copy = tmp_path / "no-exec-watchdog.sh"
+    shutil.copyfile(WATCHDOG, copy)
+    copy.chmod(0o644)
+
+    proc = spawn_watchdog(batch, stub_bin, argv0=copy, HIGHWAY_MAX_SECONDS="0")
+    reaper.append(proc)
+
+    assert wait_for(lambda: "generation=2" in log_of(batch)), (
+        f"non-executable watchdog did not re-arm; log was:\n{log_of(batch)}"
+    )
+    assert "retrying through" in log_of(batch)
+    assert proc.poll() is None
+
+
+def test_watchdog_heartbeat_is_refreshed_every_poll(tmp_path: Path, stub_bin: Path, reaper: list) -> None:
+    """Proof-of-life the MANAGER can read: .watchdog-heartbeat, touched per poll."""
+    batch = tmp_path
+    (batch / "lanes").mkdir()
+    (batch / ".manager-heartbeat").touch()
+    write_manifest(batch, "aaa")
+    hb = batch / ".watchdog-heartbeat"
+
+    proc = spawn_watchdog(batch, stub_bin, HIGHWAY_MAX_SECONDS="3600")
+    reaper.append(proc)
+
+    assert wait_for(hb.exists), "watchdog never wrote .watchdog-heartbeat"
+    first = hb.stat().st_mtime
+    assert wait_for(lambda: hb.stat().st_mtime > first), "heartbeat written once at start but never refreshed"
+
+
+# ---------------------------------------------------------------------------
+# BRANCH 2 -- batch NOT open: the cap still winds the watchdog down.
+#
+# This is the trade the cap was added to make. Removing the cap would have been
+# a far smaller change than re-arming; it would also have reversed the trade.
+# ---------------------------------------------------------------------------
+
+
+def test_cap_winds_down_when_the_batch_is_gone(tmp_path: Path, stub_bin: Path, reaper: list) -> None:
+    batch = tmp_path  # deliberately no lanes/ directory
+    (batch / ".manager-heartbeat").touch()
+    write_manifest(batch, "aaa")
+
+    proc = spawn_watchdog(batch, stub_bin, HIGHWAY_MAX_SECONDS="0")
+    reaper.append(proc)
+
+    assert proc.wait(timeout=30) == 0, "abandoned batch: watchdog did not wind down at its cap"
+    log = log_of(batch)
+    assert "exit: deadline reached, batch not open (no lanes dir" in log, log
+    assert "CAP RE-ARM:" not in log, "re-armed on an abandoned batch -- the orphan the cap exists to prevent"
+
+
+def test_cap_winds_down_when_the_manager_has_gone_home(tmp_path: Path, stub_bin: Path, reaper: list) -> None:
+    """Lanes dir present, but the manager has not checked in for hours."""
+    batch = tmp_path
+    (batch / "lanes").mkdir()
+    hb = batch / ".manager-heartbeat"
+    hb.touch()
+    ancient = time.time() - 100_000
+    os.utime(hb, (ancient, ancient))
+    write_manifest(batch, "aaa")
+
+    proc = spawn_watchdog(batch, stub_bin, HIGHWAY_MAX_SECONDS="0")
+    reaper.append(proc)
+
+    assert proc.wait(timeout=30) == 0, "ancient heartbeat: watchdog did not wind down at its cap"
+    assert "manager heartbeat ancient" in log_of(batch)
+
+
+def test_abandon_window_is_configurable_and_reopens_the_rearm(
+    tmp_path: Path, stub_bin: Path, reaper: list
+) -> None:
+    """The same ancient heartbeat re-arms once HIGHWAY_ABANDON_MAX allows it.
+
+    Pins the documented escape hatch: the wind-down above is the window's doing,
+    not an unrelated refusal.
+    """
+    batch = tmp_path
+    (batch / "lanes").mkdir()
+    hb = batch / ".manager-heartbeat"
+    hb.touch()
+    ancient = time.time() - 100_000
+    os.utime(hb, (ancient, ancient))
+    write_manifest(batch, "aaa")
+
+    proc = spawn_watchdog(batch, stub_bin, HIGHWAY_MAX_SECONDS="0", HIGHWAY_ABANDON_MAX="200000")
+    reaper.append(proc)
+
+    assert wait_for(lambda: "CAP RE-ARM:" in log_of(batch)), (
+        f"widened abandon window did not restore the re-arm; log was:\n{log_of(batch)}"
+    )
+    assert proc.poll() is None
+
+
+# ---------------------------------------------------------------------------
+# BRANCH 2, continued -- the death notice must actually reach someone.
+# ---------------------------------------------------------------------------
+
+
+def test_final_notice_is_dispatched_and_names_the_suicide_trap(
+    tmp_path: Path, stub_bin: Path, reaper: list
+) -> None:
+    """On wind-down: durable file AND a resume, dispatched detached.
+
+    The prompt has to warn the responder off `tmux kill-session`, because the
+    responder is reading it from a session that a naive restart would kill --
+    that is exactly how the measured ~34h outage happened.
+    """
+    batch = tmp_path
+    (batch / ".manager-heartbeat").touch()
+    write_manifest(batch, "aaa")
+
+    proc = spawn_watchdog(batch, stub_bin, HIGHWAY_MAX_SECONDS="0")
+    reaper.append(proc)
+
+    assert proc.wait(timeout=30) == 0
+    assert "final notice dispatched detached" in log_of(batch)
+
+    wake_needed = batch / "wake-needed"
+    assert wake_needed.exists(), "no durable wake-needed entry on wind-down"
+    assert "watchdog max runtime" in wake_needed.read_text(encoding="utf-8")
+
+    assert wait_for(lambda: len(calls(tmp_path)) >= 1), "final notice never reached `amplifier run --resume`"
+    notice = calls(tmp_path)[-1]
+    assert "run --resume sess-6c3y" in notice
+    assert "tmux kill-session" in notice and "do NOT run" in notice
+    assert "start a fresh watchdog" in notice
+
+
+def test_final_notice_is_not_eaten_by_the_wake_gap(tmp_path: Path, stub_bin: Path, reaper: list) -> None:
+    """A wake inside WAKE_GAP is suppressed; the death notice never is.
+
+    Ordinary wake suppression is what makes the gap useful, and it is also what
+    would silently discard the one message with no next poll behind it.
+    """
+    batch = tmp_path  # abandoned: no lanes/ dir
+    hb = batch / ".manager-heartbeat"
+    hb.touch()
+    # Older than ACTIVE_WINDOW so wakes are not deferred, younger than HB_MAX so
+    # the only pre-cap trigger is the ENDED lane below.
+    stale = time.time() - 300
+    os.utime(hb, (stale, stale))
+    write_manifest(batch, "aaa")
+
+    proc = spawn_watchdog(
+        batch,
+        stub_bin,
+        HIGHWAY_MAX_SECONDS="4",
+        HIGHWAY_WAKE_GAP="99999",
+    )
+    reaper.append(proc)
+
+    assert proc.wait(timeout=40) == 0
+    log = log_of(batch)
+    assert "WAKE: lane(s) ended" in log, log
+    assert "suppress wake (within 99999s gap)" in log, "the gap was never actually in force"
+
+    entries = [ln for ln in (batch / "wake-needed").read_text(encoding="utf-8").splitlines() if ln.strip()]
+    assert len(entries) == 2, f"expected the lane-end wake AND the forced death notice, got: {entries}"
+    assert "watchdog max runtime" in entries[-1]
+    assert any("do NOT run" in c for c in calls(tmp_path)), "death notice suppressed by the wake gap"
+
+
+# ---------------------------------------------------------------------------
+# The manager-facing half: a lapse is reported with a DURATION.
+# ---------------------------------------------------------------------------
+
+
+def status_json(batch: Path, stub_bin: Path) -> dict:
+    proc = subprocess.run(
+        ["bash", str(STATUS), str(batch), "3", "0"],
+        env=watchdog_env(stub_bin, HIGHWAY_JSON="1"),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+def test_status_reports_how_long_supervision_has_been_down(tmp_path: Path, stub_bin: Path) -> None:
+    batch = tmp_path
+    write_manifest(batch, "aaa")
+    hb = batch / ".watchdog-heartbeat"
+    hb.touch()
+    lapsed = time.time() - 4000
+    os.utime(hb, (lapsed, lapsed))
+
+    payload = status_json(batch, stub_bin)
+    assert payload["watchdog"] == "DEAD"
+    assert payload["watchdog_hb_age"] >= 3990, payload
+
+    text = subprocess.run(
+        ["bash", str(STATUS), str(batch), "3", "0"],
+        env=watchdog_env(stub_bin),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    ).stdout
+    assert "SUPERVISION LAPSED" in text
+    assert "watchdog_hb_age=" in text
+
+
+def test_status_says_unknown_rather_than_zero_without_a_heartbeat(tmp_path: Path, stub_bin: Path) -> None:
+    """No heartbeat file must never read as "lapsed 0s ago" (i.e. healthy)."""
+    batch = tmp_path
+    write_manifest(batch, "aaa")
+
+    payload = status_json(batch, stub_bin)
+    assert payload["watchdog_hb_age"] == -1, payload
+
+    text = subprocess.run(
+        ["bash", str(STATUS), str(batch), "3", "0"],
+        env=watchdog_env(stub_bin),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    ).stdout
+    assert "lapse duration unknown" in text


### PR DESCRIPTION
## The bug

The supervisor that catches stalled lanes could stop itself, and nothing caught **that**. Measured in the batch that filed it (`model_performance-6c3y`): the watchdog hit its 12h `MAX_HOURS` cap at `2026-09-03T14:14:05Z` and the highway sat idle **~34 hours** with four lanes ENDED and unverified.

## The mechanism was worse than the ticket said

The item assumed the final message never reached anyone. `watchdog.log` says otherwise — and says something more useful:

```
line     1:  2026-09-02T14:04:27Z watchdog start ... max=12h    (generation 1)
line 33456:  2026-09-03T02:10:29Z watchdog start ... max=12h    (generation 2)
line 50060:  2026-09-03T14:14:05Z WAKE: watchdog max runtime (12h) reached - restart me...
line 50274:  2026-09-06T00:26:06Z watchdog start ...            (~34h later)
```

Between those last two lines there is **neither `wake delivered (resume ok)` nor `exit: deadline reached`** — the watchdog never exited at its cap; it was killed. The wake **was** delivered (the resumed manager's own reasoning is in the log: *"restart the watchdog before doing anything else"*), and the manager then ran `tmux kill-session -t hw-watchdog__<batch>` **while running inside that session**, as a child of `wake()`'s synchronous `amplifier run --resume`. It killed itself mid-restart, before the line that starts the replacement.

So: delivery was never the gap. *Where the responder was standing* was the gap — and a restart that depends on someone answering a message is one participant away from failing.

## The change

`highway_watchdog.sh`
- **`CAP RE-ARM GUARD`** — at the cap, `exec "$0" "$@"` (generation counter bumped) **while the batch is open**: `BATCH_DIR/lanes/` exists AND `.manager-heartbeat` is younger than `HIGHWAY_ABANDON_MAX` (default 6h). Costs the manager nothing — no wake, no `wake-needed` entry.
- **The cap's purpose is preserved, not traded away.** Abandoned batch → still winds down. `MAX_HOURS` is neither removed nor raised. Residual bound, stated in the docs: an orphan can outlive its batch by at most one cap period, never indefinitely.
- **`shopt -s execfail`** — a failed `exec` kills a non-interactive bash outright, silently converting the re-arm back into the stop this fixes. It now falls back to `exec "${BASH:-bash}" "$0" "$@"`. *Found by the test, not by reading the manual.*
- **`final_notice()`** on wind-down: writes `wake-needed` unconditionally (never eaten by `WAKE_GAP` — the one message with no next poll behind it), then dispatches `amplifier run --resume` **detached** (`setsid`, `nohup` fallback) and exits. The prompt names the trap: *"The old watchdog has ALREADY exited: do NOT run `tmux kill-session …` first."*
- **`SUPERVISION HEARTBEAT`** — `.watchdog-heartbeat` touched every poll.

`highway_status.sh` — reports `watchdog_hb_age` (JSON, additive) and `SUPERVISION LAPSED <n>s ago` when DEAD, so a lapse from **any** cause (cap, crash, kill) is read off an instrument the manager already runs first on every wake, rather than inferred from a wake that never came.

`SKILL.md` — both branches, both env knobs, the new state file, and the do-NOT-`kill-session` rule placed in Phase 6 step 1 where a manager actually hits it. Docs ship in the same change (the `2nz` lesson), plus a proposed drift-check patch under the lane artifact root covering the **docs half** too.

## Is a manager-side inverse check still needed? No.

Rejected as a *distinct* mechanism: `highway_status.sh` is already the manager's mandatory first action on every wake and already printed `watchdog=DEAD`; a second check adds a thing to remember and no new signal. And it would not have caught this outage — the manager was idle *because* no wake arrived, so anything that runs "next cycle" is dead code when there is no next cycle. The cheap half is kept (`.watchdog-heartbeat` + `watchdog_hb_age`), which is what makes "supervision lapsed, and for how long" a measurement instead of an inference.

## Tests — 13 new, subprocess, real outcomes

`tests/test_ten_lane_highway_watchdog.py`, matching the standard `2nz` set (run the real script; prove "nothing ran" with an observable sentinel — here a PATH-stubbed `amplifier` that records argv):

- re-arms while open (asserts `generation=3` from **one** spawned process), and re-arms with the **exec bit stripped**
- winds down with no lanes dir; winds down on an ancient heartbeat; re-arms again when `HIGHWAY_ABANDON_MAX` is widened (proves the wind-down is the window's doing, not an unrelated refusal)
- death notice dispatched detached, names the `kill-session` trap, and **survives a 99999s `WAKE_GAP`** while an ordinary wake in the same run is provably suppressed
- `.watchdog-heartbeat` refreshed per poll; status reports the lapse duration, and reports `-1`/"unknown" rather than "0s ago" when there is no heartbeat at all
- drift-check markers stay greppable (`CAP RE-ARM GUARD`, `SUPERVISION HEARTBEAT`)

Tests never touch the default `hw` tmux socket or a live batch.

## Full suite

```
$ uv run pytest -q
1740 passed, 1 skipped, 13 deselected, 1 xfailed in 27.16s
```

Baseline re-measured in a clean worktree at `395fa68`: **1727 passed**, 1 skipped, 13 deselected, 1 xfailed. Delta **+13** — exactly the new tests, zero regressions. (The goal file quotes 1682 for that commit; that figure appears stale, so the re-measured baseline is what the delta is taken against.)

## Spend

**$0.00** against a $0.00 authority (`0 runs x 0 arms x $0 / 1.00 = $0.00`). Pure shell/source change; no API calls, no DTUs, no infrastructure ledgered.

Lane note: `docs/lanes/6c3y-watchdog-selfrestart/DONE-NOTE.md`
