### PR TITLE
fix(update): collapse an app subdirectory bundle into the root it shares a repo with

### DIFF
--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -44,6 +44,21 @@ def _normalize_git_url(url: str) -> str:
     return url.rstrip("/")
 
 
+def _strip_uri_fragment(uri: str) -> str:
+    """Drop a URI's #fragment, keeping the ref intact.
+
+    Examples:
+        git+https://github.com/org/bundle@main#subdirectory=behaviors/x.yaml
+        -> git+https://github.com/org/bundle@main
+
+    Deliberately not _normalize_git_url(): that also strips ``@ref``, which
+    would collapse ``@main`` and ``@v2`` into a single update target. The
+    subdirectory fragment is the only part redundant with the repo's root
+    bundle - the ref is not.
+    """
+    return uri.split("#", 1)[0]
+
+
 def _extract_module_name_from_uri(source_uri: str) -> str:
     """Extract a clean module name from a source URI.
 
@@ -388,11 +403,25 @@ async def _check_all_bundle_status() -> dict[str, "BundleStatus"]:
         except Exception:
             continue  # Skip bundles that fail status check
 
-    # App bundles are configured source URIs rather than registry aliases.  Use
-    # the exact URI as the result key so refs and subdirectory fragments remain
-    # separate update targets.
+    # App bundles are configured source URIs rather than registry aliases, so
+    # the exact URI stays the result key: different refs are genuinely
+    # different update targets.
+    #
+    # Dedupe against the ROOT bundles checked above on the fragment-stripped
+    # URI, though. An app bundle added as
+    # `<repo>@main#subdirectory=behaviors/x.yaml` is the same repo at the same
+    # ref as the `<repo>@main` root bundle already checked, so one status check
+    # covers both and a second row is noise. That is the rule
+    # AppBundleDiscovery.list_cached_root_bundles() already applies to registry
+    # sub-bundles; app bundles arrive here without having passed through it,
+    # and an exact-string comparison can never match a fragment against a root
+    # that has none.
+    #
+    # Scoped to the root URIs deliberately: two app entries that share a repo
+    # are both things the user asked for by name, and stay independent.
+    root_bases = {_strip_uri_fragment(uri) for uri in checked_uris}
     for uri in AppSettings().get_app_bundles():
-        if uri in checked_uris:
+        if uri in checked_uris or _strip_uri_fragment(uri) in root_bases:
             continue
         checked_uris.add(uri)
         try:

--- a/tests/test_bundle_commands.py
+++ b/tests/test_bundle_commands.py
@@ -324,3 +324,86 @@ def test_global_update_loads_an_app_target_by_source_uri(monkeypatch):
     assert result.exit_code == 0, result.output
     assert loaded_uris == [_FRAGMENT_URI]
     assert len(updated_bundles) == 1
+
+
+@pytest.mark.asyncio
+async def test_global_update_collapses_an_app_subdirectory_into_its_root_bundle(
+    monkeypatch,
+):
+    """A behavior YAML added as an app bundle is not a second row for its repo.
+
+    `amplifier bundle add --app <repo>@main#subdirectory=behaviors/x.yaml`
+    records the fragment URI in settings. When the same repo is already a
+    tracked root bundle, the two are the same repo at the same ref and one
+    status check covers both -- the rule list_cached_root_bundles() applies to
+    registry sub-bundles. Comparing the exact strings can never match, so
+    without a fragment-stripped comparison every such app bundle rendered a
+    duplicate row alongside its root.
+    """
+    from amplifier_foundation.sources.git import GitSourceHandler
+
+    registry = MagicMock()
+    registry.find.return_value = _URI
+    monkeypatch.setattr(
+        update_module,
+        "AppBundleDiscovery",
+        lambda: SimpleNamespace(list_cached_root_bundles=lambda: ["team"]),
+    )
+    monkeypatch.setattr(update_module, "create_bundle_registry", lambda: registry)
+    monkeypatch.setattr(
+        update_module,
+        "AppSettings",
+        lambda: SimpleNamespace(get_app_bundles=lambda: [_FRAGMENT_URI]),
+    )
+
+    async def fake_get_status(self, parsed, cache_dir):
+        return SimpleNamespace(source_uri=_URI, has_update=False)
+
+    monkeypatch.setattr(GitSourceHandler, "get_status", fake_get_status)
+
+    results = await update_module._check_all_bundle_status()
+
+    assert set(results) == {"team"}, (
+        "the fragment URI must not appear as a row of its own next to the "
+        "root bundle it shares a repo and ref with"
+    )
+
+
+@pytest.mark.asyncio
+async def test_global_update_keeps_an_app_subdirectory_on_a_different_ref(monkeypatch):
+    """Only the fragment is redundant with the root - the ref is not."""
+    from amplifier_foundation.sources.git import GitSourceHandler
+
+    other_ref_uri = (
+        "git+https://github.com/example/amplifier-bundle-team@v2"
+        "#subdirectory=behaviors/team.yaml"
+    )
+    registry = MagicMock()
+    registry.find.return_value = _URI
+    monkeypatch.setattr(
+        update_module,
+        "AppBundleDiscovery",
+        lambda: SimpleNamespace(list_cached_root_bundles=lambda: ["team"]),
+    )
+    monkeypatch.setattr(update_module, "create_bundle_registry", lambda: registry)
+    monkeypatch.setattr(
+        update_module,
+        "AppSettings",
+        lambda: SimpleNamespace(get_app_bundles=lambda: [other_ref_uri]),
+    )
+
+    async def fake_get_status(self, parsed, cache_dir):
+        return SimpleNamespace(source_uri=_URI, has_update=False)
+
+    monkeypatch.setattr(GitSourceHandler, "get_status", fake_get_status)
+
+    results = await update_module._check_all_bundle_status()
+
+    assert set(results) == {"team", other_ref_uri}
+
+
+def test_strip_uri_fragment_keeps_the_ref():
+    assert (
+        update_module._strip_uri_fragment(_FRAGMENT_URI) == _URI
+    ), "only the #fragment is redundant with the root bundle"
+    assert update_module._strip_uri_fragment(_URI) == _URI


### PR DESCRIPTION
`amplifier update` started listing every app bundle twice — once under its friendly name, once as a raw `git+https://...#subdirectory=behaviors/x.yaml` URI, same commit on both rows.

## Root cause

`_check_all_bundle_status` builds its result from two loops. The first walks registry root bundles and records their URIs in `checked_uris`. The second — added in `2e2bdcf` (#302) — walks `settings.yaml` → `bundle.app`:

```python
for uri in AppSettings().get_app_bundles():
    if uri in checked_uris:      # exact string match
        continue
```

Every app bundle added via `bundle add --app` carries a `#subdirectory=` fragment. The root URIs it is compared against do not. Those forms can never be string-equal, so the check dedupes nothing:

```
settings bundle.app : git+https://github.com/bkrabach/amplifier-bundle-adhd@main#subdirectory=behaviors/always-on.yaml
registry root URI   : git+https://github.com/bkrabach/amplifier-bundle-adhd@main
string-equal?       : False
```

Measured against a real `~/.amplifier`:

```
app bundle URIs in settings          : 21   (all 21 fragmented)
EXACT match vs checked_uris (today)  :  0   ← dedupes nothing
BASE repo already checked            : 19   ← should collapse
```

`AppBundleDiscovery.list_cached_root_bundles()` already implements the right rule, and documents it:

> *Filters out: Subdirectory bundles (`#subdirectory=` in URI) whose underlying repo is already represented by another root bundle... showing the sub-bundle is just noise.*

App bundles never reach that filter — they are consumed directly in `update.py`.

## The fix

Dedupe on the fragment-stripped URI.

Deliberately **not** via the existing `_normalize_git_url()`: that also strips `@ref`, which would collapse `@main` and `@v2` into one update target. #302's comment is right that different refs are different targets — the fragment is the only redundant part.

Scoped to the root URIs from the first loop. Two app entries that share a repo are both things the user named explicitly and stay independent — which is what `test_global_update_checks_app_only_sources_by_exact_uri` asserts, and that test still passes unchanged.

An app bundle whose repo has no tracked root still gets its own row: it is the thing to update.

## Result on a real machine

```
21 app bundles -> 19 collapsed into their root, 2 kept
   git+https://github.com/bkrabach/amplifier-bundle-steward-desk@main#subdirectory=behaviors/steward-desk.yaml
   git+https://github.com/singh2/infographic-builder@main#subdirectory=behaviors/infographic.yaml

Bundles table: 55 rows -> 36
```

Both survivors are correct — neither repo has a separately tracked root bundle.

Confirmed by running the real `amplifier update` from this branch: clean table, and it still correctly flagged `converge` as having an update available.

The Modules table is unaffected: `_normalize_git_url()` maps the fragment and root forms to the same string, so the bundle-repo exclusion set does not change.

## How to verify

- `uv run pytest -q` → `1730 passed, 1 skipped, 13 deselected, 1 xfailed`
- `git diff --check`
- `python -m compileall -q amplifier_app_cli/commands/update.py tests/test_bundle_commands.py`

New coverage: an app subdirectory collapsing into its root, an app subdirectory on a *different* ref staying separate, and `_strip_uri_fragment` preserving the ref.