### PR TITLE
fix(ten-lane-highway): default the tmux socket per batch, not to a shared "hw" (ye80)

### DIFF
--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh
@@ -11,6 +11,24 @@
 set -euo pipefail
 
 BATCH_DIR=${1:?BATCH_DIR required}
+
+# --- PER-BATCH TMUX SOCKET (model_performance-ye80) -------------------------
+# Default the socket to hw-<batch>, NOT a shared "hw".
+#
+# WHY: a tmux SERVER restart destroys every session on its socket. With every
+# batch on one shared socket, any batch can annihilate every other batch's
+# lanes AND their watchdogs in a single instant. Observed 2026-09-05: a second
+# batch restarted the server on socket "hw" and killed three unrelated lanes
+# plus this batch's watchdog at once -- no lane logged an error, because
+# nothing in a lane went wrong. Six DTU containers were left RUNNING with open
+# infra-ledger rows (Rule 14: nothing the highway stands up should outlive it).
+#
+# An explicitly exported HIGHWAY_TMUX_SOCKET still wins, so this is
+# backward-compatible; only the DEFAULT changes.
+HIGHWAY_TMUX_SOCKET="${HIGHWAY_TMUX_SOCKET:-hw-$(printf '%s' "$(basename "$BATCH_DIR")" | tr -c 'A-Za-z0-9_-' '_')}"
+export HIGHWAY_TMUX_SOCKET
+# ---------------------------------------------------------------------------
+
 WIDTH=${2:?WIDTH required}
 READY=${3:?READY required (ready unblocked work item count)}
 
@@ -43,7 +61,7 @@ live=0; ended=0; done_n=0; stalled=0; gone=0
 while IFS=$'\t' read -r lane wt branch base tmuxn goal log ts; do
   [ "$lane" = "lane" ] && continue
 
-  if tmux -L "${HIGHWAY_TMUX_SOCKET:-hw}" has-session -t "$tmuxn" 2>/dev/null; then st=LIVE; else st=ENDED; fi
+  if tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "$tmuxn" 2>/dev/null; then st=LIVE; else st=ENDED; fi
 
   age="-"; ahead="-"; dj="-"; wt_present=yes
   if [ -d "$wt" ]; then
@@ -76,7 +94,7 @@ while IFS=$'\t' read -r lane wt branch base tmuxn goal log ts; do
 done < "$MANIFEST"
 
 WD="hw-watchdog__${BATCH}"
-if tmux -L "${HIGHWAY_TMUX_SOCKET:-hw}" has-session -t "$WD" 2>/dev/null; then wd_st=LIVE; else wd_st=DEAD; fi
+if tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "$WD" 2>/dev/null; then wd_st=LIVE; else wd_st=DEAD; fi
 
 open=$(( WIDTH - live )); if [ "$open" -lt 0 ]; then open=0; fi
 if [ "$READY" -lt "$open" ]; then deficit=$READY; else deficit=$open; fi

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_watchdog.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_watchdog.sh
@@ -5,7 +5,7 @@
 # talk to the human). Wakes the orchestrator session when attention is needed.
 #
 # Run it DETACHED in its own tmux-session (the launcher is the orchestrator):
-#   tmux -L "${HIGHWAY_TMUX_SOCKET:-hw}" new-session -d -s "hw-watchdog__<batch>" \
+#   tmux -L "$HIGHWAY_TMUX_SOCKET" new-session -d -s "hw-watchdog__<batch>" \
 #     "<skill_dir>/scripts/highway_watchdog.sh BATCH_DIR WIDTH SESSION_ID [INTERVAL] [MAX_HOURS]"
 #
 # Wake triggers: a lane ended since last poll | live < WIDTH | manager heartbeat stale.
@@ -16,6 +16,24 @@
 set -uo pipefail   # deliberately NOT -e: the watch loop must survive transient failures
 
 BATCH_DIR=${1:?BATCH_DIR required}
+
+# --- PER-BATCH TMUX SOCKET (model_performance-ye80) -------------------------
+# Default the socket to hw-<batch>, NOT a shared "hw".
+#
+# WHY: a tmux SERVER restart destroys every session on its socket. With every
+# batch on one shared socket, any batch can annihilate every other batch's
+# lanes AND their watchdogs in a single instant. Observed 2026-09-05: a second
+# batch restarted the server on socket "hw" and killed three unrelated lanes
+# plus this batch's watchdog at once -- no lane logged an error, because
+# nothing in a lane went wrong. Six DTU containers were left RUNNING with open
+# infra-ledger rows (Rule 14: nothing the highway stands up should outlive it).
+#
+# An explicitly exported HIGHWAY_TMUX_SOCKET still wins, so this is
+# backward-compatible; only the DEFAULT changes.
+HIGHWAY_TMUX_SOCKET="${HIGHWAY_TMUX_SOCKET:-hw-$(printf '%s' "$(basename "$BATCH_DIR")" | tr -c 'A-Za-z0-9_-' '_')}"
+export HIGHWAY_TMUX_SOCKET
+# ---------------------------------------------------------------------------
+
 WIDTH=${2:?WIDTH required}
 SESSION_ID=${3:?SESSION_ID required (the orchestrator session to wake)}
 INTERVAL=${4:-300}
@@ -75,7 +93,7 @@ live_lanes() {
   local n=0 lane wt branch base tmuxn rest
   while IFS=$'\t' read -r lane wt branch base tmuxn rest; do
     [ "$lane" = "lane" ] && continue
-    tmux -L "${HIGHWAY_TMUX_SOCKET:-hw}" has-session -t "$tmuxn" 2>/dev/null && n=$((n+1))
+    tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "$tmuxn" 2>/dev/null && n=$((n+1))
   done < "$MANIFEST"
   echo "$n"
 }
@@ -84,7 +102,7 @@ ended_list() {
   local lane wt branch base tmuxn rest
   while IFS=$'\t' read -r lane wt branch base tmuxn rest; do
     [ "$lane" = "lane" ] && continue
-    tmux -L "${HIGHWAY_TMUX_SOCKET:-hw}" has-session -t "$tmuxn" 2>/dev/null || echo "$lane"
+    tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "$tmuxn" 2>/dev/null || echo "$lane"
   done < "$MANIFEST"
 }
 

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/launch_lane.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/launch_lane.sh
@@ -13,6 +13,24 @@
 set -euo pipefail
 
 BATCH_DIR=${1:?BATCH_DIR required}
+
+# --- PER-BATCH TMUX SOCKET (model_performance-ye80) -------------------------
+# Default the socket to hw-<batch>, NOT a shared "hw".
+#
+# WHY: a tmux SERVER restart destroys every session on its socket. With every
+# batch on one shared socket, any batch can annihilate every other batch's
+# lanes AND their watchdogs in a single instant. Observed 2026-09-05: a second
+# batch restarted the server on socket "hw" and killed three unrelated lanes
+# plus this batch's watchdog at once -- no lane logged an error, because
+# nothing in a lane went wrong. Six DTU containers were left RUNNING with open
+# infra-ledger rows (Rule 14: nothing the highway stands up should outlive it).
+#
+# An explicitly exported HIGHWAY_TMUX_SOCKET still wins, so this is
+# backward-compatible; only the DEFAULT changes.
+HIGHWAY_TMUX_SOCKET="${HIGHWAY_TMUX_SOCKET:-hw-$(printf '%s' "$(basename "$BATCH_DIR")" | tr -c 'A-Za-z0-9_-' '_')}"
+export HIGHWAY_TMUX_SOCKET
+# ---------------------------------------------------------------------------
+
 LANE=${2:?LANE required}
 REPO=${3:?REPO_PATH required}
 GOAL=${4:?GOAL_FILE required}
@@ -78,10 +96,10 @@ merge time.
   $DONE_MARKER
 EOF
 
-if tmux -L "${HIGHWAY_TMUX_SOCKET:-hw}" has-session -t "$TMUX_NAME" 2>/dev/null; then
+if tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "$TMUX_NAME" 2>/dev/null; then
   echo "SKIP: $TMUX_NAME already running"
 else
-  tmux -L "${HIGHWAY_TMUX_SOCKET:-hw}" new-session -d -s "$TMUX_NAME" -c "$WT" \
+  tmux -L "$HIGHWAY_TMUX_SOCKET" new-session -d -s "$TMUX_NAME" -c "$WT" \
     "amplifier run '/goal @GOAL.md' 2>&1 | tee '$LOG'"
   echo "LAUNCHED: $TMUX_NAME -> $WT ($BRANCH @ ${BASE_SHA:0:8})"
 fi

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/verify_lane.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/verify_lane.sh
@@ -10,6 +10,24 @@
 set -euo pipefail
 
 BATCH_DIR=${1:?BATCH_DIR required}
+
+# --- PER-BATCH TMUX SOCKET (model_performance-ye80) -------------------------
+# Default the socket to hw-<batch>, NOT a shared "hw".
+#
+# WHY: a tmux SERVER restart destroys every session on its socket. With every
+# batch on one shared socket, any batch can annihilate every other batch's
+# lanes AND their watchdogs in a single instant. Observed 2026-09-05: a second
+# batch restarted the server on socket "hw" and killed three unrelated lanes
+# plus this batch's watchdog at once -- no lane logged an error, because
+# nothing in a lane went wrong. Six DTU containers were left RUNNING with open
+# infra-ledger rows (Rule 14: nothing the highway stands up should outlive it).
+#
+# An explicitly exported HIGHWAY_TMUX_SOCKET still wins, so this is
+# backward-compatible; only the DEFAULT changes.
+HIGHWAY_TMUX_SOCKET="${HIGHWAY_TMUX_SOCKET:-hw-$(printf '%s' "$(basename "$BATCH_DIR")" | tr -c 'A-Za-z0-9_-' '_')}"
+export HIGHWAY_TMUX_SOCKET
+# ---------------------------------------------------------------------------
+
 LANE=${2:?LANE required}
 MANIFEST="$BATCH_DIR/manifest.tsv"
 
@@ -18,7 +36,7 @@ row=$(awk -F'\t' -v l="$LANE" 'NR>1 && $1==l' "$MANIFEST" || true)
 IFS=$'\t' read -r lane wt branch base tmuxn goal log ts <<< "$row"
 
 echo "== lane=$lane branch=$branch base=${base:0:8} wt=$wt"
-if tmux -L "${HIGHWAY_TMUX_SOCKET:-hw}" has-session -t "$tmuxn" 2>/dev/null; then
+if tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "$tmuxn" 2>/dev/null; then
   echo "TMUX: LIVE (still running - do NOT merge yet)"
 else
   echo "TMUX: ended"

--- a/tests/test_ten_lane_highway_socket_default.py
+++ b/tests/test_ten_lane_highway_socket_default.py
@@ -14,10 +14,23 @@ scripts and assert on observable behaviour, never grep-for-a-marker.
 from __future__ import annotations
 
 import re
+import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
+
+# The highway scripts are GNU/Linux shell scripts (`stat -c %Y`, tmux, bash).
+# The text assertions below read them as data and run anywhere; the ones that
+# EXECUTE the derivation need a real bash, which Windows runners do not have.
+needs_bash = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason=(
+        "executes the scripts' own derivation via bash; the ten-lane-highway "
+        "scripts are GNU/Linux-only (stat -c %Y, tmux) and no bash is present"
+    ),
+)
 
 SCRIPTS = (
     Path(__file__).resolve().parents[1]
@@ -65,6 +78,7 @@ def _derived_socket(batch_dir: Path) -> str:
     ).stdout
 
 
+@needs_bash
 def test_two_batches_derive_two_different_sockets(tmp_path: Path) -> None:
     """The whole point: batch isolation, so one server restart cannot cross over."""
     a = tmp_path / "hw-model-performance"
@@ -77,12 +91,14 @@ def test_two_batches_derive_two_different_sockets(tmp_path: Path) -> None:
     assert sa != sb, "two batches must not share a tmux server"
 
 
+@needs_bash
 def test_an_explicit_socket_still_wins(tmp_path: Path, monkeypatch) -> None:
     """Backward compatibility: only the DEFAULT changes."""
     monkeypatch.setenv("HIGHWAY_TMUX_SOCKET", "hw-explicit")
     assert _derived_socket(tmp_path / "whatever") == "hw-explicit"
 
 
+@needs_bash
 def test_a_batch_name_with_shell_metacharacters_is_sanitised(tmp_path: Path) -> None:
     nasty = tmp_path / "batch; rm -rf x"
     nasty.mkdir()

--- a/tests/test_ten_lane_highway_socket_default.py
+++ b/tests/test_ten_lane_highway_socket_default.py
@@ -1,0 +1,91 @@
+"""The highway's tmux socket must default PER BATCH, not to a shared "hw".
+
+model_performance-ye80. A tmux SERVER restart destroys every session on its
+socket. With every batch sharing one socket, any batch can annihilate every
+other batch's lanes AND watchdogs in a single instant -- observed 2026-09-05,
+when a second batch restarted the server on socket "hw" and killed three
+unrelated lanes plus a watchdog at once, leaving six DTU containers running
+with open infra-ledger rows.
+
+Follows tests/test_ten_lane_highway_infra_ledger.py's standard: run the real
+scripts and assert on observable behaviour, never grep-for-a-marker.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / "amplifier_app_cli/data/skills/ten-lane-highway/scripts"
+)
+SOCKET_USERS = (
+    "highway_status.sh",
+    "highway_watchdog.sh",
+    "launch_lane.sh",
+    "verify_lane.sh",
+)
+
+
+@pytest.mark.parametrize("script", SOCKET_USERS)
+def test_no_script_falls_back_to_the_shared_hw_socket(script: str) -> None:
+    """The `${HIGHWAY_TMUX_SOCKET:-hw}` fallback is the defect itself."""
+    text = (SCRIPTS / script).read_text(encoding="utf-8")
+    assert "HIGHWAY_TMUX_SOCKET:-hw}" not in text, (
+        f"{script} still falls back to the SHARED socket 'hw'; a server restart "
+        "there kills every other batch's lanes and watchdog (ye80)"
+    )
+
+
+@pytest.mark.parametrize("script", SOCKET_USERS)
+def test_every_socket_user_derives_the_default_from_the_batch(script: str) -> None:
+    text = (SCRIPTS / script).read_text(encoding="utf-8")
+    assert re.search(r'HIGHWAY_TMUX_SOCKET:-hw-\$\(printf', text), (
+        f"{script} must default the socket to hw-<batch> derived from BATCH_DIR"
+    )
+
+
+def _derived_socket(batch_dir: Path) -> str:
+    """Run the real derivation the scripts use, via bash -- not a reimplementation."""
+    snippet = (
+        'BATCH_DIR="$1"\n'
+        'HIGHWAY_TMUX_SOCKET="${HIGHWAY_TMUX_SOCKET:-hw-$(printf \'%s\' '
+        '"$(basename "$BATCH_DIR")" | tr -c \'A-Za-z0-9_-\' \'_\')}"\n'
+        'printf %s "$HIGHWAY_TMUX_SOCKET"\n'
+    )
+    return subprocess.run(
+        ["bash", "-c", snippet, "_", str(batch_dir)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+
+
+def test_two_batches_derive_two_different_sockets(tmp_path: Path) -> None:
+    """The whole point: batch isolation, so one server restart cannot cross over."""
+    a = tmp_path / "hw-model-performance"
+    b = tmp_path / "converge"
+    a.mkdir()
+    b.mkdir()
+    sa, sb = _derived_socket(a), _derived_socket(b)
+    assert sa == "hw-hw-model-performance"
+    assert sb == "hw-converge"
+    assert sa != sb, "two batches must not share a tmux server"
+
+
+def test_an_explicit_socket_still_wins(tmp_path: Path, monkeypatch) -> None:
+    """Backward compatibility: only the DEFAULT changes."""
+    monkeypatch.setenv("HIGHWAY_TMUX_SOCKET", "hw-explicit")
+    assert _derived_socket(tmp_path / "whatever") == "hw-explicit"
+
+
+def test_a_batch_name_with_shell_metacharacters_is_sanitised(tmp_path: Path) -> None:
+    nasty = tmp_path / "batch; rm -rf x"
+    nasty.mkdir()
+    got = _derived_socket(nasty)
+    assert got == "hw-batch__rm_-rf_x", got
+    assert ";" not in got and " " not in got


### PR DESCRIPTION
## The incident

A tmux **server** restart destroys every session on its socket. Every batch currently defaults to the shared socket `hw`, so **any batch can annihilate every other batch's lanes and their watchdogs in one instant.**

Observed 2026-09-05:

```
$ ps -eo pid,lstart,args | grep 'tmux.*-L hw'
1102562  Sat Sep  5 20:05:25 2026  tmux -L hw new-session -d -s hw__converge__w11-apply-ratified
```

The server was ~4 minutes old while the affected batch had been running for hours. It killed **three unrelated lanes** (three different repos) **and that batch's watchdog** simultaneously. No lane logged an error, because nothing in a lane went wrong.

Ruled out by measurement: OOM (dmesg clean, 47/121 GB used), the watchdog's own `MAX_HOURS` cap (it died at `uptime=7929s` of a 12h cap), and per-lane failure — three unrelated lanes do not fail identically at one instant.

**Worse than the lost work:** six DTU containers were left **RUNNING** with open infra-ledger rows — infrastructure outliving the highway that created it (Rule 14). Recovered by hand: `verified-gone=6 rows-flipped=6 failed=0`. One killed lane had already finished all five test tiers and committed; only its push and marker were lost.

## The change

Each of the four socket users derives its default from `BATCH_DIR`'s basename, sanitised with the same `tr` expression the scripts already use for tmux session names:

```sh
HIGHWAY_TMUX_SOCKET="${HIGHWAY_TMUX_SOCKET:-hw-$(printf '%s' \
  "$(basename "$BATCH_DIR")" | tr -c 'A-Za-z0-9_-' '_')}"
```

**Backward compatible** — an explicitly exported `HIGHWAY_TMUX_SOCKET` still wins; only the *default* changes. The variable was already plumbed through all four scripts; only the shared default coupled the batches.

Sessions cannot migrate between sockets, so an existing batch cuts over at its next `live=0` point — which is how the batch that hit this incident cut over.

## Tests

`tests/test_ten_lane_highway_socket_default.py`, 11 cases, following `test_ten_lane_highway_infra_ledger.py`'s standard (exercise the real derivation via bash rather than reimplementing it in Python):

- no script retains the `${HIGHWAY_TMUX_SOCKET:-hw}` fallback — *the defect itself*
- every socket user derives its default from `BATCH_DIR`
- **two batches derive two different sockets** — the actual point
- an explicit socket still wins (backward compatibility)
- a batch name carrying shell metacharacters is sanitised

That last test found a defect **in its own first draft**: the helper interpolated `BATCH_DIR` into a `bash -c` string unquoted, so a `;` in a directory name split the command. Fixed by passing it as argv — which is exactly how the real scripts receive it (`BATCH_DIR=${1:?...}`), so the test now exercises the real path.

## Two smaller findings from the same incident, not fixed here

1. **`lane_teardown.sh` silently no-ops on a near-miss lane name.** `lane_teardown.sh <batch> drbf teardown --yes` reported *"lane 'drbf' owns no open rows — nothing to do"* while six rows were open under the full name `drbf-compaction-notice-ab`. On the one path reached for in an emergency, a near-miss name should error listing candidates.
2. **Nothing reaps ledger rows whose owning lane is gone.** The ledger recorded the six DTUs correctly; nothing notices their lane is dead. Even surfacing *"N open rows owned by lanes no longer live"* in `highway_status.sh` would have caught it.

Draft: `#306` also edits `highway_watchdog.sh` (watchdog self-restart). No overlap on the socket lines — verified `0` changed `HIGHWAY_TMUX_SOCKET` lines there — but they touch the same file, so whichever lands second should rebase.

Tracked as `model_performance-ye80`.