### PR TITLE
fix: serialize truststore's unlocked wrap_bio at CLI startup (mitigation pending upstream)

### DIFF
--- a/amplifier_app_cli/__init__.py
+++ b/amplifier_app_cli/__init__.py
@@ -2,6 +2,16 @@
 
 __version__ = "0.1.0"
 
+# TEMPORARY, remove when truststore ships the fix. This must run before any
+# TLS happens in this process, and nothing in the amplifier tree owns the
+# truststore call site (httpx2/httpcore2 construct the context), so CLI
+# package import is the earliest amplifier-owned point available. It is a
+# no-op unless the installed truststore's wrap_bio is genuinely unlocked.
+# See truststore_shim.py for the full story.
+from . import truststore_shim as _truststore_shim
+
+_truststore_shim.apply()
+
 from .main import cli
 from .main import main
 

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -3480,6 +3480,10 @@ async def interactive_chat(
         bundle_name=bundle_name,
         initial_transcript=initial_transcript,
         prepared_bundle=prepared_bundle,
+        # Resolved mode: reaching interactive_chat() IS the resolution -- run.py
+        # dispatches here only after collapsing --mode, prompt presence, and pipe
+        # presence into "chat".
+        invocation_mode="chat",
     )
 
     # Create fully initialized session (handles all setup including resume)
@@ -4146,6 +4150,10 @@ async def execute_single(
         initial_transcript=initial_transcript,
         prepared_bundle=prepared_bundle,
         output_format=output_format,
+        # Resolved mode: reaching execute_single() IS the resolution -- run.py
+        # dispatches here for an explicit --mode single, and for a prompt or a
+        # pipe arriving with no --mode at all.
+        invocation_mode="single",
     )
 
     # Create fully initialized session (handles all setup including resume)

--- a/amplifier_app_cli/session_runner.py
+++ b/amplifier_app_cli/session_runner.py
@@ -26,6 +26,7 @@ Philosophy:
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import uuid
 from collections import Counter
@@ -82,6 +83,13 @@ class SessionConfig:
 
     # Execution mode
     output_format: str = "text"  # text | json | json-trace
+
+    # Resolved execution mode ("chat" | "single"), recorded as invocation
+    # provenance on session:start.  This is the value AFTER prompt- and
+    # pipe-presence inference (commands/run.py), not the raw --mode flag: an
+    # interactive session launched without --mode would otherwise be recorded
+    # as "single".  None => recorded as "unknown", never guessed.
+    invocation_mode: str | None = None
 
     @property
     def is_resume(self) -> bool:
@@ -360,6 +368,93 @@ def _inject_observability_events(prepared_bundle: "PreparedBundle") -> None:
     inject_additional_events(prepared_bundle.mount_plan, _CLEANUP_EVENTS)
 
 
+# Names the session that launched this OS process, when the launcher is a
+# *different* process (an agent shelling out `amplifier run`, or foundation's
+# subprocess spawn).  In-process lineage is already carried end-to-end by
+# ``parent_id``; this covers only the cross-process case ``parent_id`` cannot
+# see.  The ``AMPLIFIER_`` prefix is on foundation's subprocess env allowlist,
+# so it propagates to children for free.  Unset => null, never a fabricated id.
+LAUNCHER_SESSION_ID_ENV = "AMPLIFIER_LAUNCHED_BY_SESSION_ID"
+
+# Bump only on a breaking change to the meaning of the fields below.
+INVOCATION_SCHEMA = 1
+
+
+def _fd_isatty(fd: int) -> bool:
+    """``os.isatty`` that cannot take a session down.
+
+    fd-level rather than ``sys.stdin.isatty()`` -- see dedicated_tty_input.py,
+    which already reasoned about this distinction: the fd is the thing that
+    actually matters, since sys.stdin can be swapped in-process.  A closed or
+    invalid fd (daemonised harness) reads as "not a tty", which is the truth.
+    """
+    try:
+        return os.isatty(fd)
+    except (OSError, ValueError):
+        return False
+
+
+def _build_invocation_metadata(mode: str | None) -> dict[str, Any]:
+    """Describe HOW this session was invoked, for provenance consumers.
+
+    Deliberately NOT recorded: argv / the full command line.  Prompt text,
+    ``--api-key ...``, and ``"$(cat token)"`` all land in argv, while
+    events.jsonl is a long-lived, greppable, exported artifact.  Raw config was
+    already moved *off* ``session:start`` onto the separate, redacted
+    ``session:config`` event -- adding an unredactable free-text field here
+    would reverse that.  The fields below answer the provenance question
+    without opening that hole.
+
+    This is a self-report, not a security control.  A harness that fills these
+    in dishonestly will be believed, exactly as one that declines to pass
+    ``parent_id`` is believed.  It defends against the overwhelmingly common
+    case -- a harness that never thought about provenance at all.
+
+    Args:
+        mode: The *resolved* execution mode ("chat" / "single"), i.e. the value
+            after prompt- and pipe-presence inference, not the raw ``--mode``
+            flag.  ``None`` when a caller did not state one -- recorded as
+            "unknown" rather than guessed, since a wrong mode is worse than an
+            absent one.
+    """
+    return {
+        "schema": INVOCATION_SCHEMA,
+        "mode": mode or "unknown",
+        "stdin_isatty": _fd_isatty(0),
+        "stdout_isatty": _fd_isatty(1),
+        "launched_by": "cli",
+        "launched_by_session_id": os.environ.get(LAUNCHER_SESSION_ID_ENV) or None,
+    }
+
+
+def _inject_invocation_metadata(
+    prepared_bundle: "PreparedBundle", *, mode: str | None
+) -> None:
+    """Record invocation provenance on the root session's mount plan.
+
+    Rides the kernel's existing ``session.metadata`` passthrough channel
+    (amplifier-core ``docs/specs/CONTRIBUTION_CHANNELS.md``), so this surfaces
+    at ``session:start`` as ``metadata.invocation`` and lands in events.jsonl
+    at ``data.metadata.invocation``.  No new event, no schema change, and no
+    change required in hooks-logging (``metadata`` is not a promoted key, so it
+    nests under ``data`` automatically).
+
+    Merges under the ``invocation`` key only: any other metadata a bundle or
+    caller already placed on the mount plan is left exactly as it was.
+
+    Args:
+        prepared_bundle: The PreparedBundle whose mount_plan will be updated
+            in-place.  Same ordering constraint as
+            ``_inject_observability_events``: must run after
+            inject_user_providers() (step 4b) and before create_session()
+            (step 4c), which is when the kernel reads session.metadata.
+        mode: Resolved execution mode -- see ``_build_invocation_metadata``.
+    """
+    session_section = prepared_bundle.mount_plan.setdefault("session", {})
+    metadata = session_section.setdefault("metadata", {})
+    metadata["invocation"] = _build_invocation_metadata(mode)
+
+
 async def _create_bundle_session(
     config: SessionConfig,
     session_id: str,
@@ -399,6 +494,12 @@ async def _create_bundle_session(
     # This MUST run before create_session() (which calls mount() internally) so the
     # config dict is populated when each hook module is mounted.
     _inject_observability_events(prepared_bundle)
+
+    # Step 4b-post: Record how this session was invoked, on the same mount plan
+    # and under the same ordering constraint. The kernel reads session.metadata
+    # when it builds the session:start payload, so this must land before
+    # create_session() below.
+    _inject_invocation_metadata(prepared_bundle, mode=config.invocation_mode)
 
     # Step 4c: Create session (foundation handles init internally)
     # Self-healing: The kernel intentionally swallows module load errors to be resilient.

--- a/amplifier_app_cli/truststore_shim.py
+++ b/amplifier_app_cli/truststore_shim.py
@@ -1,0 +1,227 @@
+"""TEMPORARY mitigation: serialize ``truststore.SSLContext.wrap_bio``.
+
+**Delete this module when `truststore` ships the lock upstream.** Everything
+here exists only because a third-party package we do not own has a data race
+that kills this process with no Python-level error surface.
+
+The defect
+----------
+``truststore`` re-applies the OS trust store to its wrapped ``ssl.SSLContext``
+on every wrap, via ``_configure_context()``, which calls
+``ctx.set_default_verify_paths()``. That writes to the context's
+``X509_STORE`` and is not safe to call concurrently on one context.
+
+``truststore/_api.py`` knows this. ``wrap_socket`` holds ``self._ctx_lock``
+across the ``_configure_context().__enter__()``::
+
+    with contextlib.ExitStack() as stack:
+        with self._ctx_lock:
+            stack.enter_context(_configure_context(self._ctx))
+
+``wrap_bio``, 25 lines later, does not::
+
+    with _configure_context(self._ctx):
+        ssl_obj = self._ctx.wrap_bio(...)
+
+``self._ctx_lock`` exists and is simply not used on that path. Verified
+against ``truststore`` 0.10.4 (the current latest release) and against
+``sethmlarson/truststore@main`` on 2026-09-05: both still unlocked.
+
+Why it reaches us
+-----------------
+``wrap_bio`` is the path every async HTTP client in this stack takes --
+anyio -> httpcore2 -> httpx2 -> the Anthropic SDK -- and ``anyio`` hands it to
+a worker thread (``anyio/streams/tls.py``: "External SSLContext
+implementations may do blocking I/O in wrap_bio()"). The CLI resolves the
+model role of every agent in the composed bundle concurrently on every session
+mount, so tens of those worker threads enter the unlocked
+``set_default_verify_paths()`` on one shared context at the same instant and
+glibc aborts::
+
+    double free or corruption (!prev)
+    Fatal Python error: Aborted
+
+Exit 134, sometimes 139. No traceback, no result envelope, no partial output.
+Every abort captured had 20-37 threads inside
+``truststore/_openssl.py:38 _configure_context``, **100% via ``wrap_bio``,
+0% via ``wrap_socket``**.
+
+Nothing in the amplifier tree constructs a ``truststore.SSLContext``. It is
+pulled in by ``httpx2/_config.py:40`` and ``httpcore2/_ssl.py:12`` (pydantic's
+httpx fork, which declares ``truststore>=0.10``). So there is no amplifier-owned
+call site to fix -- the earliest amplifier-owned point that runs before any TLS
+is CLI startup, which is where this shim is applied from.
+
+What this does
+--------------
+Wraps ``truststore.SSLContext.wrap_bio`` so it runs while holding the very
+lock ``wrap_socket`` already takes, mirroring the upstream one-line fix from
+the consumer side by monkeypatch.
+
+One honest difference from the upstream diff: upstream holds the lock only
+across ``_configure_context().__enter__()``, then releases it for the wrap
+itself. From outside the function we cannot interleave like that, so this
+holds the lock for the whole call. That is strictly stronger and costs
+nothing here: ``SSLContext.wrap_bio`` only builds an ``SSLObject`` over two
+memory BIOs -- there is no socket and no I/O in it; the handshake happens
+later in ``do_handshake``.
+
+Safety
+------
+``_ctx_lock`` is a plain ``threading.Lock``, so taking it around a
+``wrap_bio`` that *also* took it would deadlock. This shim therefore refuses
+to patch unless it can read the installed ``wrap_bio`` source and confirm it
+does **not** reference ``_ctx_lock``. Unreadable source means no patch. Every
+skip path is a no-op, and any unexpected failure is swallowed and logged --
+a mitigation must never be the reason the CLI cannot start.
+
+Removal
+-------
+When a ``truststore`` release carries the lock, set
+:data:`FIRST_FIXED_VERSION` and this becomes a no-op on that version; the
+whole module (and its call in ``amplifier_app_cli/__init__.py``) can then be
+deleted.
+
+Escape hatch: ``AMPLIFIER_TRUSTSTORE_WRAP_BIO_SHIM=0`` disables it.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+import logging
+import os
+import threading
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# First `truststore` release known to take `self._ctx_lock` inside `wrap_bio`.
+# None means "no fixed release exists yet" -- as of 2026-09-05 the latest
+# release (0.10.4) and `main` are both still unlocked. Set this when one ships;
+# the shim then stands down on its own for anyone on that version or newer.
+FIRST_FIXED_VERSION: str | None = None
+
+# Env var that turns the shim off entirely.
+DISABLE_ENV_VAR = "AMPLIFIER_TRUSTSTORE_WRAP_BIO_SHIM"
+
+_FALSEY = {"0", "false", "no", "off"}
+
+# Stamped on the replacement function so a second apply() is a no-op.
+_MARKER = "_amplifier_wrap_bio_lock_shim"
+
+# Outcome of the most recent apply(). Read this rather than the log: apply()
+# runs at import time, before the CLI configures logging, so the log line
+# itself lands nowhere useful on a default run.
+SHIM_STATUS: str = "not applied"
+
+_apply_lock = threading.Lock()
+
+
+def _installed_truststore_version() -> str | None:
+    """Version of the installed `truststore` distribution, or None."""
+    try:
+        from importlib.metadata import version
+
+        return version("truststore")
+    except Exception:  # pragma: no cover - metadata missing/broken
+        return None
+
+
+def _wrap_bio_takes_lock(func: Any) -> bool | None:
+    """Does this `wrap_bio` already take `_ctx_lock`?
+
+    Returns None when the source cannot be read, which is treated as "do not
+    patch" -- guessing wrong in that direction is a deadlock.
+    """
+    try:
+        source = inspect.getsource(func)
+    except (OSError, TypeError):  # pragma: no cover - frozen/zipped installs
+        return None
+    return "_ctx_lock" in source
+
+
+def _make_locked_wrap_bio(original: Any) -> Any:
+    """Return a `wrap_bio` that holds `self._ctx_lock` across the original."""
+
+    @functools.wraps(original)
+    def wrap_bio(self: Any, *args: Any, **kwargs: Any) -> Any:
+        # anyio calls this positionally via to_thread.run_sync(), httpcore by
+        # keyword -- *args/**kwargs passes both through untouched.
+        lock = getattr(self, "_ctx_lock", None)
+        if lock is None:
+            return original(self, *args, **kwargs)
+        with lock:
+            return original(self, *args, **kwargs)
+
+    setattr(wrap_bio, _MARKER, True)
+    return wrap_bio
+
+
+def apply_to(ssl_context_cls: type, installed_version: str | None = None) -> str:
+    """Apply the lock shim to one `truststore.SSLContext`-shaped class.
+
+    Split out from :func:`apply` so it can be exercised against a fake class
+    without importing or mutating the real `truststore`.
+
+    Returns a short status string; only a status starting with "applied" means
+    the class was changed.
+    """
+    original = ssl_context_cls.__dict__.get("wrap_bio")
+    if original is None:
+        return f"skipped: {ssl_context_cls.__name__} has no own wrap_bio"
+
+    if getattr(original, _MARKER, False):
+        return "skipped: already applied"
+
+    if installed_version and FIRST_FIXED_VERSION:
+        try:
+            from packaging.version import Version
+
+            if Version(installed_version) >= Version(FIRST_FIXED_VERSION):
+                return (
+                    f"skipped: truststore {installed_version} >= "
+                    f"{FIRST_FIXED_VERSION}, fixed upstream"
+                )
+        except Exception:  # pragma: no cover - unparseable version
+            pass
+
+    takes_lock = _wrap_bio_takes_lock(original)
+    if takes_lock is None:
+        return "skipped: could not read wrap_bio source, refusing to patch blind"
+    if takes_lock:
+        return "skipped: wrap_bio already takes _ctx_lock"
+
+    setattr(ssl_context_cls, "wrap_bio", _make_locked_wrap_bio(original))
+    return f"applied to truststore {installed_version or 'unknown'}"
+
+
+def apply() -> str:
+    """Install the shim on the real `truststore.SSLContext`, if warranted.
+
+    Safe to call more than once and safe to call when `truststore` is not
+    installed. Never raises.
+    """
+    global SHIM_STATUS
+    try:
+        with _apply_lock:
+            status = _apply()
+    except Exception as exc:  # pragma: no cover - defensive
+        status = f"skipped: shim raised {exc!r}"
+    SHIM_STATUS = status
+    logger.debug("truststore wrap_bio lock shim: %s", status)
+    return status
+
+
+def _apply() -> str:
+    if os.environ.get(DISABLE_ENV_VAR, "").strip().lower() in _FALSEY:
+        return f"skipped: disabled by {DISABLE_ENV_VAR}"
+
+    try:
+        import truststore
+    except Exception:
+        # No truststore, no race. httpx2/httpcore2 declare it, but nothing here
+        # requires it to be present.
+        return "skipped: truststore is not importable"
+
+    return apply_to(truststore.SSLContext, _installed_truststore_version())

--- a/tests/test_invocation_metadata.py
+++ b/tests/test_invocation_metadata.py
@@ -1,0 +1,334 @@
+"""Tests for invocation-provenance metadata on the root session's mount plan.
+
+app-cli records HOW a session was invoked (resolved mode, tty-ness of stdin and
+stdout, launching component, cross-process launcher session id) under
+``mount_plan["session"]["metadata"]["invocation"]``.  The kernel's CP-SM
+passthrough channel carries it to ``session:start``, where it persists as
+``data.metadata.invocation`` in events.jsonl.
+
+What these tests pin down:
+  * the exact field set -- notably that argv is NOT among it
+  * the *resolved* mode, per entry point (chat vs single)
+  * both tty flags, mocked both ways
+  * pre-existing metadata is never clobbered
+  * an unset launcher env var yields null, never a fabricated id
+  * the mount plan is mutated BEFORE create_session() reads it
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from amplifier_app_cli.session_runner import (
+    INVOCATION_SCHEMA,
+    LAUNCHER_SESSION_ID_ENV,
+    SessionConfig,
+    _build_invocation_metadata,
+    _inject_invocation_metadata,
+)
+
+_MODULE = "amplifier_app_cli.session_runner"
+_MAIN = "amplifier_app_cli.main"
+
+EXPECTED_FIELDS = {
+    "schema",
+    "mode",
+    "stdin_isatty",
+    "stdout_isatty",
+    "launched_by",
+    "launched_by_session_id",
+}
+
+
+def _prepared_bundle(mount_plan=None):
+    """A PreparedBundle stand-in carrying a real (mutable) mount plan dict."""
+    bundle = MagicMock()
+    bundle.mount_plan = mount_plan if mount_plan is not None else {}
+    return bundle
+
+
+def _invocation(bundle) -> dict:
+    return bundle.mount_plan["session"]["metadata"]["invocation"]
+
+
+# ---------------------------------------------------------------------------
+# Field set and shape
+# ---------------------------------------------------------------------------
+
+
+class TestInvocationShape:
+    def test_field_set_is_exactly_the_designed_one(self, monkeypatch):
+        monkeypatch.delenv(LAUNCHER_SESSION_ID_ENV, raising=False)
+        assert set(_build_invocation_metadata("single")) == EXPECTED_FIELDS
+
+    def test_no_argv_or_command_line_is_recorded(self, monkeypatch):
+        """argv is a live secrets surface -- it must never reach events.jsonl.
+
+        `amplifier run "$(cat prod-token.txt)"` and `--api-key ...` both land in
+        argv, and events.jsonl is long-lived, greppable, and exported.  This
+        test exists so a future 'just add argv, it's useful' change has to
+        delete an explicit assertion rather than quietly widen the record.
+        """
+        invocation = _build_invocation_metadata("single")
+        forbidden = ("argv", "cmd", "command", "args", "prompt", "env")
+        for key in invocation:
+            assert not any(bad in key.lower() for bad in forbidden), (
+                f"Field {key!r} looks like a raw command-line/environment dump. "
+                f"Invocation provenance is deliberately limited to "
+                f"{sorted(EXPECTED_FIELDS)}."
+            )
+
+    def test_schema_is_versioned(self, monkeypatch):
+        monkeypatch.delenv(LAUNCHER_SESSION_ID_ENV, raising=False)
+        assert _build_invocation_metadata("single")["schema"] == INVOCATION_SCHEMA
+        assert isinstance(INVOCATION_SCHEMA, int)
+
+    def test_launched_by_is_cli_from_this_construction_site(self):
+        assert _build_invocation_metadata("single")["launched_by"] == "cli"
+
+
+# ---------------------------------------------------------------------------
+# Resolved mode
+# ---------------------------------------------------------------------------
+
+
+class TestResolvedMode:
+    @pytest.mark.parametrize("mode", ["chat", "single"])
+    def test_mode_recorded_verbatim(self, mode):
+        bundle = _prepared_bundle()
+        _inject_invocation_metadata(bundle, mode=mode)
+        assert _invocation(bundle)["mode"] == mode
+
+    def test_absent_mode_is_unknown_not_guessed(self):
+        """A wrong mode is worse than an absent one (absent => UNKNOWN)."""
+        bundle = _prepared_bundle()
+        _inject_invocation_metadata(bundle, mode=None)
+        assert _invocation(bundle)["mode"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# tty matrix
+# ---------------------------------------------------------------------------
+
+
+class TestTtyFlags:
+    @pytest.mark.parametrize(
+        ("stdin_tty", "stdout_tty"),
+        [(True, True), (True, False), (False, True), (False, False)],
+    )
+    def test_isatty_matrix(self, stdin_tty, stdout_tty):
+        fds = {0: stdin_tty, 1: stdout_tty}
+        with patch(f"{_MODULE}.os.isatty", side_effect=lambda fd: fds[fd]):
+            invocation = _build_invocation_metadata("single")
+        assert invocation["stdin_isatty"] is stdin_tty
+        assert invocation["stdout_isatty"] is stdout_tty
+
+    def test_closed_fd_reads_as_not_a_tty_instead_of_raising(self):
+        """A daemonised harness with a closed stdin must not fail to start."""
+        with patch(f"{_MODULE}.os.isatty", side_effect=OSError("Bad file descriptor")):
+            invocation = _build_invocation_metadata("single")
+        assert invocation["stdin_isatty"] is False
+        assert invocation["stdout_isatty"] is False
+
+
+# ---------------------------------------------------------------------------
+# Cross-process launcher id
+# ---------------------------------------------------------------------------
+
+
+class TestLauncherSessionId:
+    def test_unset_env_var_yields_null_never_a_fabricated_id(self, monkeypatch):
+        monkeypatch.delenv(LAUNCHER_SESSION_ID_ENV, raising=False)
+        assert _build_invocation_metadata("single")["launched_by_session_id"] is None
+
+    def test_empty_env_var_is_also_null(self, monkeypatch):
+        monkeypatch.setenv(LAUNCHER_SESSION_ID_ENV, "")
+        assert _build_invocation_metadata("single")["launched_by_session_id"] is None
+
+    def test_set_env_var_is_recorded(self, monkeypatch):
+        monkeypatch.setenv(LAUNCHER_SESSION_ID_ENV, "launcher-session-abc")
+        assert (
+            _build_invocation_metadata("single")["launched_by_session_id"]
+            == "launcher-session-abc"
+        )
+
+    def test_env_var_uses_the_amplifier_prefix(self):
+        """foundation's subprocess env allowlist forwards AMPLIFIER_* for free."""
+        assert LAUNCHER_SESSION_ID_ENV.startswith("AMPLIFIER_")
+
+
+# ---------------------------------------------------------------------------
+# Merge behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestMergeSemantics:
+    def test_existing_session_metadata_is_preserved(self):
+        bundle = _prepared_bundle(
+            {"session": {"metadata": {"agent_name": "kept", "run_id": "also-kept"}}}
+        )
+        _inject_invocation_metadata(bundle, mode="single")
+
+        metadata = bundle.mount_plan["session"]["metadata"]
+        assert metadata["agent_name"] == "kept"
+        assert metadata["run_id"] == "also-kept"
+        assert set(metadata) == {"agent_name", "run_id", "invocation"}
+
+    def test_existing_session_section_keys_are_preserved(self):
+        bundle = _prepared_bundle(
+            {"session": {"orchestrator": "loop-basic", "context": "context-simple"}}
+        )
+        _inject_invocation_metadata(bundle, mode="chat")
+
+        session = bundle.mount_plan["session"]
+        assert session["orchestrator"] == "loop-basic"
+        assert session["context"] == "context-simple"
+        assert "invocation" in session["metadata"]
+
+    def test_rest_of_mount_plan_is_untouched(self):
+        bundle = _prepared_bundle({"providers": [{"id": "anthropic"}], "tools": []})
+        _inject_invocation_metadata(bundle, mode="single")
+
+        assert bundle.mount_plan["providers"] == [{"id": "anthropic"}]
+        assert bundle.mount_plan["tools"] == []
+
+    def test_missing_session_section_is_created(self):
+        bundle = _prepared_bundle({})
+        _inject_invocation_metadata(bundle, mode="single")
+        assert set(_invocation(bundle)) == EXPECTED_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# Ordering -- the mount plan must be mutated before create_session() reads it
+# ---------------------------------------------------------------------------
+
+
+class TestOrdering:
+    @pytest.mark.anyio
+    async def test_mount_plan_carries_invocation_when_create_session_is_called(
+        self, tmp_path: Path
+    ):
+        """The kernel reads session.metadata during create_session().
+
+        Injecting after that call would be a silent no-op, so this asserts on
+        the mount plan as observed *at the moment* create_session() runs, not
+        afterwards.
+        """
+        from amplifier_app_cli.session_runner import _create_bundle_session
+
+        seen: dict = {}
+
+        prepared_bundle = MagicMock()
+        prepared_bundle.mount_plan = {"providers": [], "tools": []}
+
+        async def _capture_mount_plan(**_kwargs):
+            # Deep-ish copy of just what we assert on, captured at call time.
+            seen["invocation"] = dict(
+                prepared_bundle.mount_plan["session"]["metadata"]["invocation"]
+            )
+            return MagicMock()
+
+        prepared_bundle.create_session = AsyncMock(side_effect=_capture_mount_plan)
+
+        cfg = SessionConfig(
+            config={},
+            search_paths=[tmp_path],
+            verbose=False,
+            prepared_bundle=prepared_bundle,
+            bundle_name="test-bundle",
+            invocation_mode="single",
+        )
+
+        console = MagicMock()
+        console.status = MagicMock()
+        console.status.return_value.__enter__ = MagicMock()
+        console.status.return_value.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(f"{_MODULE}.inject_user_providers", create=True),
+            patch(f"{_MODULE}._inject_observability_events"),
+            patch(f"{_MODULE}._should_attempt_self_healing", return_value=False),
+            patch("amplifier_app_cli.runtime.config.inject_user_providers"),
+            patch("amplifier_app_cli.lib.bundle_loader.AppModuleResolver"),
+            patch("amplifier_app_cli.paths.create_foundation_resolver"),
+        ):
+            await _create_bundle_session(
+                cfg,
+                session_id="test-session-id",
+                approval_system=MagicMock(),
+                display_system=MagicMock(),
+                console=console,
+            )
+
+        assert seen["invocation"]["mode"] == "single"
+        assert set(seen["invocation"]) == EXPECTED_FIELDS
+
+
+# ---------------------------------------------------------------------------
+# Entry points -- the two resolved-mode paths run.py dispatches to
+# ---------------------------------------------------------------------------
+
+
+class TestEntryPointsRecordResolvedMode:
+    """interactive_chat() => "chat"; execute_single() => "single".
+
+    Reaching one of these functions IS the mode resolution: run.py collapses
+    --mode, prompt presence, and pipe presence before dispatching, so the raw
+    --mode flag (which defaults to "single") is never what gets recorded.
+    """
+
+    @pytest.mark.asyncio
+    async def test_execute_single_records_single(self, tmp_path: Path):
+        from amplifier_app_cli.main import execute_single
+
+        captured: list[SessionConfig] = []
+
+        async def _capture(session_config, _console):
+            captured.append(session_config)
+            raise SystemExit(0)  # stop before the rest of the session machinery
+
+        with (
+            patch(
+                f"{_MAIN}.create_initialized_session",
+                new=AsyncMock(side_effect=_capture),
+            ),
+            patch(f"{_MAIN}.console"),
+            pytest.raises(SystemExit),
+        ):
+            await execute_single(
+                prompt="Hi",
+                config={},
+                search_paths=[tmp_path],
+                verbose=False,
+                bundle_name="test-bundle",
+            )
+
+        assert captured[0].invocation_mode == "single"
+
+    @pytest.mark.asyncio
+    async def test_interactive_chat_records_chat(self, tmp_path: Path):
+        from amplifier_app_cli.main import interactive_chat
+
+        captured: list[SessionConfig] = []
+
+        async def _capture(session_config, _console):
+            captured.append(session_config)
+            raise SystemExit(0)
+
+        with (
+            patch(
+                f"{_MAIN}.create_initialized_session",
+                new=AsyncMock(side_effect=_capture),
+            ),
+            patch(f"{_MAIN}.console"),
+            pytest.raises(SystemExit),
+        ):
+            await interactive_chat(
+                config={},
+                search_paths=[tmp_path],
+                verbose=False,
+                bundle_name="test-bundle",
+            )
+
+        assert captured[0].invocation_mode == "chat"

--- a/tests/test_truststore_wrap_bio_shim.py
+++ b/tests/test_truststore_wrap_bio_shim.py
@@ -1,0 +1,258 @@
+"""The truststore `wrap_bio` lock shim actually serializes concurrent calls.
+
+The bug being mitigated is a data race in a third-party package: `truststore`
+0.10.4's `wrap_bio` mutates a shared OpenSSL context without the `_ctx_lock`
+its own `wrap_socket` takes, and the CLI drives ~20 threads into it at once.
+The failure mode is a glibc abort (exit 134), so it cannot be asserted on
+directly -- these tests assert the property that prevents it instead: after the
+shim, no two threads are inside `wrap_bio` at the same time.
+
+Every test drives a fake `truststore.SSLContext`-shaped class, so the real
+`truststore` is never mutated here.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from amplifier_app_cli import truststore_shim
+
+THREADS = 20
+
+
+class _Recorder:
+    """Tracks how many threads were inside `wrap_bio` simultaneously."""
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.live = 0
+        self.peak = 0
+        self.calls = 0
+
+
+def _make_unlocked_context_class() -> type:
+    """A class shaped like `truststore.SSLContext` 0.10.4: wrap_bio unlocked."""
+
+    class FakeUnlockedSSLContext:
+        def __init__(self) -> None:
+            self._ctx_lock = threading.Lock()
+            self.recorder = _Recorder()
+            self.barrier: threading.Barrier | None = None
+
+        def wrap_bio(
+            self,
+            incoming,
+            outgoing,
+            server_side=False,
+            server_hostname=None,
+            session=None,
+        ):
+            rec = self.recorder
+            with rec.lock:
+                rec.live += 1
+                rec.peak = max(rec.peak, rec.live)
+                rec.calls += 1
+            try:
+                if self.barrier is not None:
+                    # Only the control test sets this: it proves the fake really
+                    # can run THREADS-way concurrent, so a peak of 1 later is
+                    # the shim's doing and not an artifact of the harness.
+                    self.barrier.wait()
+                else:
+                    time.sleep(0.01)
+            finally:
+                with rec.lock:
+                    rec.live -= 1
+            return ("sslobj", incoming, outgoing, server_side, server_hostname, session)
+
+    return FakeUnlockedSSLContext
+
+
+def _make_locked_context_class() -> type:
+    """A class shaped like a future, already-fixed truststore."""
+
+    class FakeLockedSSLContext:
+        def __init__(self) -> None:
+            self._ctx_lock = threading.Lock()
+
+        def wrap_bio(
+            self,
+            incoming,
+            outgoing,
+            server_side=False,
+            server_hostname=None,
+            session=None,
+        ):
+            with self._ctx_lock:
+                return "sslobj"
+
+    return FakeLockedSSLContext
+
+
+def _hammer(ctx, threads: int = THREADS) -> None:
+    """Call `wrap_bio` from `threads` threads at once, positionally.
+
+    Positional on purpose: anyio invokes it as
+    `to_thread.run_sync(ssl_context.wrap_bio, bio_in, bio_out, server_side,
+    server_hostname, None)`.
+    """
+    with ThreadPoolExecutor(max_workers=threads) as pool:
+        futures = [
+            pool.submit(ctx.wrap_bio, "in", "out", False, "example.invalid", None)
+            for _ in range(threads)
+        ]
+        for future in futures:
+            future.result(timeout=30)
+
+
+def test_control_unpatched_wrap_bio_runs_concurrently():
+    """Positive control: without the shim the fake really does run in parallel."""
+    cls = _make_unlocked_context_class()
+    ctx = cls()
+    ctx.barrier = threading.Barrier(THREADS, timeout=30)
+
+    _hammer(ctx)
+
+    assert ctx.recorder.calls == THREADS
+    assert ctx.recorder.peak == THREADS
+
+
+def test_shim_serializes_concurrent_wrap_bio():
+    """The point of the whole exercise."""
+    cls = _make_unlocked_context_class()
+    status = truststore_shim.apply_to(cls, "0.10.4")
+    assert status.startswith("applied"), status
+
+    ctx = cls()
+    _hammer(ctx)
+
+    assert ctx.recorder.calls == THREADS
+    assert ctx.recorder.peak == 1, (
+        f"{ctx.recorder.peak} threads were inside wrap_bio at once; "
+        "the shim did not serialize them"
+    )
+
+
+def test_shim_applies_to_instances_created_before_patching():
+    """Patching the class covers contexts httpx2/httpcore2 already built."""
+    cls = _make_unlocked_context_class()
+    ctx = cls()  # built first, patched after -- the startup-shim ordering case
+
+    assert truststore_shim.apply_to(cls, "0.10.4").startswith("applied")
+
+    _hammer(ctx)
+    assert ctx.recorder.peak == 1
+
+
+def test_shim_preserves_arguments_and_return_value():
+    cls = _make_unlocked_context_class()
+    truststore_shim.apply_to(cls, "0.10.4")
+    ctx = cls()
+
+    positional = ctx.wrap_bio("in", "out", False, "example.invalid", None)
+    keyword = ctx.wrap_bio(
+        "in", "out", server_side=True, server_hostname="other.invalid", session=None
+    )
+
+    assert positional == ("sslobj", "in", "out", False, "example.invalid", None)
+    assert keyword == ("sslobj", "in", "out", True, "other.invalid", None)
+
+
+def test_shim_is_idempotent():
+    cls = _make_unlocked_context_class()
+    assert truststore_shim.apply_to(cls, "0.10.4").startswith("applied")
+    patched = cls.__dict__["wrap_bio"]
+
+    assert truststore_shim.apply_to(cls, "0.10.4") == "skipped: already applied"
+    assert cls.__dict__["wrap_bio"] is patched
+
+
+def test_shim_refuses_when_wrap_bio_already_takes_the_lock():
+    """`_ctx_lock` is not reentrant -- double-locking would deadlock."""
+    cls = _make_locked_context_class()
+    original = cls.__dict__["wrap_bio"]
+
+    assert truststore_shim.apply_to(cls, "9.9.9") == (
+        "skipped: wrap_bio already takes _ctx_lock"
+    )
+    assert cls.__dict__["wrap_bio"] is original
+
+    # And it still works -- no deadlock, because nothing was wrapped.
+    assert cls().wrap_bio("in", "out") == "sslobj"
+
+
+def test_shim_refuses_when_source_is_unreadable():
+    """Unreadable source means we cannot rule out a deadlock, so: no patch."""
+    cls = _make_unlocked_context_class()
+    original = cls.__dict__["wrap_bio"]
+
+    exec_globals: dict = {}
+    exec(  # noqa: S102 - deliberately source-less, mimics a frozen install
+        "def wrap_bio(self, *a, **k):\n    return 'sslobj'\n", exec_globals
+    )
+    cls.wrap_bio = exec_globals["wrap_bio"]
+
+    assert truststore_shim.apply_to(cls, "0.10.4") == (
+        "skipped: could not read wrap_bio source, refusing to patch blind"
+    )
+    assert cls.__dict__["wrap_bio"] is not original
+    assert not hasattr(cls.__dict__["wrap_bio"], "_amplifier_wrap_bio_lock_shim")
+
+
+def test_shim_stands_down_once_upstream_ships_the_fix(monkeypatch):
+    monkeypatch.setattr(truststore_shim, "FIRST_FIXED_VERSION", "0.11.0")
+    cls = _make_unlocked_context_class()
+    original = cls.__dict__["wrap_bio"]
+
+    status = truststore_shim.apply_to(cls, "0.11.0")
+
+    assert status == "skipped: truststore 0.11.0 >= 0.11.0, fixed upstream"
+    assert cls.__dict__["wrap_bio"] is original
+
+
+def test_shim_honours_the_disable_env_var(monkeypatch):
+    monkeypatch.setenv(truststore_shim.DISABLE_ENV_VAR, "0")
+    assert truststore_shim.apply() == (
+        f"skipped: disabled by {truststore_shim.DISABLE_ENV_VAR}"
+    )
+
+
+def test_apply_is_safe_without_truststore(monkeypatch):
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "truststore":
+            raise ImportError("no truststore here")
+        return real_import(name, *args, **kwargs)
+
+    # Patch __import__ rather than evicting sys.modules: the `import truststore`
+    # statement always routes through __import__, and evicting the real module
+    # would hand a fresh, unpatched truststore to every later test.
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    assert truststore_shim.apply() == "skipped: truststore is not importable"
+
+
+def test_real_truststore_is_covered_at_cli_import():
+    """Importing the CLI package must leave the real truststore patched."""
+    truststore = pytest.importorskip("truststore")
+
+    marked = getattr(
+        truststore.SSLContext.__dict__.get("wrap_bio"),
+        "_amplifier_wrap_bio_lock_shim",
+        False,
+    )
+    already_locked = truststore_shim._wrap_bio_takes_lock(
+        truststore.SSLContext.__dict__.get("wrap_bio")
+    )
+
+    assert marked or already_locked, (
+        "amplifier_app_cli import did not leave truststore.SSLContext.wrap_bio "
+        f"serialized (status was: {truststore_shim.SHIM_STATUS!r})"
+    )


### PR DESCRIPTION
> **Mitigation, not the fix.** The defect is one missing line in
> [`sethmlarson/truststore`](https://github.com/sethmlarson/truststore), a package
> this repo does not own. This PR applies the equivalent lock from the consumer
> side so the CLI stops dying, and stands itself down automatically once a fixed
> truststore release ships. A separate lane is filing the upstream fix.
>
> **Verified end to end: 0 aborts in 26 runs with this change, 4 in 17 without it,
> and 3 in 10 after removing it again.** Numbers below.

## The symptom

The CLI dies partway through a run:

```
double free or corruption (!prev)
Fatal Python error: Aborted
```

Exit **134**, sometimes **139**. No Python traceback, no result envelope, no
partial output — the process is simply gone. From an orchestrator's side that is
indistinguishable from an OOM kill or a scheduler eviction, which is how it has
been misattributed until now.

## Root cause (third-party)

`truststore.SSLContext` re-applies the OS trust store to its wrapped
`ssl.SSLContext` on **every wrap**, via `_configure_context()` →
`ctx.set_default_verify_paths()`. That writes the context's `X509_STORE` and is
not safe to call concurrently on one context.

`truststore/_api.py` knows this. `wrap_socket` holds `self._ctx_lock`:

```python
with contextlib.ExitStack() as stack:
    with self._ctx_lock:
        stack.enter_context(_configure_context(self._ctx))
```

`wrap_bio`, 25 lines later in the same file, does not:

```python
with _configure_context(self._ctx):
    ssl_obj = self._ctx.wrap_bio(...)
```

`self._ctx_lock` exists (`_api.py:89`) and is simply unused on that path.
Verified against **truststore 0.10.4** (the current latest release) and against
`sethmlarson/truststore@main` on 2026-09-05 — **both still unlocked**. There is
no fixed release to upgrade to.

`wrap_bio` is the path this stack actually takes — anyio → httpcore2 → httpx2 →
the Anthropic SDK — and anyio hands it to a worker thread ("External SSLContext
implementations may do blocking I/O in `wrap_bio()`"). The CLI resolves the model
role of every agent in the composed bundle concurrently on every session mount,
so tens of those threads enter the unlocked `set_default_verify_paths()` on one
shared context at the same instant.

Every abort observed — in the originating investigation and in the verification
below — had the same shape: 20–37 threads inside
`truststore/_openssl.py:38 _configure_context`, **100% reached via `wrap_bio`,
0% via `wrap_socket`**.

## Why the shim lives in *this* repo

Nothing in the amplifier tree constructs a `truststore.SSLContext`. It is pulled
in by `httpx2/_config.py:40` and `httpcore2/_ssl.py:12` (pydantic's httpx fork,
which declares `truststore>=0.10`) and reached through the Anthropic SDK — which
is why `truststore` appears nowhere in this repo's dependency list and only lands
in the installed venv once a provider module is installed.

So there is no amplifier-owned call site to fix. The earliest amplifier-owned
point that runs before any TLS in this process is CLI package import — which is
where `amplifier_app_cli/__init__.py` now applies it, before
`from .main import cli` and its transitive imports.

## What this changes

`amplifier_app_cli/truststore_shim.py` wraps `truststore.SSLContext.wrap_bio` so
it runs while holding the very lock `wrap_socket` already takes — the upstream
one-line diff, applied by monkeypatch from outside.

One honest difference: upstream holds the lock only across
`_configure_context().__enter__()` and releases it for the wrap itself. From
outside the function we cannot interleave like that, so the shim holds it for the
whole call. That is strictly stronger and costs nothing here —
`SSLContext.wrap_bio` only builds an `SSLObject` over two memory BIOs; there is
no socket and no I/O in it, and the handshake happens later in `do_handshake`.

### It refuses to patch unless it is sure

`_ctx_lock` is a plain `threading.Lock`, so taking it around a `wrap_bio` that
*also* took it would **deadlock**. Every one of these is a silent no-op:

| Condition | Behaviour |
|---|---|
| Installed `wrap_bio` already references `_ctx_lock` | no-op |
| `wrap_bio` source unreadable (frozen/zipped install) | no-op — refuses to patch blind |
| `truststore >= FIRST_FIXED_VERSION` once one exists | no-op |
| `truststore` not importable | no-op |
| `AMPLIFIER_TRUSTSTORE_WRAP_BIO_SHIM=0` | no-op |
| Anything unexpected raises | swallowed and logged |

A mitigation must never be the reason the CLI cannot start.

### Removal

`FIRST_FIXED_VERSION` is currently `None` — no fixed release exists. When one
ships, set it and the shim stands down on its own for anyone on that version;
the module and its one call in `__init__.py` can then be deleted outright.

## Verification — end to end

A-B-A′ in one disposable container: `-b recipes` (41-agent bundle), the
originating report's own probe recipe, `PYTHONFAULTHANDLER=1`, counting exit
134/139. Only this PR's two files changed between conditions —
`truststore/_api.py` was verified **stock** (`wrap_bio` still unlocked)
throughout, including during **B**.

| | condition | attempts | aborts |
|---|---|---|---|
| **A** | stock, first run (sequential, alone) | 1 | **1** |
| **A** | stock, 5 concurrent × 2 rounds | 10 | **2** |
| **A** | stock, strictly sequential | 6 | **1** |
| **B** | **shim applied**, 5 concurrent × 4 rounds | **20** | **0** |
| **B** | **shim applied**, strictly sequential | **6** | **0** |
| **A′** | shim removed again, 5 concurrent × 2 rounds | 10 | **3** |

Stock: **4 aborts in 17**. Shim applied: **0 in 26**. Removed: the failure
returns immediately — **3 in 10**.

Every abort carried the identical signature — `double free or corruption
(fasttop)`, 28–37 threads inside `truststore/_openssl.py:38 _configure_context`,
**100% via `wrap_bio`, 0% via `wrap_socket`**:

```
stock    c-r2c3: _configure_context=32  wrap_bio=32  wrap_socket=0
stock    c-r2c4: _configure_context=33  wrap_bio=33  wrap_socket=0
stock    s-6:    _configure_context=28  wrap_bio=28  wrap_socket=0
stock    warmup: _configure_context=36  wrap_bio=36  wrap_socket=0
reverted c-r2c2: _configure_context=37  wrap_bio=37  wrap_socket=0
reverted c-r2c3: _configure_context=33  wrap_bio=33  wrap_socket=0
reverted c-r2c4: _configure_context=32  wrap_bio=32  wrap_socket=0
```

Under **B** there was not a single `Fatal Python error` line in 26 runs.

Environment: Ubuntu 24.04 aarch64, Python 3.12.3, **OpenSSL 3.0.13**, truststore
**0.10.4**, anthropic 1.4.0 → httpx2/httpcore2 2.12.0. The container was
destroyed once the evidence was pulled.

## Verification — unit

`tests/test_truststore_wrap_bio_shim.py`, 11 tests driving a fake
`truststore.SSLContext`-shaped class (the real one is never mutated). The abort
cannot be asserted on directly, so these assert the property that prevents it:

- a **positive control** proving the unpatched fake genuinely runs 20-way
  concurrent (a `threading.Barrier(20)` all 20 threads reach), so a peak of 1
  afterwards is the shim's doing and not an artifact of the harness
- after the shim, peak simultaneous threads inside `wrap_bio` is **1 of 20**
- instances built *before* patching are covered too (the startup-shim ordering case)
- positional call-through, because anyio invokes it as
  `to_thread.run_sync(ctx.wrap_bio, bio_in, bio_out, server_side, server_hostname, None)`
- idempotence; the already-locked refusal (deadlock guard); the unreadable-source
  refusal; the version stand-down; the env kill switch

Full suite: **1467 passed**, green on ubuntu/macOS/Windows × py3.11/3.12.

## Not addressed here, deliberately

The originating report names a second, independent contributor: a session mount
fires an unbounded `asyncio.gather` of `list_models()` calls across every agent
in the bundle (41 under `-b recipes`), on every mount. That is what converts a
latent race into a routine crash, and it is worth bounding on its own merits —
but it lives in `amplifier-bundle-routing-matrix`, not here, and is being handled
separately.
