### PR TITLE
fix(routing): list a live matrix the runtime loads but the CLI required a `name:` for (teel)

### DIFF
--- a/amplifier_app_cli/commands/routing.py
+++ b/amplifier_app_cli/commands/routing.py
@@ -182,10 +182,29 @@ def _load_all_matrices_with_paths(
 
     Only the winning file is parsed into the row, so a shadowed file can never
     supply the description, ``updated:`` date or compatibility count shown for
-    a matrix. A stem whose winner is unparseable or carries no ``name:`` is
-    dropped entirely rather than falling back to a file the loader would not
-    read -- that keeps the old "must have ``name:`` to be listed" rule without
-    letting a loser back in through it.
+    a matrix. A stem whose winner is unparseable is dropped entirely rather
+    than falling back to a file the loader would not read.
+
+    A row survives on exactly the loader's own terms: ``load_matrix()`` accepts
+    any file that parses to a mapping (``"Matrix file must contain a YAML
+    mapping"``) and ``validate_matrix()`` asks for ``general``/``fast`` roles.
+    **Neither reads the YAML's ``name:`` field** -- as of routing-matrix
+    ``972b0ce``, ``matrix_loader.py`` and ``resolver_class.py`` contain no read
+    of it at all. This function used to require it anyway::
+
+        if data and "name" in data:
+            matrices[stem] = (data, path)
+
+    which made a matrix the runtime loads and routes through invisible here:
+    absent from ``list`` (contributing to neither the active nor the disabled
+    count) and "not found" in ``show``. Measured on a live host with
+    ``routing.matrix = anthropic-knob-consistent`` in effect and 13 agents
+    routing through it, the CLI reported ``Matrix 'anthropic-knob-consistent'
+    not found`` and ``0 active, 9 disabled`` -- the opposite of the truth, from
+    the tool an operator reaches for precisely when routing is misbehaving.
+
+    ``name:`` is CLI-facing metadata. It is reported when it disagrees with the
+    stem (see :func:`_print_name_stem_note`), and never decides existence.
 
     Args:
         matrix_files: Every discovered matrix file.
@@ -199,7 +218,10 @@ def _load_all_matrices_with_paths(
     matrices: dict[str, tuple[dict[str, Any], Path]] = {}
     for stem, path in winners.items():
         data = _load_matrix(path)
-        if data and "name" in data:
+        # The loader's rule, not ours: a non-empty YAML mapping. An empty or
+        # non-mapping file raises in load_matrix(), so it has no runtime
+        # identity to report and must not gain a row here either.
+        if isinstance(data, dict) and data:
             matrices[stem] = (data, path)
     return matrices
 
@@ -222,6 +244,21 @@ def _load_all_matrices(matrix_files: list[Path]) -> dict[str, dict[str, Any]]:
 def _declared_name(data: Mapping[str, Any]) -> str:
     """The ``name:`` field inside a matrix YAML (may differ from its stem)."""
     return str(data.get("name", ""))
+
+
+def _disagreeing_name(data: Mapping[str, Any], stem: str) -> str | None:
+    """The declared ``name:`` when it is present AND differs from *stem*.
+
+    ``None`` covers both "agrees" and "not declared at all", which are the two
+    cases an operator must not be warned about. Absence is not disagreement:
+    the runtime never reads ``name:``, so a file without one is entirely
+    ordinary, and a warning there would send someone looking for a problem
+    that does not exist -- the same wasted trip the "not found" message caused.
+    """
+    if "name" not in data:
+        return None
+    declared = _declared_name(data)
+    return declared if declared != stem else None
 
 
 def _print_matrix_not_found(
@@ -461,8 +498,8 @@ def routing_list(compact: bool, detailed: bool, fmt: str):
 
         origin = origins.get(source_path.stem)
         is_shadowing = origin is not None and origin.is_shadowed
-        declared = _declared_name(data)
-        name_disagrees = declared != name
+        declared = _disagreeing_name(data, name)
+        name_disagrees = declared is not None
 
         config_summary: dict[str, Any] = {
             "description": description,
@@ -482,7 +519,7 @@ def routing_list(compact: bool, detailed: bool, fmt: str):
         # `routing use` must write. `declared_name` is reported alongside so a
         # disagreement is visible instead of silently keying on the wrong one.
         item["matrix_file"] = _display_path(source_path)
-        if name_disagrees:
+        if declared is not None:
             mismatched.append((name, declared))
             config_summary["declared_name"] = declared
 
@@ -538,7 +575,7 @@ def routing_use(matrix_name: str, scope: str):
     )
 
     # Show the effective resolution as a preview
-    _show_matrix_resolution(matrices[matrix_name], settings)
+    _show_matrix_resolution(matrices[matrix_name], settings, matrix_name)
 
 
 # ============================================================
@@ -590,15 +627,17 @@ def routing_show(matrix_name: str | None, compact: bool, detailed: bool, fmt: st
         return
 
     _print_shadowing_note(origin)
-    declared = _declared_name(matrix_data)
-    if declared != matrix_name:
+    declared = _disagreeing_name(matrix_data, matrix_name)
+    if declared is not None:
         _print_name_stem_note([(matrix_name, declared)])
 
-    # detailed view → full waterfall; regular/compact → resolved routing
+    # detailed view → full waterfall; regular/compact → resolved routing.
+    # `matrix_name` is the file stem the runtime resolved, so the heading names
+    # the identity in effect rather than the YAML's own `name:` field.
     if view == "detailed":
-        _show_matrix_details(matrix_data, settings)
+        _show_matrix_details(matrix_data, settings, matrix_name)
     else:
-        _show_matrix_resolution(matrix_data, settings)
+        _show_matrix_resolution(matrix_data, settings, matrix_name)
 
 
 def _print_shadowing_note(origin: Any) -> None:
@@ -618,9 +657,31 @@ def _print_shadowing_note(origin: Any) -> None:
     console.print()
 
 
-def _show_matrix_resolution(matrix_data: dict[str, Any], settings: AppSettings) -> None:
+def _resolved_identity(matrix_data: Mapping[str, Any], stem: str | None) -> str:
+    """What to call this matrix in a heading.
+
+    *stem* -- the file stem the runtime resolved -- wins whenever the caller
+    knows it, because that is the identity in effect: it is what
+    ``routing.matrix`` holds and what ``resolve_matrix_source()`` appends
+    ``.yaml`` to. Titling by the YAML's own ``name:`` printed a string the
+    runtime never reads, which for a file carrying no ``name:`` rendered as
+    the actively misleading ``Matrix: unknown``.
+
+    ``None`` is for the one caller with no stem to offer -- the unsaved
+    working copy inside ``routing edit`` -- which keeps its previous heading.
+    """
+    if stem is not None:
+        return stem
+    return str(matrix_data.get("name", "unknown"))
+
+
+def _show_matrix_resolution(
+    matrix_data: dict[str, Any],
+    settings: AppSettings,
+    stem: str | None = None,
+) -> None:
     """Display a role-by-role resolution table for a matrix."""
-    matrix_name = matrix_data.get("name", "unknown")
+    matrix_name = _resolved_identity(matrix_data, stem)
     provider_types = _get_configured_provider_types(settings)
 
     roles = matrix_data.get("roles", {})
@@ -662,13 +723,17 @@ def _show_matrix_resolution(matrix_data: dict[str, Any], settings: AppSettings) 
         )
 
 
-def _show_matrix_details(matrix_data: dict[str, Any], settings: AppSettings) -> None:
+def _show_matrix_details(
+    matrix_data: dict[str, Any],
+    settings: AppSettings,
+    stem: str | None = None,
+) -> None:
     """Display the full candidate waterfall for a routing matrix.
 
     Shows every candidate for each role with ★/✓/✗ indicators based on
     whether the provider is configured, and highlights the active winner.
     """
-    name = matrix_data.get("name", "unknown")
+    name = _resolved_identity(matrix_data, stem)
     description = matrix_data.get("description", "")
     updated = str(matrix_data.get("updated", ""))
 
@@ -798,7 +863,9 @@ def routing_manage_loop(settings: AppSettings, scope: Scope = "global") -> Scope
 
             # 3. Show current resolution table
             if active_matrix in matrices:
-                _show_matrix_resolution(matrices[active_matrix], settings)
+                _show_matrix_resolution(
+                    matrices[active_matrix], settings, active_matrix
+                )
 
         # 4. Actions menu
         console.print("\n  Actions:")
@@ -880,7 +947,7 @@ def _manage_view_matrix(
         num = int(num_str)
         if 1 <= num <= len(matrix_names):
             name = matrix_names[num - 1]
-            _show_matrix_details(matrices[name], settings)
+            _show_matrix_details(matrices[name], settings, name)
         else:
             console.print(f"  [red]Invalid number. Enter 1-{len(matrix_names)}.[/red]")
     except ValueError:

--- a/docs/lanes/teel-routing-cli-identity/DONE-NOTE.md
+++ b/docs/lanes/teel-routing-cli-identity/DONE-NOTE.md
@@ -1,0 +1,245 @@
+# DONE-NOTE — lane `teel-routing-cli-identity`
+
+**Item:** `model_performance-teel` (project `model_performance`)
+**Repo:** `microsoft/amplifier-app-cli`, branch `lane/teel-routing-cli-identity`
+**Parent commit:** `3bb0104`
+**Outcome branch:** **A — RESOLVED.** Every deliverable is DONE. Nothing was
+recorded NOT-POSSIBLE; the cap did not bind (see Spend).
+
+Per the LANDING STAGE rule, the deliverables that read as "the live system now
+behaves X" are satisfied as "X is demonstrated fail-before/pass-after and
+shipped as a draft PR". The merge is the manager's next stage; this lane never
+merges.
+
+---
+
+## 1. Result in one paragraph
+
+`amplifier routing list|show` told an operator the opposite of the truth about a
+live matrix. The cause was **not** the one the item inferred. PR #294 (merged
+`8c4ad7a`, 2026-09-02) had already moved the CLI's row **keying** from the
+YAML's internal `name:` to the file stem — the identity the runtime uses — so
+the "stem disagrees with `name:`" case the item names was fixed before this lane
+opened. What #294 left behind was the **existence gate**: a row survived only
+`if data and "name" in data`. The runtime never reads `name:` at all, so a
+matrix that hooks-routing loads and routes through was dropped from the CLI
+entirely — missing from `list` (contributing to neither the active nor the
+disabled count) and "not found" in `show`. That is the residual half that
+produces otr's measured output, and it still reproduced at `3bb0104`. This lane
+keys the CLI's *existence* rule to the loader's own rule, and titles `show`
+headings by the stem in effect rather than by a field the runtime never reads.
+
+---
+
+## 2. What was measured
+
+### 2.1 The defect reproduces at the parent commit, byte-for-byte
+
+Tree: the nine matrices the routing-matrix bundle ships (`972b0ce`), plus one
+live user matrix `~/.amplifier/routing/anthropic-knob-consistent.yaml` carrying
+no `name:` field, with `routing.matrix = anthropic-knob-consistent` in effect.
+
+At `3bb0104` (`docs/lanes/teel-routing-cli-identity/fail-before.txt`):
+
+```
+── routing matrices (0 active, 9 disabled) ──
+  [off]    anthropic  (available)  ← disabled
+  ... (the eight others)
+  [off]    quality  (available)  ← disabled
+
+$ amplifier routing show
+Matrix 'anthropic-knob-consistent' not found. Available: anthropic, balanced,
+copilot, economy, gemini, ollama, openai, openai-knob-consistent, quality
+```
+
+Both of otr's measured lines, including the literal `9`. The live matrix is not
+merely mis-keyed — it has **no row at all**.
+
+On the branch (`pass-after.txt`), same tree, same commands:
+
+```
+── routing matrices (1 active, 9 disabled) ──
+  [on]  → anthropic-knob-consistent  (active)
+
+$ amplifier routing show
+Matrix: anthropic-knob-consistent
+  Knob-consistent anthropic routing.
+```
+
+### 2.2 The runtime genuinely does not need `name:` — checked, not assumed
+
+Read directly from the cached bundle at
+`~/.amplifier/cache/amplifier-bundle-routing-matrix-972b0ce7f0cbc2f7/`:
+
+| Runtime function | What it requires |
+|---|---|
+| `resolve_matrix_source(name, ...)` | builds `f"{name}.yaml"`, takes the first hit in `[*custom_routing_dirs, bundle routing/]` |
+| `load_matrix(path)` | only that the file parse to a **mapping** (`"Matrix file must contain a YAML mapping"`) |
+| `validate_matrix(matrix)` | `general` and `fast` roles; per-role `description` and `candidates` |
+
+`grep '"name"\|'"'"'name'"'"'' matrix_loader.py resolver_class.py` returns
+**nothing**. The YAML's `name:` is read nowhere in the runtime. Its own
+docstring says so in prose (`matrix_loader.py:41-43`): the resolved name is
+"the file stem … **not necessarily the `name:` field declared inside the
+YAML**". The CLI's requirement was the CLI's own invention.
+
+### 2.3 Suite, fail-before / pass-after
+
+| | parent `3bb0104` | branch |
+|---|---|---|
+| `uv run pytest -q` | 2 failed, **1776 passed**, 1 skipped, 13 deselected, 1 xfailed | 2 failed, **1804 passed**, 1 skipped, 13 deselected, 1 xfailed |
+| `tests/test_routing_cli_runtime_identity.py` | **12 failed**, 16 passed | **28 passed** |
+
++28 passing = exactly the new file. No test changed status in either direction.
+
+The **2 failures are pre-existing and unrelated**, present at the parent commit
+with the same two ids. Root-caused rather than waved past: the highway exports
+`HIGHWAY_TMUX_SOCKET=hw-model-performance` into every lane session, and
+`test_ten_lane_highway_socket_default.py::_derived_socket` shells out with no
+`env=`, so the `${HIGHWAY_TMUX_SOCKET:-…}` default branch those two tests exist
+to exercise is never taken. Proof:
+
+```
+$ echo $HIGHWAY_TMUX_SOCKET                                   -> hw-model-performance
+$ uv run pytest tests/test_ten_lane_highway_socket_default.py -q   -> 2 failed, 9 passed
+$ env -u HIGHWAY_TMUX_SOCKET uv run pytest … -q                    -> 11 passed
+```
+
+Filed as `model_performance-etuz`, linked discovered-from this item. Not fixed
+here: that file is outside this lane's owned paths, and CI does not see it (no
+`HIGHWAY_TMUX_SOCKET` on GitHub runners), so it is green there and red only for
+the lanes that actually run it.
+
+### 2.4 No regression for the common case — stash-compare, byte-identical
+
+Nine invocations (`list`, `list --format json`, bare `show`, `show <stem>`,
+`--detailed`, `--compact`, a custom matrix, the not-found path, and `use`)
+against an agreeing tree, captured at the parent commit and on the branch at a
+fixed console width:
+
+```
+parent: 6497 bytes   branch: 6497 bytes
+diff -u before after  ->  BYTE-IDENTICAL
+```
+
+Captures committed as `byte-identity-parent.txt` / `byte-identity-branch.txt`;
+re-verified after `ruff format`. Titling by stem is a no-op *exactly* when stem
+and `name:` agree, which is why the common case cannot move.
+
+---
+
+## 3. The change
+
+`amplifier_app_cli/commands/routing.py`, three edits, reporting path only:
+
+1. **`_load_all_matrices_with_paths`** — the existence gate becomes the
+   loader's own rule. `if data and "name" in data` → `if isinstance(data, dict)
+   and data`. A matrix exists for the CLI exactly when the runtime can load it.
+2. **`_disagreeing_name(data, stem)`** (new) — returns the declared name only
+   when it is **present and different**. Absence is not disagreement: the
+   runtime never reads the field, so warning about its absence would send an
+   operator hunting a problem that does not exist — the same wasted trip the
+   "not found" message caused. A genuinely mismatched `name:` still warns
+   exactly as #294 made it.
+3. **`_resolved_identity(data, stem)`** (new), threaded into
+   `_show_matrix_resolution` / `_show_matrix_details` — headings name the stem
+   the runtime resolved. Previously `matrix_data.get("name", "unknown")`, which
+   printed a string the runtime never reads and rendered as the actively
+   misleading `Matrix: unknown` for a file with no `name:`. The one caller with
+   no stem to offer — the unsaved working copy inside `routing edit` — passes
+   `None` and keeps its previous heading.
+
+**Which candidate fix, and why.** The item offered three. This is **(1),
+argued from the code**: the CLI now derives *both* keying and existence from
+the runtime's rule, so there is one source of truth rather than two that agree
+by convention. **(3) — validate at load time and warn — is already present and
+was kept**, narrowed so it fires on real disagreement only. **(2) was
+rejected**: reporting both identities as co-equal implies the declared name has
+standing in resolution, and it has none.
+
+---
+
+## 4. Deliverables
+
+| Deliverable | State |
+|---|---|
+| Live matrix whose stem differs from its `name:` reports PRESENT and ACTIVE, with a fail-before test on the parent commit | **DONE** — §2.1. Note the stem-vs-`name:` case was already fixed by #294; the case that still reproduced, and that this lane fixes, is the file carrying no `name:` at all. Both are pinned. |
+| CLI and runtime cannot diverge, pinned by a test; no cross-repo edit | **DONE** — `TestCliAndRuntimeCannotDiverge` asserts the CLI's row set equals the set `resolve_matrix_source()` resolves, obtaining that function through production's own `load_resolve_matrix_source()`. It asks the runtime rather than re-deriving its rule, so it cannot be satisfied by teaching the test the same wrong answer as the code. A non-vacuity case pins that an unresolvable stem is absent from both sides. No file outside this repo was touched. |
+| No regression for the common case, pinned | **DONE** — §2.4 (stash-compare) plus `TestAgreeingTreeUnchanged`, which holds the agreeing-tree listing as an exact golden literal. |
+| Runtime selection UNCHANGED | **DONE** — `TestRuntimeSelectionUnchanged`: settings bytes are unchanged across `list`/`show`, and `resolve_winning_paths` (which decides *which file* a stem loads) returns the same winner per stem. The change alters which rows survive, never which file a row points at, and never what `routing.matrix` holds. |
+| Full suite green, pasted in PR body; fail-before transcript from the parent | **DONE, with a stated caveat** — §2.3. Green except two pre-existing, root-caused, unrelated failures that are equally red at the parent commit. Reported rather than hidden, and filed as `model_performance-etuz`. |
+| Draft PR on origin | **DONE** — see the marker's `publication` block for the values read back from the remote. |
+| DONE-NOTE at `docs/lanes/teel-routing-cli-identity/DONE-NOTE.md` | **DONE** — this file (artifact-path/v1; repo root never touched). |
+
+---
+
+## 5. The cross-repo boundary — reported, not crossed
+
+The runtime identity lives in `matrix_loader.py` in
+**amplifier-bundle-routing-matrix**, a different repo. Nothing there was edited.
+
+**What a matching change in that repo would need to be: none.** The runtime's
+rule was already correct and already documented (`matrix_loader.py:41-43`); the
+CLI was the half that disagreed with it, and the CLI is the half that moved.
+This lane pins the CLI against that documented keying.
+
+Two things that repo *could* do, neither required for this fix:
+
+- **Publish the identity rule as a function rather than as a docstring.** The
+  CLI currently learns "the stem is the identity" by loading
+  `resolve_matrix_source` and by prose. A tiny exported helper (e.g.
+  `matrix_identity(path) -> str`, returning `path.stem`) would let the CLI
+  import the rule instead of mirroring it, and the pin in
+  `TestCliAndRuntimeCannotDiverge` could assert against the import directly.
+- **Warn at load time when `name:` disagrees with the stem** — the item's
+  candidate (3), on the runtime side. The CLI now warns; the runtime is still
+  silent, so a user who never runs `routing list` never learns the field is
+  decorative.
+
+Both are suggestions for that repo's owner. Neither blocks this change, and
+neither was attempted from here.
+
+---
+
+## 6. Spend
+
+**Authority: $0.00** — arithmetic as stated in the goal, `0 runs × 0 arms ×
+$0.00 / 1.00 = $0.00`, slack $0.00. The arithmetic closes: this deliverable
+buys no runs, no arms, and no validity-gated measurements, so a $0 authority is
+correctly sized for it rather than mis-sized.
+
+**Spent: $0.00.** No API calls, no containers, no DTU, no eval runs. Pure
+code-and-test change verified with the repo's own pytest suite and a
+stash-compare. No infrastructure was created, so no `infra_ledger.sh` row was
+opened and no teardown was needed. The cap never bound; no deliverable was
+dropped or shrunk.
+
+---
+
+## 7. Choices recorded (no human was waited on)
+
+1. **Fixed the residual defect rather than reporting the item as already
+   fixed.** #294 fixed the keying half; the item's *measured symptom* still
+   reproduced at `3bb0104`. The operator-facing lie is the deliverable, so the
+   lane fixed the half that still produces it, and says plainly which half was
+   already done.
+2. **Existence keyed to loadability, not to the stem's mere presence.** A file
+   that fails `load_matrix()` — non-mapping, empty, unparseable — still gets no
+   row. Pinned by `TestUnloadableFilesStillDropped`. Widening existence past
+   what the runtime can load would be the same class of lie in the other
+   direction.
+3. **Absent `name:` produces no warning.** Warning on a field the runtime never
+   reads manufactures a false problem in the exact tool an operator reaches for
+   when they already suspect one.
+4. **`routing edit`'s working copy keeps its old heading.** An unsaved copy has
+   no stem, so inventing one would be worse than the status quo.
+5. **The two pre-existing suite failures were root-caused, not waved past** —
+   and filed rather than fixed, because the file is outside this lane's owned
+   paths.
+
+## 8. What remains open
+
+- `model_performance-etuz` — the `HIGHWAY_TMUX_SOCKET` test-isolation defect
+  above. Red for every lane in this repo, green in CI.
+- The two optional routing-matrix-side suggestions in §5, for that repo's owner.
+- Nothing in this lane's own scope.

--- a/docs/lanes/teel-routing-cli-identity/byte-identity-branch.txt
+++ b/docs/lanes/teel-routing-cli-identity/byte-identity-branch.txt
@@ -1,0 +1,231 @@
+$ amplifier routing list
+[exit 0]
+── routing matrices (1 active, 9 disabled) ──
+  [off]    anthropic  (available)  ← disabled
+  [on]  → balanced  (active)
+  [off]    copilot  (available)  ← disabled
+  [off]    economy  (available)  ← disabled
+  [off]    gemini  (available)  ← disabled
+  [off]    my-custom  (available)  ← disabled
+  [off]    ollama  (available)  ← disabled
+  [off]    openai  (available)  ← disabled
+  [off]    openai-knob-consistent  (available)  ← disabled
+  [off]    quality  (available)  ← disabled
+
+
+$ amplifier routing list --format json
+[exit 0]
+[
+  {
+    "name": "  anthropic",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped anthropic.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/anthropic.yaml"
+  },
+  {
+    "name": "\u2192 balanced",
+    "enabled": true,
+    "behaviors": [
+      "active"
+    ],
+    "config_summary": {
+      "description": "Shipped balanced.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/balanced.yaml"
+  },
+  {
+    "name": "  copilot",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped copilot.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/copilot.yaml"
+  },
+  {
+    "name": "  economy",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped economy.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/economy.yaml"
+  },
+  {
+    "name": "  gemini",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped gemini.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/gemini.yaml"
+  },
+  {
+    "name": "  my-custom",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Custom matrix.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/routing/my-custom.yaml"
+  },
+  {
+    "name": "  ollama",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped ollama.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/ollama.yaml"
+  },
+  {
+    "name": "  openai",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped openai.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/openai.yaml"
+  },
+  {
+    "name": "  openai-knob-consistent",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped openai-knob-consistent.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/openai-knob-consistent.yaml"
+  },
+  {
+    "name": "  quality",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped quality.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/quality.yaml"
+  }
+]
+
+$ amplifier routing show
+[exit 0]
+
+  Matrix: balanced
+  Shipped balanced.
+  Updated: 2026-09-02
+
+  fast — Quick tasks
+    ★ anthropic / claude-haiku-*  ← active
+
+  general — Catch-all
+    ★ anthropic / claude-sonnet-*  ← active
+
+$ amplifier routing show balanced
+[exit 0]
+
+  Matrix: balanced
+  Shipped balanced.
+  Updated: 2026-09-02
+
+  fast — Quick tasks
+    ★ anthropic / claude-haiku-*  ← active
+
+  general — Catch-all
+    ★ anthropic / claude-sonnet-*  ← active
+
+$ amplifier routing show balanced --detailed
+[exit 0]
+
+  Matrix: balanced
+  Shipped balanced.
+  Updated: 2026-09-02
+
+  fast — Quick tasks
+    ★ anthropic / claude-haiku-*  ← active
+
+  general — Catch-all
+    ★ anthropic / claude-sonnet-*  ← active
+
+$ amplifier routing show balanced --compact
+[exit 0]
+            Routing: balanced            
+┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Role    ┃ Model           ┃ Provider  ┃
+┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ fast    │ claude-haiku-*  │ anthropic │
+│ general │ claude-sonnet-* │ anthropic │
+└─────────┴─────────────────┴───────────┘
+
+Providers: anthropic (★)
+
+$ amplifier routing show my-custom
+[exit 0]
+
+  Matrix: my-custom
+  Custom matrix.
+  Updated: 2026-09-02
+
+  fast — Quick tasks
+    ★ anthropic / claude-haiku-*  ← active
+
+  general — Catch-all
+    ★ anthropic / claude-sonnet-*  ← active
+
+$ amplifier routing show nonexistent
+[exit 0]
+Matrix 'nonexistent' not found. Available: anthropic, balanced, copilot, economy, gemini, my-custom,
+ollama, openai, openai-knob-consistent, quality
+
+$ amplifier routing use balanced
+[exit 0]
+✓ Routing matrix set to 'balanced' (global scope)
+            Routing: balanced            
+┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Role    ┃ Model           ┃ Provider  ┃
+┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ fast    │ claude-haiku-*  │ anthropic │
+│ general │ claude-sonnet-* │ anthropic │
+└─────────┴─────────────────┴───────────┘
+
+Providers: anthropic (★)

--- a/docs/lanes/teel-routing-cli-identity/byte-identity-parent.txt
+++ b/docs/lanes/teel-routing-cli-identity/byte-identity-parent.txt
@@ -1,0 +1,231 @@
+$ amplifier routing list
+[exit 0]
+── routing matrices (1 active, 9 disabled) ──
+  [off]    anthropic  (available)  ← disabled
+  [on]  → balanced  (active)
+  [off]    copilot  (available)  ← disabled
+  [off]    economy  (available)  ← disabled
+  [off]    gemini  (available)  ← disabled
+  [off]    my-custom  (available)  ← disabled
+  [off]    ollama  (available)  ← disabled
+  [off]    openai  (available)  ← disabled
+  [off]    openai-knob-consistent  (available)  ← disabled
+  [off]    quality  (available)  ← disabled
+
+
+$ amplifier routing list --format json
+[exit 0]
+[
+  {
+    "name": "  anthropic",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped anthropic.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/anthropic.yaml"
+  },
+  {
+    "name": "\u2192 balanced",
+    "enabled": true,
+    "behaviors": [
+      "active"
+    ],
+    "config_summary": {
+      "description": "Shipped balanced.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/balanced.yaml"
+  },
+  {
+    "name": "  copilot",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped copilot.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/copilot.yaml"
+  },
+  {
+    "name": "  economy",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped economy.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/economy.yaml"
+  },
+  {
+    "name": "  gemini",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped gemini.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/gemini.yaml"
+  },
+  {
+    "name": "  my-custom",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Custom matrix.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/routing/my-custom.yaml"
+  },
+  {
+    "name": "  ollama",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped ollama.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/ollama.yaml"
+  },
+  {
+    "name": "  openai",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped openai.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/openai.yaml"
+  },
+  {
+    "name": "  openai-knob-consistent",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped openai-knob-consistent.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/openai-knob-consistent.yaml"
+  },
+  {
+    "name": "  quality",
+    "enabled": false,
+    "behaviors": [
+      "available"
+    ],
+    "config_summary": {
+      "description": "Shipped quality.",
+      "compatibility": "2/2 roles",
+      "updated": "2026-09-02"
+    },
+    "matrix_file": "~/.amplifier/cache/amplifier-bundle-routing-matrix-test/routing/quality.yaml"
+  }
+]
+
+$ amplifier routing show
+[exit 0]
+
+  Matrix: balanced
+  Shipped balanced.
+  Updated: 2026-09-02
+
+  fast — Quick tasks
+    ★ anthropic / claude-haiku-*  ← active
+
+  general — Catch-all
+    ★ anthropic / claude-sonnet-*  ← active
+
+$ amplifier routing show balanced
+[exit 0]
+
+  Matrix: balanced
+  Shipped balanced.
+  Updated: 2026-09-02
+
+  fast — Quick tasks
+    ★ anthropic / claude-haiku-*  ← active
+
+  general — Catch-all
+    ★ anthropic / claude-sonnet-*  ← active
+
+$ amplifier routing show balanced --detailed
+[exit 0]
+
+  Matrix: balanced
+  Shipped balanced.
+  Updated: 2026-09-02
+
+  fast — Quick tasks
+    ★ anthropic / claude-haiku-*  ← active
+
+  general — Catch-all
+    ★ anthropic / claude-sonnet-*  ← active
+
+$ amplifier routing show balanced --compact
+[exit 0]
+            Routing: balanced            
+┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Role    ┃ Model           ┃ Provider  ┃
+┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ fast    │ claude-haiku-*  │ anthropic │
+│ general │ claude-sonnet-* │ anthropic │
+└─────────┴─────────────────┴───────────┘
+
+Providers: anthropic (★)
+
+$ amplifier routing show my-custom
+[exit 0]
+
+  Matrix: my-custom
+  Custom matrix.
+  Updated: 2026-09-02
+
+  fast — Quick tasks
+    ★ anthropic / claude-haiku-*  ← active
+
+  general — Catch-all
+    ★ anthropic / claude-sonnet-*  ← active
+
+$ amplifier routing show nonexistent
+[exit 0]
+Matrix 'nonexistent' not found. Available: anthropic, balanced, copilot, economy, gemini, my-custom,
+ollama, openai, openai-knob-consistent, quality
+
+$ amplifier routing use balanced
+[exit 0]
+✓ Routing matrix set to 'balanced' (global scope)
+            Routing: balanced            
+┏━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
+┃ Role    ┃ Model           ┃ Provider  ┃
+┡━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
+│ fast    │ claude-haiku-*  │ anthropic │
+│ general │ claude-sonnet-* │ anthropic │
+└─────────┴─────────────────┴───────────┘
+
+Providers: anthropic (★)

--- a/docs/lanes/teel-routing-cli-identity/fail-before.txt
+++ b/docs/lanes/teel-routing-cli-identity/fail-before.txt
@@ -1,0 +1,46 @@
+FAIL-BEFORE at parent commit 3bb010409b7b41e693d8c0aa59c3fcb90be9217a (2026-09-06T09:38:07Z)
+command: uv run pytest tests/test_routing_cli_runtime_identity.py -q
+
+tests/test_routing_cli_runtime_identity.py:430: KeyError
+----------------------------- Captured stdout call -----------------------------
+⚠ Could not resolve provider module 'provider-anthropic' for entry 
+'provider-anthropic' -- skipping plaintext-secret scan for this entry.
+⚠ Could not resolve provider module 'provider-anthropic' for entry 
+'provider-anthropic' -- skipping plaintext-secret scan for this entry.
+=========================== short test summary info ============================
+FAILED tests/test_routing_cli_runtime_identity.py::TestLiveMatrixWithNoDeclaredName::test_list_reports_the_live_matrix_as_present
+FAILED tests/test_routing_cli_runtime_identity.py::TestLiveMatrixWithNoDeclaredName::test_list_reports_the_live_matrix_as_active
+FAILED tests/test_routing_cli_runtime_identity.py::TestLiveMatrixWithNoDeclaredName::test_console_listing_never_says_zero_active
+FAILED tests/test_routing_cli_runtime_identity.py::TestLiveMatrixWithNoDeclaredName::test_show_renders_the_live_matrix_instead_of_not_found
+FAILED tests/test_routing_cli_runtime_identity.py::TestLiveMatrixWithNoDeclaredName::test_bare_show_follows_the_active_setting_to_the_live_matrix
+FAILED tests/test_routing_cli_runtime_identity.py::TestLiveMatrixWithNoDeclaredName::test_show_detailed_titles_the_matrix_by_the_stem_the_runtime_uses
+FAILED tests/test_routing_cli_runtime_identity.py::TestLiveMatrixWithNoDeclaredName::test_show_compact_titles_the_matrix_by_the_stem
+FAILED tests/test_routing_cli_runtime_identity.py::TestLiveMatrixWithNoDeclaredName::test_use_accepts_the_stem_the_runtime_resolves
+FAILED tests/test_routing_cli_runtime_identity.py::TestLiveMatrixWithNoDeclaredName::test_absent_name_is_not_reported_as_a_disagreement
+FAILED tests/test_routing_cli_runtime_identity.py::TestCliAndRuntimeCannotDiverge::test_row_set_equals_the_runtime_resolvable_set_with_a_nameless_matrix
+FAILED tests/test_routing_cli_runtime_identity.py::TestMismatchedNameStillWarns::test_show_titles_a_mismatched_matrix_by_its_stem_not_its_declared_name
+FAILED tests/test_routing_cli_runtime_identity.py::TestRuntimeSelectionUnchanged::test_the_row_points_at_the_file_the_runtime_would_load
+12 failed, 16 passed in 0.43s
+
+=== live CLI reproduction at 3bb010409b7b41e693d8c0aa59c3fcb90be9217a (otr's measured output) ===
+### routing.matrix = anthropic-knob-consistent  (file exists, runtime loads it)
+
+--- amplifier routing list ---
+── routing matrices (0 active, 9 disabled) ──
+  [off]    anthropic  (available)  ← disabled
+  [off]    balanced  (available)  ← disabled
+  [off]    copilot  (available)  ← disabled
+  [off]    economy  (available)  ← disabled
+  [off]    gemini  (available)  ← disabled
+  [off]    ollama  (available)  ← disabled
+  [off]    openai  (available)  ← disabled
+  [off]    openai-knob-consistent  (available)  ← disabled
+  [off]    quality  (available)  ← disabled
+
+--- amplifier routing show ---
+Matrix 'anthropic-knob-consistent' not found. Available: anthropic, balanced, 
+copilot, economy, gemini, ollama, openai, openai-knob-consistent, quality
+
+--- amplifier routing show anthropic-knob-consistent ---
+Matrix 'anthropic-knob-consistent' not found. Available: anthropic, balanced, 
+copilot, economy, gemini, ollama, openai, openai-knob-consistent, quality

--- a/docs/lanes/teel-routing-cli-identity/pass-after.txt
+++ b/docs/lanes/teel-routing-cli-identity/pass-after.txt
@@ -1,0 +1,43 @@
+PASS-AFTER on branch lane/teel-routing-cli-identity (2026-09-06T09:42:42Z)
+command: uv run pytest tests/test_routing_cli_runtime_identity.py -q
+
+............................                                                                 [100%]
+28 passed in 0.61s
+
+=== same tree, same commands, after the fix ===
+### routing.matrix = anthropic-knob-consistent  (file exists, runtime loads it)
+
+--- amplifier routing list ---
+── routing matrices (1 active, 9 disabled) ──
+  [off]    anthropic  (available)  ← disabled
+  [on]  → anthropic-knob-consistent  (active)
+  [off]    balanced  (available)  ← disabled
+  [off]    copilot  (available)  ← disabled
+  [off]    economy  (available)  ← disabled
+  [off]    gemini  (available)  ← disabled
+  [off]    ollama  (available)  ← disabled
+  [off]    openai  (available)  ← disabled
+  [off]    openai-knob-consistent  (available)  ← disabled
+  [off]    quality  (available)  ← disabled
+
+--- amplifier routing show ---
+Matrix: anthropic-knob-consistent
+  Knob-consistent anthropic routing.
+  Updated: 2026-09-02
+
+  fast — Quick tasks
+    ★ anthropic / claude-haiku-*  ← active
+
+  general — Catch-all
+    ★ anthropic / claude-sonnet-*  ← active
+
+--- amplifier routing show anthropic-knob-consistent ---
+Matrix: anthropic-knob-consistent
+  Knob-consistent anthropic routing.
+  Updated: 2026-09-02
+
+  fast — Quick tasks
+    ★ anthropic / claude-haiku-*  ← active
+
+  general — Catch-all
+    ★ anthropic / claude-sonnet-*  ← active

--- a/tests/test_routing_cli_runtime_identity.py
+++ b/tests/test_routing_cli_runtime_identity.py
@@ -1,0 +1,542 @@
+"""`routing list`/`show` must agree with the runtime about which matrices exist.
+
+MEASURED DEFECT (lane otr, 2026-09-06). With ``routing.matrix =
+anthropic-knob-consistent`` in effect and the session actively routing 13
+agents through it, the CLI said::
+
+    Matrix 'anthropic-knob-consistent' not found
+    0 active, 9 disabled
+
+That is the tool an operator reaches for *precisely when routing is
+misbehaving*, telling them the opposite of the truth.
+
+WHY IT HAPPENS. Two identities, one of which the runtime does not have:
+
+* the runtime resolves a matrix by **file stem** -- ``resolve_matrix_source()``
+  builds ``f"{name}.yaml"`` and loads the first hit. ``load_matrix()`` requires
+  only that the file parse to a mapping, and ``validate_matrix()`` requires
+  ``general``/``fast`` roles. **Neither reads the YAML's ``name:`` field at
+  all**; as of routing-matrix ``972b0ce``, ``matrix_loader.py`` and
+  ``resolver_class.py`` contain no read of it.
+* the CLI dropped any matrix whose YAML lacked a ``name:`` key::
+
+      if data and "name" in data:
+          matrices[stem] = (data, path)
+
+  A file with no ``name:`` is fully loadable and routable by the runtime, and
+  invisible to the CLI. Dropped from ``list`` (so a live matrix contributes to
+  neither the active nor the disabled count) and "not found" in ``show``.
+
+PR #294 fixed the *keying* -- rows moved from the YAML's ``name:`` to the file
+stem. It left the *existence gate* on ``name:``, which is the half that
+produces the measured output above. This file pins the gate.
+
+The invariant, stated once: **a stem the runtime can resolve is a stem the CLI
+lists.** :class:`TestCliAndRuntimeCannotDiverge` asserts exactly that,
+comparing the CLI's row set against the runtime's own resolver rather than
+against a hand-written expectation.
+
+About ``_STAND_IN_MATRIX_LOADER``: hooks-routing is a *bundle* module, not a
+distribution this repo depends on, so there is nothing to import in a test
+environment. It is imported here from ``test_routing_winner_selection`` rather
+than copied, so the two files cannot drift apart -- see that module's docstring
+for its provenance (routing-matrix ``d17d03c``, PR #52).
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+from click.testing import CliRunner
+
+from test_routing_winner_selection import (  # type: ignore[import-not-found]
+    _STAND_IN_MATRIX_LOADER,
+    _discovered,
+    _make_bundle,
+    _make_settings,
+    _matrix,
+)
+
+# The nine matrices the routing-matrix bundle ships (972b0ce), so the
+# reproduction below produces otr's "9 disabled" literally rather than
+# approximately.
+SHIPPED = (
+    "anthropic",
+    "balanced",
+    "copilot",
+    "economy",
+    "gemini",
+    "ollama",
+    "openai-knob-consistent",
+    "openai",
+    "quality",
+)
+
+LIVE_STEM = "anthropic-knob-consistent"
+
+
+# ---------------------------------------------------------------------------
+# Tree fixtures
+# ---------------------------------------------------------------------------
+
+
+def _no_name(description: str) -> dict:
+    """A valid, runtime-loadable matrix that simply carries no ``name:``.
+
+    ``validate_matrix()`` requires ``general`` and ``fast`` roles; ``_matrix``
+    supplies both. Nothing in the runtime asks for ``name:``.
+    """
+    data = _matrix("ignored", description)
+    del data["name"]
+    return data
+
+
+def _host_tree(tmp_path: Path, live: dict | None = None) -> Path:
+    """The measured host: nine shipped matrices + one live user matrix."""
+    _make_bundle(tmp_path, matrices={stem: f"Shipped {stem}." for stem in SHIPPED})
+    user_dir = tmp_path / ".amplifier" / "routing"
+    user_dir.mkdir(parents=True, exist_ok=True)
+    if live is not None:
+        (user_dir / f"{LIVE_STEM}.yaml").write_text(yaml.dump(live))
+    return user_dir
+
+
+def _invoke(tmp_path: Path, args: list[str], *, active: str | None = None):
+    """Run a routing subcommand, optionally with ``routing.matrix`` set.
+
+    ``active`` is written to the top-level ``routing:`` key -- the one
+    ``get_routing_config()`` reads and the one hooks-routing appends
+    ``.yaml`` to.
+    """
+    from amplifier_app_cli.commands import routing as routing_mod
+
+    settings = _make_settings(tmp_path)
+    if active is not None:
+        scope = settings._read_scope("global")
+        scope["routing"] = {"matrix": active}
+        settings._write_scope("global", scope)
+
+    with (
+        patch.object(routing_mod, "_get_settings", return_value=settings),
+        patch.object(
+            routing_mod, "_discover_matrix_files", return_value=_discovered(tmp_path)
+        ),
+        patch.object(routing_mod.Path, "home", return_value=tmp_path),
+    ):
+        return CliRunner().invoke(routing_mod.routing_group, args)
+
+
+def _flat(output: str) -> str:
+    """Collapse Rich's console wrapping so substring asserts are width-proof."""
+    return " ".join(output.split())
+
+
+def _row_key(rendered_name: str) -> str:
+    """Strip the ``→ `` active marker and any ``⚠ ...`` suffixes from a row."""
+    name = rendered_name.strip().removeprefix("→ ").strip()
+    return name.split("  ")[0].strip()
+
+
+def _rows(tmp_path: Path, *, active: str | None = None) -> dict[str, dict]:
+    """`routing list --format json`, keyed by the row's bare name."""
+    result = _invoke(tmp_path, ["list", "--format", "json"], active=active)
+    assert result.exit_code == 0, result.output
+    return {_row_key(item["name"]): item for item in json.loads(result.output)}
+
+
+# ---------------------------------------------------------------------------
+# The runtime's own answer, asked directly
+# ---------------------------------------------------------------------------
+
+
+def _runtime_resolvable(tmp_path: Path, stems: list[str]) -> set[str]:
+    """Which stems hooks-routing would actually resolve, per its own function.
+
+    ``resolve_matrix_source`` is obtained through *production's own*
+    ``load_resolve_matrix_source`` -- the same call ``routing list`` makes --
+    so this asks the runtime rather than re-deriving its rule in the test.
+    """
+    from amplifier_app_cli.lib.routing_provenance import (
+        classify_routing_dirs,
+        load_resolve_matrix_source,
+    )
+
+    matrix_files = _discovered(tmp_path)
+    custom_dirs, bundle_dirs = classify_routing_dirs(matrix_files)
+    resolve = load_resolve_matrix_source(bundle_dirs)
+    assert resolve is not None, "fixture bundle must carry matrix_loader.py"
+
+    resolvable = set()
+    for stem in stems:
+        source = resolve(stem, custom_dirs, bundle_dirs[0])
+        if source.path is not None:
+            resolvable.add(stem)
+    return resolvable
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity: the runtime really does not need `name:`
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeDoesNotReadDeclaredName:
+    """If the runtime DID require ``name:``, dropping the row would be right.
+
+    These gate the rest of the file: they prove the CLI's old requirement was
+    the CLI's own invention, not a rule inherited from the loader.
+    """
+
+    def test_stand_in_loader_resolves_a_file_that_has_no_name_field(self, tmp_path):
+        _host_tree(tmp_path, live=_no_name("Knob-consistent anthropic routing."))
+
+        assert LIVE_STEM in _runtime_resolvable(tmp_path, [LIVE_STEM])
+
+    def test_stand_in_loader_source_never_reads_the_declared_name(self, tmp_path):
+        """The contract in prose, pinned against the fixture's own source."""
+        assert '"name"' not in _STAND_IN_MATRIX_LOADER.replace("name: str", "")
+        # It keys on the requested stem, and only on that.
+        assert 'filename = f"{name}.yaml"' in _STAND_IN_MATRIX_LOADER
+
+
+# ---------------------------------------------------------------------------
+# The measured defect
+# ---------------------------------------------------------------------------
+
+
+class TestLiveMatrixWithNoDeclaredName:
+    """otr's measured contradiction, reproduced end to end.
+
+    Fail-before, at parent commit ``3bb0104``::
+
+        ── routing matrices (0 active, 9 disabled) ──
+        Matrix 'anthropic-knob-consistent' not found. Available: anthropic, ...
+    """
+
+    def test_list_reports_the_live_matrix_as_present(self, tmp_path):
+        _host_tree(tmp_path, live=_no_name("Knob-consistent anthropic routing."))
+
+        rows = _rows(tmp_path, active=LIVE_STEM)
+
+        assert LIVE_STEM in rows, (
+            "the live matrix is missing from `routing list` -- this is otr's "
+            "'0 active, 9 disabled' against a matrix that was routing 13 agents"
+        )
+        assert set(rows) == {*SHIPPED, LIVE_STEM}
+
+    def test_list_reports_the_live_matrix_as_active(self, tmp_path):
+        _host_tree(tmp_path, live=_no_name("Knob-consistent anthropic routing."))
+
+        rows = _rows(tmp_path, active=LIVE_STEM)
+
+        assert rows[LIVE_STEM]["enabled"] is True
+        assert rows[LIVE_STEM]["behaviors"] == ["active"]
+
+    def test_console_listing_never_says_zero_active(self, tmp_path):
+        _host_tree(tmp_path, live=_no_name("Knob-consistent anthropic routing."))
+
+        result = _invoke(tmp_path, ["list"], active=LIVE_STEM)
+
+        assert result.exit_code == 0, result.output
+        flat = _flat(result.output)
+        assert "0 active" not in flat
+        assert "1 active" in flat
+        assert LIVE_STEM in flat
+
+    def test_show_renders_the_live_matrix_instead_of_not_found(self, tmp_path):
+        _host_tree(tmp_path, live=_no_name("Knob-consistent anthropic routing."))
+
+        result = _invoke(tmp_path, ["show", LIVE_STEM], active=LIVE_STEM)
+
+        assert result.exit_code == 0, result.output
+        assert "not found" not in _flat(result.output)
+
+    def test_bare_show_follows_the_active_setting_to_the_live_matrix(self, tmp_path):
+        """`routing show` with no argument reads ``routing.matrix``."""
+        _host_tree(tmp_path, live=_no_name("Knob-consistent anthropic routing."))
+
+        result = _invoke(tmp_path, ["show"], active=LIVE_STEM)
+
+        assert result.exit_code == 0, result.output
+        assert "not found" not in _flat(result.output)
+
+    def test_show_detailed_titles_the_matrix_by_the_stem_the_runtime_uses(
+        self, tmp_path
+    ):
+        """Never ``Matrix: unknown`` -- that is the same lie in a quieter voice."""
+        _host_tree(tmp_path, live=_no_name("Knob-consistent anthropic routing."))
+
+        result = _invoke(tmp_path, ["show", LIVE_STEM, "--detailed"], active=LIVE_STEM)
+
+        assert result.exit_code == 0, result.output
+        flat = _flat(result.output)
+        assert f"Matrix: {LIVE_STEM}" in flat
+        assert "unknown" not in flat
+
+    def test_show_compact_titles_the_matrix_by_the_stem(self, tmp_path):
+        _host_tree(tmp_path, live=_no_name("Knob-consistent anthropic routing."))
+
+        result = _invoke(tmp_path, ["show", LIVE_STEM, "--compact"], active=LIVE_STEM)
+
+        assert result.exit_code == 0, result.output
+        assert f"Routing: {LIVE_STEM}" in _flat(result.output)
+
+    def test_use_accepts_the_stem_the_runtime_resolves(self, tmp_path):
+        _host_tree(tmp_path, live=_no_name("Knob-consistent anthropic routing."))
+
+        result = _invoke(tmp_path, ["use", LIVE_STEM])
+
+        assert result.exit_code == 0, result.output
+        assert f"set to '{LIVE_STEM}'" in _flat(result.output)
+        assert "not found" not in _flat(result.output)
+
+    def test_absent_name_is_not_reported_as_a_disagreement(self, tmp_path):
+        """No ``name:`` is not a MISMATCHED ``name:``.
+
+        The runtime never reads the field, so its absence is unremarkable and
+        must not produce a warning that sends an operator looking for a
+        problem that does not exist.
+        """
+        _host_tree(tmp_path, live=_no_name("Knob-consistent anthropic routing."))
+
+        result = _invoke(tmp_path, ["list"], active=LIVE_STEM)
+        rows = _rows(tmp_path, active=LIVE_STEM)
+
+        assert "file says name:" not in _flat(result.output)
+        assert "declared_name" not in rows[LIVE_STEM]["config_summary"]
+
+
+# ---------------------------------------------------------------------------
+# The invariant, asked of the runtime rather than of a fixture
+# ---------------------------------------------------------------------------
+
+
+class TestCliAndRuntimeCannotDiverge:
+    """Every stem the runtime resolves is a stem the CLI lists, and vice versa.
+
+    This is the pin the deliverable asks for. It compares the CLI's row set
+    against ``resolve_matrix_source()`` -- the runtime's own function, loaded
+    out of the cached bundle -- so it cannot be satisfied by teaching the test
+    the same wrong answer as the code.
+
+    The identity lives in another repo (``matrix_loader.py`` in
+    amplifier-bundle-routing-matrix), so this pins the CLI side against the
+    documented keying rather than editing across the boundary.
+    """
+
+    def test_row_set_equals_the_runtime_resolvable_set_with_a_nameless_matrix(
+        self, tmp_path
+    ):
+        _host_tree(tmp_path, live=_no_name("Knob-consistent anthropic routing."))
+        stems = [*SHIPPED, LIVE_STEM]
+
+        assert set(_rows(tmp_path)) == _runtime_resolvable(tmp_path, stems)
+
+    def test_row_set_equals_the_runtime_resolvable_set_with_a_mismatched_name(
+        self, tmp_path
+    ):
+        _host_tree(tmp_path, live=_matrix("knob-consistent-v3", "Live matrix."))
+        stems = [*SHIPPED, LIVE_STEM]
+
+        assert set(_rows(tmp_path)) == _runtime_resolvable(tmp_path, stems)
+
+    def test_row_set_equals_the_runtime_resolvable_set_on_a_stock_tree(self, tmp_path):
+        _host_tree(tmp_path, live=None)
+
+        assert set(_rows(tmp_path)) == _runtime_resolvable(tmp_path, list(SHIPPED))
+
+    def test_a_stem_the_runtime_cannot_resolve_is_not_listed(self, tmp_path):
+        """Non-vacuity: the comparison above is not trivially true of any set."""
+        _host_tree(tmp_path, live=None)
+
+        assert "nonexistent-matrix" not in _rows(tmp_path)
+        assert _runtime_resolvable(tmp_path, ["nonexistent-matrix"]) == set()
+
+
+# ---------------------------------------------------------------------------
+# A mismatched `name:` still warns (PR #294's behaviour, unchanged)
+# ---------------------------------------------------------------------------
+
+
+class TestMismatchedNameStillWarns:
+    def test_list_still_flags_a_name_that_disagrees_with_the_filename(self, tmp_path):
+        _host_tree(tmp_path, live=_matrix("knob-consistent-v3", "Live matrix."))
+
+        result = _invoke(tmp_path, ["list"], active=LIVE_STEM)
+
+        assert result.exit_code == 0, result.output
+        flat = _flat(result.output)
+        assert "file says name: knob-consistent-v3" in flat
+        assert "routing resolves by filename" in flat
+
+    def test_show_titles_a_mismatched_matrix_by_its_stem_not_its_declared_name(
+        self, tmp_path
+    ):
+        """The header named the identity the runtime does NOT use."""
+        _host_tree(tmp_path, live=_matrix("knob-consistent-v3", "Live matrix."))
+
+        result = _invoke(tmp_path, ["show", LIVE_STEM, "--detailed"], active=LIVE_STEM)
+
+        assert result.exit_code == 0, result.output
+        flat = _flat(result.output)
+        assert f"Matrix: {LIVE_STEM}" in flat
+        assert "Matrix: knob-consistent-v3" not in flat
+        # The declared name is still disclosed -- surfaced, not hidden.
+        assert "file says name: knob-consistent-v3" in flat
+
+
+# ---------------------------------------------------------------------------
+# Runtime selection is UNCHANGED -- this is a reporting fix
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeSelectionUnchanged:
+    def test_list_and_show_never_write_settings(self, tmp_path):
+        """A reporting command that mutated ``routing.matrix`` would be a
+        behaviour change; assert the settings bytes are untouched."""
+        _host_tree(tmp_path, live=_no_name("Knob-consistent anthropic routing."))
+
+        settings_file = tmp_path / "global" / "settings.yaml"
+        _invoke(tmp_path, ["list"], active=LIVE_STEM)
+        before = settings_file.read_bytes()
+
+        _invoke(tmp_path, ["list"], active=LIVE_STEM)
+        _invoke(tmp_path, ["show", LIVE_STEM], active=LIVE_STEM)
+        _invoke(tmp_path, ["show"], active=LIVE_STEM)
+
+        assert settings_file.read_bytes() == before
+
+    def test_the_winning_path_per_stem_is_untouched_by_this_change(self, tmp_path):
+        """``resolve_winning_paths`` decides which FILE the runtime reads.
+
+        The fix changes which rows survive, never which file a row points at.
+        """
+        from amplifier_app_cli.lib.routing_provenance import resolve_winning_paths
+
+        user = _host_tree(tmp_path, live=_no_name("Knob-consistent anthropic routing."))
+
+        winners = resolve_winning_paths(_discovered(tmp_path))
+
+        assert winners[LIVE_STEM] == user / f"{LIVE_STEM}.yaml"
+        for stem in SHIPPED:
+            assert winners[stem].name == f"{stem}.yaml"
+            assert ".amplifier/routing" not in winners[stem].as_posix()
+
+    def test_the_row_points_at_the_file_the_runtime_would_load(self, tmp_path):
+        _host_tree(tmp_path, live=_no_name("Knob-consistent anthropic routing."))
+
+        rows = _rows(tmp_path, active=LIVE_STEM)
+
+        assert (
+            rows[LIVE_STEM]["matrix_file"] == f"~/.amplifier/routing/{LIVE_STEM}.yaml"
+        )
+
+
+# ---------------------------------------------------------------------------
+# No regression for the common case
+# ---------------------------------------------------------------------------
+
+
+class TestAgreeingTreeUnchanged:
+    """A tree where every stem agrees with its ``name:`` must not move.
+
+    The golden strings below are the output at parent commit ``3bb0104``,
+    captured before the change. Any drift in the common case fails here.
+    """
+
+    def _agreeing(self, tmp_path: Path) -> None:
+        _make_bundle(tmp_path, matrices={stem: f"Shipped {stem}." for stem in SHIPPED})
+
+    def test_console_listing_is_byte_identical(self, tmp_path):
+        self._agreeing(tmp_path)
+
+        result = _invoke(tmp_path, ["list"], active="balanced")
+
+        assert result.exit_code == 0, result.output
+        rendered = [
+            line
+            for line in result.output.splitlines()
+            if "plaintext-secret" not in line
+            and "Could not resolve provider" not in line
+            and line.strip()
+        ]
+        assert rendered == [
+            "── routing matrices (1 active, 8 disabled) ──",
+            "  [off]    anthropic  (available)  ← disabled",
+            "  [on]  → balanced  (active)",
+            "  [off]    copilot  (available)  ← disabled",
+            "  [off]    economy  (available)  ← disabled",
+            "  [off]    gemini  (available)  ← disabled",
+            "  [off]    ollama  (available)  ← disabled",
+            "  [off]    openai  (available)  ← disabled",
+            "  [off]    openai-knob-consistent  (available)  ← disabled",
+            "  [off]    quality  (available)  ← disabled",
+        ]
+
+    def test_no_warning_footers_on_an_agreeing_tree(self, tmp_path):
+        self._agreeing(tmp_path)
+
+        result = _invoke(tmp_path, ["list"], active="balanced")
+
+        assert "file says name:" not in result.output
+        assert "shadow" not in result.output
+
+    def test_show_header_is_unchanged_when_stem_and_name_agree(self, tmp_path):
+        """Titling by stem is a no-op exactly when the two agree."""
+        self._agreeing(tmp_path)
+
+        result = _invoke(
+            tmp_path, ["show", "balanced", "--detailed"], active="balanced"
+        )
+
+        assert result.exit_code == 0, result.output
+        flat = _flat(result.output)
+        assert "Matrix: balanced" in flat
+        assert "Shipped balanced." in flat
+
+    def test_json_rows_carry_no_declared_name_when_they_agree(self, tmp_path):
+        self._agreeing(tmp_path)
+
+        rows = _rows(tmp_path, active="balanced")
+
+        assert set(rows) == set(SHIPPED)
+        for stem in SHIPPED:
+            assert "declared_name" not in rows[stem]["config_summary"]
+
+
+# ---------------------------------------------------------------------------
+# A file the runtime cannot load must still be dropped
+# ---------------------------------------------------------------------------
+
+
+class TestUnloadableFilesStillDropped:
+    """The gate loosens to the runtime's rule -- it does not disappear.
+
+    ``load_matrix()`` raises unless the file parses to a mapping, so a
+    non-mapping or empty file is unloadable for the runtime too and must not
+    gain a row.
+    """
+
+    def test_a_non_mapping_file_is_not_listed(self, tmp_path):
+        user = _host_tree(tmp_path, live=None)
+        (user / f"{LIVE_STEM}.yaml").write_text("[not, a, mapping]\n")
+
+        assert LIVE_STEM not in _rows(tmp_path)
+
+    def test_an_empty_file_is_not_listed(self, tmp_path):
+        user = _host_tree(tmp_path, live=None)
+        (user / f"{LIVE_STEM}.yaml").write_text("")
+
+        assert LIVE_STEM not in _rows(tmp_path)
+
+    def test_an_unparseable_file_is_not_listed(self, tmp_path):
+        user = _host_tree(tmp_path, live=None)
+        (user / f"{LIVE_STEM}.yaml").write_text("{[: unbalanced\n")
+
+        assert LIVE_STEM not in _rows(tmp_path)
+
+    def test_the_shipped_matrices_survive_a_broken_neighbour(self, tmp_path):
+        user = _host_tree(tmp_path, live=None)
+        (user / f"{LIVE_STEM}.yaml").write_text("[not, a, mapping]\n")
+
+        assert set(_rows(tmp_path)) == set(SHIPPED)


### PR DESCRIPTION
## The defect

`amplifier routing list|show` told an operator the **opposite of the truth** about a matrix that was actively routing every agent in the session. Measured on a live host by lane `otr`, with `routing.matrix = anthropic-knob-consistent` in effect and the session resolving **13 agents** through it:

```
Matrix 'anthropic-knob-consistent' not found
0 active, 9 disabled
```

This is the tool a human reaches for *precisely when routing is misbehaving* — the moment "not found / 0 active" is most expensive. It invites exactly the wrong next action (re-point config, re-copy the file, disable the preset) against a system that was working.

## Root cause — and it is not the one the report inferred

The report attributed it to the CLI keying on the YAML's internal `name:` while the runtime keys on the **file stem**. **PR #294 (`8c4ad7a`) already fixed that half** — rows have been keyed by stem since 2026-09-02. What #294 left behind is the **existence gate**:

```python
if data and "name" in data:
    matrices[stem] = (data, path)
```

The runtime never reads that field. Checked, not assumed, against the cached bundle at `972b0ce`:

| Runtime function | What it actually requires |
|---|---|
| `resolve_matrix_source(name, …)` | builds `f"{name}.yaml"` — the **stem**, first hit in `[*custom_routing_dirs, bundle routing/]` |
| `load_matrix(path)` | only that the file parse to a **mapping** |
| `validate_matrix(matrix)` | `general` + `fast` roles, per-role `description`/`candidates` |

`grep '"name"' matrix_loader.py resolver_class.py` returns **nothing**. Its own docstring (`matrix_loader.py:41-43`) says the resolved name is the file stem and *"not necessarily the `name:` field declared inside the YAML"*.

So a valid, loadable, actively-routing matrix that simply carried no `name:` was **dropped from the CLI entirely** — no row in `list` (contributing to neither the active nor the disabled count, hence `0 active`) and `not found` in `show`. That requirement was the CLI's own invention.

## Before / after — same tree, same commands

**At the parent commit `3bb0104`:**
```
── routing matrices (0 active, 9 disabled) ──
  [off]    anthropic  (available)  ← disabled
  …
$ amplifier routing show
Matrix 'anthropic-knob-consistent' not found. Available: anthropic, balanced, …
```

**On this branch:**
```
── routing matrices (1 active, 9 disabled) ──
  [on]  → anthropic-knob-consistent  (active)

$ amplifier routing show
Matrix: anthropic-knob-consistent
  Knob-consistent anthropic routing.
```

## The change — reporting path only, three edits

1. **The existence gate becomes the loader's own rule.** `if data and "name" in data` → `if isinstance(data, dict) and data`. A matrix exists for the CLI exactly when the runtime can load it. An empty, non-mapping or unparseable file still gets **no** row — the runtime cannot load it either, and widening past that would be the same class of lie in the other direction.
2. **`_disagreeing_name()`** distinguishes a `name:` that is **absent** from one that **disagrees**. Absence draws no warning: the runtime never reads the field, so warning about it would send an operator hunting a problem that does not exist — the same wasted trip the "not found" message caused. A genuine mismatch still warns exactly as #294 made it.
3. **`show` headings name the stem the runtime resolved**, not `data["name"]` — which printed a string the runtime never reads, and rendered as the actively misleading `Matrix: unknown` for a file with no `name:`. `routing edit`'s unsaved working copy has no stem to offer and keeps its previous heading.

The report offered three candidate fixes. This is **(1)** — one source of truth, both keying *and* existence derived from the runtime's rule. **(3)** (validate and warn) was already present and is kept, narrowed to fire on real disagreement only. **(2)** (report both identities co-equally) was rejected: it implies the declared name has standing in resolution, and it has none.

## Runtime selection is UNCHANGED

This is a reporting fix. `resolve_winning_paths()` still decides which **file** a stem loads; this changes only which rows survive to be shown. `TestRuntimeSelectionUnchanged` pins that the settings bytes and the per-stem winner are identical across `list`/`show`, and that reporting commands never write settings.

## The cross-repo boundary — reported, not crossed

The runtime identity lives in `matrix_loader.py` in **amplifier-bundle-routing-matrix**. **Nothing there was edited.**

**What a matching change in that repo would need to be: none.** The runtime's rule was already correct and already documented; the CLI was the half that disagreed, and the CLI is the half that moved.

`TestCliAndRuntimeCannotDiverge` pins the CLI side by **asking that function directly** — obtained through production's own `load_resolve_matrix_source()` — and asserting the CLI's row set equals the set the runtime resolves. It cannot be satisfied by teaching the test the same wrong answer as the code, and a non-vacuity case pins that an unresolvable stem is absent from both sides.

Two optional suggestions for that repo's owner, neither required here: export the identity rule as a function so the CLI can import it rather than mirror it; and warn at load time on a `name:`/stem disagreement (the runtime is still silent, so a user who never runs `routing list` never learns the field is decorative).

## No regression for the common case — byte-identical

Nine invocations (`list`, `list --format json`, bare `show`, `show <stem>`, `--detailed`, `--compact`, a custom matrix, the not-found path, `use`) against an agreeing tree, captured at the parent commit and on this branch by stash-compare at a fixed width:

```
parent: 6497 bytes   branch: 6497 bytes
diff -u before after  ->  BYTE-IDENTICAL
```

Re-verified after `ruff format`. Held in-test by `TestAgreeingTreeUnchanged`, which pins the agreeing-tree listing as an exact golden literal. Titling by stem is a no-op *exactly* when stem and `name:` agree, which is why the common case cannot move.

## Tests

`tests/test_routing_cli_runtime_identity.py`, 28 tests:

- **fail-before at `3bb0104`: 12 failed, 16 passed** — the 16 that pass are the stock-tree and non-vacuity gates, which *should* pass at the parent; the 12 are the defect.
- **after: 28 passed.**

## Full suite

```
parent 3bb0104 : 2 failed, 1776 passed, 1 skipped, 13 deselected, 1 xfailed
this branch    : 2 failed, 1804 passed, 1 skipped, 13 deselected, 1 xfailed
```

+28 = exactly the new file. No test changed status in either direction.

**The 2 failures are pre-existing and unrelated**, identical at the parent commit. Root-caused rather than waved past: the highway exports `HIGHWAY_TMUX_SOCKET` into every lane session, and `test_ten_lane_highway_socket_default.py::_derived_socket` shells out with no `env=`, so the `${HIGHWAY_TMUX_SOCKET:-…}` default branch those two tests exist to exercise is never taken:

```
$ echo $HIGHWAY_TMUX_SOCKET                                       -> hw-model-performance
$ uv run pytest tests/test_ten_lane_highway_socket_default.py -q  -> 2 failed, 9 passed
$ env -u HIGHWAY_TMUX_SOCKET uv run pytest … -q                   -> 11 passed
```

CI does not see it (no such variable on GitHub runners), so it is green there and red only for the lanes that run it. Filed as `model_performance-etuz`, linked discovered-from this item; not fixed here, as that file is outside this lane's owned paths.

## Spend

**$0.00** against a $0.00 authority (`0 runs × 0 arms × $0.00 / 1.00`). Pure code-and-test change: no API calls, no containers, no DTU, no eval runs, no infrastructure created.

---

Item: `model_performance-teel`. Lane note with full evidence: `docs/lanes/teel-routing-cli-identity/DONE-NOTE.md`.
