### PR TITLE
fix(ten-lane-highway): report infra-ledger rows no live lane owns (ye80)

### DIFF
--- a/amplifier_app_cli/data/skills/ten-lane-highway/SKILL.md
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/SKILL.md
@@ -113,6 +113,21 @@ perform that teardown. A REAL teardown failure still exits non-zero and leaves
 the row open; the already-gone signature is deliberately narrow, so the signal
 that a teardown genuinely failed is never lost.
 
+**`highway_status.sh` reports `orphan_rows=N owned by: <lane>(n)`** — open
+ledger rows whose owning lane is **not live**. On 2026-09-05 a tmux server
+restart killed three lanes at once and left six DTU containers RUNNING with
+open rows; the ledger recorded all six correctly and the status report showed
+the lanes ENDED, but **nothing joined the two**, so the manager found the
+containers only by running `incus list` by hand. A non-zero `orphan_rows` means
+infrastructure with nothing driving it (Rule 14) — reclaim each named lane with
+`lane_teardown.sh BATCH_DIR <lane> teardown --yes`. The report **destroys
+nothing**: a false positive that prints is a nuisance, a false positive that
+destroys is another 0rg. A **live** lane's rows are never counted. Owners are
+matched by exact lane name, else by a unique lane-name prefix (so a row claimed
+with the short work-item id `vbs` still resolves to lane `vbs-…`); an owner
+that matches no lane, matches ambiguously, or is unclaimed is reported as such
+rather than guessed at.
+
 State lives in `BATCH_DIR` (create one per highway, e.g. `~/dev/hw-<name>`):
 `manifest.tsv` (scripts write), `HIGHWAY.md` (you write), `goals/` (pre-composed
 goal files), `lanes/` (worktrees), `.width` (authoritative width), `infra.tsv`

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh
@@ -56,6 +56,8 @@ BATCH=$(printf '%s' "$(basename "$BATCH_DIR")" | tr -c 'A-Za-z0-9_-' '_')
 
 now=$(date +%s)
 live=0; ended=0; done_n=0; stalled=0; gone=0
+# Lane-name sets for the ORPHAN-ROWS join below (newline-joined, awk splits them).
+live_lanes=""; all_lanes=""
 
 [ "$JSON" = 1 ] || printf '%-20s %-6s %-9s %-6s %-5s %-14s %s\n' LANE TMUX LOG_AGE AHEAD DONE FLAG WORKTREE
 while IFS=$'\t' read -r lane wt branch base tmuxn goal log ts; do
@@ -72,11 +74,14 @@ while IFS=$'\t' read -r lane wt branch base tmuxn goal log ts; do
     wt_present=no
   fi
 
+  all_lanes="$all_lanes$lane"$'\n'
+
   flag=""
   if [ "$st" = "LIVE" ]; then
     # A live tmux-session counts as a live lane even if its worktree vanished —
     # that is an anomaly to flag, not a lane to ignore.
     live=$((live+1))
+    live_lanes="$live_lanes$lane"$'\n'
     if [ "$wt_present" = "no" ]; then flag="NO-WORKTREE"; fi
     if [ "$age" != "-" ] && [ "${age%s}" -gt "$STALL_SECS" ]; then flag="STALLED"; stalled=$((stalled+1)); fi
   else
@@ -96,21 +101,108 @@ done < "$MANIFEST"
 WD="hw-watchdog__${BATCH}"
 if tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "$WD" 2>/dev/null; then wd_st=LIVE; else wd_st=DEAD; fi
 
+# --- ORPHAN ROWS (model_performance-ye80) -----------------------------------
+# Join lane liveness (above) to infra-ledger row ownership. Nothing else does.
+#
+# WHY: on 2026-09-05 a tmux server restart killed three lanes at once and left
+# SIX DTU containers RUNNING with open ledger rows. Every part was working: the
+# ledger recorded all six correctly, and this script reported the lanes ENDED.
+# The two were simply never joined, so nobody could see "infrastructure with
+# nothing driving it" (Rule 14) without running `incus list` by hand -- which is
+# how the manager eventually found them.
+#
+# REPORTING ONLY. This block destroys nothing, writes nothing, and touches no
+# ledger row. Reaping is deliberately NOT done here: a false positive that
+# merely prints is a nuisance, a false positive that destroys is another 0rg.
+#
+# A LIVE lane's rows are NEVER counted. That is the load-bearing property --
+# the reason this is a `live[]` lookup and not a "did the lane finish" guess.
+#
+# OWNER-NAME RESOLUTION, and why it is not a string equality. The two sides of
+# this join disagree about what a lane is called, measured in this batch's own
+# files: infra.owners.tsv holds SHORT work-item ids for 5 of 13 owners
+# (127, 3d2, 6da, k64, vbs) and LONG manifest names for the other 8
+# (drbf-compaction-notice-ab, ...). lane_teardown.sh documents the short form;
+# lanes claim with whichever they have. So an exact-match join would have
+# reported every short-id owner's rows as orphaned -- a false alarm on ~40% of
+# owners, which is how a report gets ignored. Resolution is therefore
+# exact-name, else a UNIQUE token-boundary prefix (`vbs` -> `vbs-...`), and
+# ambiguity is reported as ambiguity rather than guessed at.
+LEDGER_F="$BATCH_DIR/infra.tsv"
+OWNERS_F="$BATCH_DIR/infra.owners.tsv"
+orphan_rows=0
+orphan_owners=""
+if [ -f "$LEDGER_F" ]; then
+  orphan_line=$(awk -F'\t' \
+    -v owners="$OWNERS_F" -v live_s="$live_lanes" -v all_s="$all_lanes" '
+    function resolve(o,   l, hit, cnt) {
+      if (o == "") return ""
+      if (o in all) return o
+      cnt = 0
+      for (l in all) if (index(l, o "-") == 1) { hit = l; cnt++ }
+      if (cnt == 1) return hit
+      if (cnt > 1)  return "\001ambiguous"
+      return ""
+    }
+    BEGIN {
+      n = split(live_s, t, "\n"); for (i = 1; i <= n; i++) if (t[i] != "") live[t[i]] = 1
+      n = split(all_s,  t, "\n"); for (i = 1; i <= n; i++) if (t[i] != "") all[t[i]]  = 1
+      while ((getline line < owners) > 0) {
+        split(line, f, "\t"); if (f[2] != "") own[f[2]] = f[3]
+      }
+      k = 0; total = 0
+    }
+    $4 == "open" && $3 != "" {
+      id = $3
+      owner = (id in own) ? own[id] : ""
+      r = resolve(owner)
+      # A live lane owns it -> driven, not orphaned. The safety property.
+      if (r != "" && r != "\001ambiguous" && (r in live)) next
+      if      (owner == "")          key = "<unclaimed>"
+      else if (r == "\001ambiguous") key = owner "(ambiguous-lane)"
+      else if (r == "")              key = owner "(no-such-lane)"
+      else                           key = r
+      total++
+      if (!(key in cnt)) order[++k] = key
+      cnt[key]++
+    }
+    END {
+      s = ""
+      for (i = 1; i <= k; i++) s = s (s == "" ? "" : ",") order[i] "(" cnt[order[i]] ")"
+      printf "%d\t%s", total, s
+    }
+  ' "$LEDGER_F")
+  orphan_rows=${orphan_line%%$'\t'*}
+  orphan_owners=${orphan_line#*$'\t'}
+fi
+# ---------------------------------------------------------------------------
+
 open=$(( WIDTH - live )); if [ "$open" -lt 0 ]; then open=0; fi
 if [ "$READY" -lt "$open" ]; then deficit=$READY; else deficit=$open; fi
 
 if [ "$JSON" = 1 ]; then
-  printf '{"ts":"%s","batch":"%s","live":%d,"ended":%d,"done_marker":%d,"stalled":%d,"gone":%d,"width":%d,"width_source":"%s","ready":%d,"deficit":%d,"watchdog":"%s"}\n' \
-    "$(date -u +%FT%TZ)" "$BATCH" "$live" "$ended" "$done_n" "$stalled" "$gone" "$WIDTH" "$width_source" "$READY" "$deficit" "$wd_st"
+  # The owner list is ledger-derived text landing inside a JSON string; keep it
+  # to characters that cannot terminate one.
+  oo=$(printf '%s' "$orphan_owners" | tr -c 'A-Za-z0-9_,()<>.:-' '_')
+  printf '{"ts":"%s","batch":"%s","live":%d,"ended":%d,"done_marker":%d,"stalled":%d,"gone":%d,"width":%d,"width_source":"%s","ready":%d,"deficit":%d,"watchdog":"%s","orphan_rows":%d,"orphan_owners":"%s"}\n' \
+    "$(date -u +%FT%TZ)" "$BATCH" "$live" "$ended" "$done_n" "$stalled" "$gone" "$WIDTH" "$width_source" "$READY" "$deficit" "$wd_st" "$orphan_rows" "$oo"
   exit 0
 fi
 
 echo
-echo "SUMMARY batch=$BATCH live=$live ended=$ended done_marker=$done_n stalled=$stalled gone=$gone width=$WIDTH width_source=$width_source ready=$READY watchdog=$wd_st"
+echo "SUMMARY batch=$BATCH live=$live ended=$ended done_marker=$done_n stalled=$stalled gone=$gone width=$WIDTH width_source=$width_source ready=$READY watchdog=$wd_st orphan_rows=$orphan_rows"
 echo "DEFICIT=$deficit"
 if [ "$deficit" -gt 0 ]; then
   echo "ACTION: launch $deficit lane(s) NOW - refill before anything else."
 fi
 if [ "$wd_st" = "DEAD" ]; then
   echo "WARNING: watchdog $WD is not running - do not end the turn until it is."
+fi
+if [ "$orphan_rows" -gt 0 ]; then
+  # The count alone is not actionable: the manager needs the lane name to pass
+  # to the lane-scoped teardown tool.
+  echo "WARNING: orphan_rows=$orphan_rows owned by: $orphan_owners"
+  echo "  Open infra-ledger rows whose owning lane is NOT live - infrastructure"
+  echo "  with nothing driving it (Rule 14). Nothing was destroyed; reclaim each"
+  echo "  with: lane_teardown.sh $BATCH_DIR <lane> teardown --yes"
 fi

--- a/docs/lanes/ye80b-teardown-orphan-rows/DONE-NOTE.md
+++ b/docs/lanes/ye80b-teardown-orphan-rows/DONE-NOTE.md
@@ -253,6 +253,26 @@ divergence there is worse than the footgun.
   wrote to `/home/bkrabach/dev/hw-model-performance`. The incident replay used a
   `cp` of its three state files into `$TMPDIR`.
 
+## Incidental finding — `verify_lane_publication.sh` scrapes outside the block
+
+Worth two lines because it will bite the next lane. The verifier reads **any
+`branch` key anywhere in `DONE.json`** as a publication claim, not just the one
+inside the `publication/v1` block. This lane's suite counts were recorded as
+`deliverables.full_suite_green_in_pr_body.branch`, and the verifier duly
+reported:
+
+```
+WARN: branch microsoft/amplifier-app-cli:1 failed, 1818 passed, … does NOT exist on origin
+```
+
+Renamed here to `suite_on_branch` / `suite_on_parent`; the marker now verifies
+with `warnings=0`. This is precisely the class of guessing
+`check_done_marker_schema.py`'s own docstring was written to end ("DONE.json is
+free-form English and every lane invented its own keys … that guessing produced
+real false alarms"). The schema half now exists; the **verify** half still
+scrapes the whole document. Both tools live in the evals repo, so this is
+recorded, not fixed here.
+
 ## Files
 
 | path | what |

--- a/docs/lanes/ye80b-teardown-orphan-rows/DONE-NOTE.md
+++ b/docs/lanes/ye80b-teardown-orphan-rows/DONE-NOTE.md
@@ -1,0 +1,265 @@
+# Lane ye80b — the teardown footgun and orphaned ledger rows
+
+**Item:** `model_performance-ye80` (project `model_performance`)
+**Repo:** `microsoft/amplifier-app-cli`, branch `lane/ye80b-teardown-orphan-rows`
+**Date:** 2026-09-06
+**Outcome:** **A. RESOLVED** — the orphan-row deliverables are DONE and landed in
+this repo. The near-miss deliverables are **DONE in substance** (fixed, proven
+fail-before/pass-after) but **NOT-LANDABLE-HERE for a scope reason, not a cap
+reason**: their only target lives in another repo. Patch + proof shipped as
+artifacts, and the goal defect is reported below.
+
+**Spend:** $0.00 of the $0.00 authority. No container, no DTU, no eval, no API
+spend. Pure shell/test change, as the goal's arithmetic (`0 runs × 0 arms × $0
+/ 1.00 = $0.00`) predicted. No infrastructure was registered, claimed, or torn
+down; the live ledger was never written to.
+
+---
+
+## The root cause, measured — and it is ONE cause
+
+Both sub-findings are the same defect wearing two hats: **nothing reconciles a
+lane's identity across the three files that describe it**, so a lane-name
+lookup silently returns "nothing" instead of "I could not tell".
+
+Measured in this batch's own files (`/home/bkrabach/dev/hw-model-performance`):
+
+| file | lane column holds | example |
+|---|---|---|
+| `manifest.tsv` | LONG lane name | `drbf-compaction-notice-ab` |
+| `infra.owners.tsv` | **either** | `drbf-compaction-notice-ab` *and* `vbs`, `127`, `3d2`, `6da`, `k64` |
+| `infra.tsv` (`id`) | SHORT work-item id | `val-drbf-a` |
+
+**5 of the 13 distinct owner values are short work-item ids; the other 8 are
+long manifest names.** `lane_teardown.sh`'s own usage text documents the short
+form ("LANE — SHORT lane / work-item id … NOT the lane directory name"), but
+lanes claim with whichever name they happen to hold. Both conventions are live
+in one ledger, and nothing declares which is correct.
+
+### Sub-finding 1, traced through the code
+
+`lane_teardown.sh <batch> drbf teardown --yes` exited 0 saying "owns no open
+rows" while six rows were open. The path, exactly:
+
+1. rows are `val-drbf-a … val-drbf-c2`, claimed to `drbf-compaction-notice-ab`
+   (`infra.owners.tsv` lines 35–40, still on disk);
+2. `classify()` (line 137) consults **claims first**:
+   `claimed_lane("val-drbf-a")` → `drbf-compaction-notice-ab`, which `!= "drbf"`,
+   so it returns `OTHER:drbf-compaction-notice-ab`;
+3. the **inference** rule on line 144 — `val-$LANE-*`, which *would* have matched
+   `val-drbf-a` for lane `drbf` — is unreachable, because the claim branch
+   already returned;
+4. every candidate lands in `prot_ids`, `sel_ids` is empty, and line 302 prints
+   a success message and exits 0.
+
+The guard was working exactly as designed. The design simply had no way to say
+"you named something that nearly matches".
+
+### Sub-finding 2, traced through the code
+
+`highway_status.sh` computes lane liveness (`tmux has-session`, line 64) and
+`infra_ledger.sh list` reports open rows, and **no code path reads both**. The
+manager found the six orphaned containers by running `incus list` by hand.
+
+### One fix or two? — **One cause, two sites, and they must ship separately.**
+
+The goal asks this be argued from the code. The cause is single (above). The
+*blast radii* are not, and that decides the shape:
+
+- **`lane_teardown.sh` DESTROYS.** Its failure mode is silence on the emergency
+  path. Its fix must therefore make a near miss **loud and non-zero** — and must
+  be conservative, because a guard that fires too widely makes every clean
+  lane's routine teardown look broken.
+- **`highway_status.sh` only REPORTS.** Its failure mode is invisibility. Its
+  fix can afford to over-report, because the cost of a false positive is a
+  printed line, not a destroyed container.
+
+They are the same join written twice on purpose: one fails **closed** (refuse,
+name the candidates), one fails **open** (report, name the reason). Merging them
+into a single mechanism would force one of those two policies onto the wrong
+side. That is why this note ships one fix here and one as a patch, rather than a
+shared helper.
+
+---
+
+## Deliverables
+
+### 1. A near-miss lane name FAILS LOUDLY — **DONE in substance, NOT LANDABLE IN THIS REPO**
+
+Implemented, proven, and shipped as a patch. See "Goal defect" below for why it
+could not be committed as code.
+
+- Patch: `PROPOSED-evals-lane-teardown-near-miss.patch` (applies cleanly with `patch -p0` to
+  upstream sha256 `40e6ee93575a784c34a24a9b91b0c871c975d1cc822923ad5e9a88c8f774cd9d`;
+  verified by `--dry-run`)
+- Harness: `test_lane_teardown_near_miss.sh` (takes the script under test as an
+  argument, runs against a throwaway batch in `$TMPDIR`, stubs the DTU CLI
+  through the script's own `AMPLIFIER_DT_CLI` seam)
+- Transcript: `evidence/00-near-miss-fail-before.txt`, `evidence/01-near-miss-pass-after.txt`
+
+**Fail-before (unpatched): 3 expectations unmet.** **Pass-after: all 13 pass.**
+
+A near miss is defined narrowly — an id that inference *would* have selected
+(`val-$LANE`, `val-$LANE-*`), or an owner name prefix-related to `$LANE` on a
+token boundary **in either direction**. It exits **4** and prints each candidate
+with its open-row count and the exact corrected command. It is deliberately NOT
+"any protected row is an error": most lanes provision nothing and run teardown
+anyway, so failing them because an unrelated lane holds rows would be a
+regression. CASE 4 of the harness pins that.
+
+### 2. An exact lane name still works; `protected-untouched` still protects — **DONE**
+
+Pinned in the same harness against the **patched** script, reproducing the
+incident's own recovery transcript byte-for-byte in the numbers that matter:
+
+```
+verified-gone=6 rows-flipped=6 ... protected-untouched=4
+```
+
+CASE 3 additionally asserts each of the four live-lane containers **still
+exists** in the stub's state dir — observable, not inferred from an exit code.
+
+### 3. Orphaned rows are surfaced — **DONE, landed here**
+
+`highway_status.sh` now joins lane liveness to row ownership and reports:
+
+```
+SUMMARY batch=… live=1 ended=1 … watchdog=DEAD orphan_rows=6
+WARNING: orphan_rows=6 owned by: drbf-compaction-notice-ab(6)
+  Open infra-ledger rows whose owning lane is NOT live - infrastructure
+  with nothing driving it (Rule 14). Nothing was destroyed; reclaim each
+  with: lane_teardown.sh <BATCH_DIR> <lane> teardown --yes
+```
+
+and in `HIGHWAY_JSON=1` mode: `"orphan_rows":6,"orphan_owners":"drbf-compaction-notice-ab(6)"`.
+
+**Reporting only. Reaping was deliberately not implemented** — the goal names it
+as the riskier choice, and `test_reporting_destroys_nothing` proves inertness
+with a `touch <sentinel>` destroy_cmd plus a byte-identical ledger, rather than
+inferring it from an exit code.
+
+**Replayed against the real incident data.** A copy of the live batch's
+`manifest.tsv` / `infra.tsv` / `infra.owners.tsv`, with drbf's six rows set back
+to `open`:
+
+```
+{"batch":"replay","live":1,"ended":147,…,"orphan_rows":6,
+ "orphan_owners":"drbf-compaction-notice-ab(6)"}
+```
+
+The live batch today reports `orphan_rows:0`, matching its zero open rows.
+
+Owner resolution is exact-name, else a **unique** token-boundary prefix, so the
+five short-id owners resolve to their lanes. Without that, an exact-match join
+would have false-alarmed on ~40% of this batch's owners — and a report that
+cries wolf is a report nobody reads. Ambiguous (`l1` against `l1-alpha` and
+`l1-beta`), unresolvable, and unclaimed owners are each reported **as such**
+rather than guessed at.
+
+### 4. A live lane's rows are NEVER touched by either change — **DONE**
+
+The goal flags this as the deliverable that can be faked by making everything
+pass. Pinned on both sides, with a live lane and a dead lane holding rows
+**simultaneously**:
+
+- `test_a_live_lanes_rows_are_never_reported_as_orphaned` — live lane owns 2
+  rows, dead lane owns 6; asserts `orphan_rows == 6` **and** that the live
+  lane's name does not appear in the owner list. Counting every open row would
+  also satisfy the incident test; this is the case that separates a real join
+  from a row count.
+- `test_real_tmux_agrees_with_the_stub` — the same scenario against a **real
+  tmux server** on a private socket, then kills the session mid-test and asserts
+  the SAME batch flips 1 → 2 orphans with nothing else changed. The stub cannot
+  hide an integration break.
+- Harness CASE 3 — the live lanes' containers survive an exact-name teardown.
+
+### 5. Full suite green — **DONE, with one pre-existing failure that is not mine**
+
+```
+1 failed, 1818 passed, 2 skipped, 13 deselected, 1 xfailed in 14.45s
+```
+
+The failure is `tests/test_fail_loud_bundle_activation.py::…::test_error_is_a_bundle_error`
+(`assert issubclass(ModuleActivationError, BundleError)`), a foundation-contract
+assertion. **Proven pre-existing**: `git stash -u` → the identical failure on
+clean HEAD (`1 failed, 1805 passed`). The delta is exactly my +13 tests.
+
+**Two corrections to the goal's KNOWN section**, both cheap to verify:
+- The failure it predicted (`test_truststore_wrap_bio_shim.py::test_real_truststore_is_covered_at_cli_import`)
+  did **not** occur, in either the clean or the changed run. That prediction is stale.
+- The failure that *does* occur is a different one, and the goal does not
+  mention it. A later lane should not absorb it either.
+
+`ruff check` and `ruff format` clean on the new test file.
+
+---
+
+## Goal defect (reported, per the goal's own instruction)
+
+**Deliverables 1 and 2 have no target inside the paths this lane owns.**
+
+`lane_teardown.sh` lives at
+`/home/bkrabach/dev/openai-evals-team-ci/.amplifier/evaluation/tools/lane_teardown.sh`
+— a different repo, and **untracked even there**:
+
+```
+$ git -C /home/bkrabach/dev/openai-evals-team-ci ls-files --error-unmatch \
+      .amplifier/evaluation/tools/lane_teardown.sh
+error: pathspec '…' did not match any file(s) known to git
+```
+
+This lane's worktree is `amplifier-app-cli`, which ships
+`infra_ledger.sh`, `highway_status.sh`, `launch_lane.sh`, `verify_lane.sh`,
+`highway_watchdog.sh` — and **no** `lane_teardown.sh`. Per the goal's own rule
+("If the only way to satisfy a deliverable is to write a file outside your
+worktree … that is a DEFECT IN THIS GOAL, not a task. Report it against the
+goal, ship the patch as an artifact under your ARTIFACT ROOT, and resolve"), I
+did exactly that: the fix is implemented and proven, shipped as a patch, and the
+other repo was not touched.
+
+**The deeper defect this is a symptom of** — and lane 2nz already flagged it
+(its DONE-NOTE, finding 3): the shipped skill **names a tool it does not
+ship**. `infra_ledger.sh` tells the operator, in its refusal message, to run
+`.amplifier/evaluation/tools/lane_teardown.sh` — an evals-repo path — and
+`SKILL.md` names the tool with no path at all. So the shipped skill's
+documented recovery path points at an untracked file in a repo the skill knows
+nothing about, and that file is where the emergency footgun lives. Until
+`lane_teardown.sh` is adopted into this repo (or the skill stops naming it),
+every fix to it is unversioned and every lane that finds a bug in it hits this
+same wall.
+
+**Recommended next item:** adopt `lane_teardown.sh` into
+`amplifier_app_cli/data/skills/ten-lane-highway/scripts/`, with the near-miss
+patch applied and this harness converted to a pytest file. That is a
+deliberate scope decision, not something to smuggle in here: it would create a
+second copy of a 409-line tool the manager runs live from the other path, and a
+divergence there is worse than the footgun.
+
+---
+
+## Deviations and choices
+
+- **No reaping.** Reporting only, as the goal permits and prefers. Recorded here
+  as a choice, not an omission.
+- **tmux is stubbed** in most tests, through a `PATH` shim, for the same reason
+  `lane_teardown.sh` indirects the DTU CLI: the subject is the join, not the
+  multiplexer. One test runs against real tmux so the stub cannot hide a break.
+- **Environments are built explicitly** in every subprocess call
+  (`model_performance-etuz`): a lane exports `HIGHWAY_TMUX_SOCKET`, so an
+  inherited env would make these pass in CI and fail inside every lane.
+- **`skipif` with a stated reason** on Windows / no-bash, matching the precedent
+  set on #306 and #310 — these scripts are GNU/Linux-only by construction.
+- **Never ran `sweep`**, never ran a teardown against the live ledger, and never
+  wrote to `/home/bkrabach/dev/hw-model-performance`. The incident replay used a
+  `cp` of its three state files into `$TMPDIR`.
+
+## Files
+
+| path | what |
+|---|---|
+| `amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh` | the orphan-row join (+95 lines) |
+| `amplifier_app_cli/data/skills/ten-lane-highway/SKILL.md` | documents `orphan_rows`, per 0rg's guard-and-docs-together precedent |
+| `tests/test_ten_lane_highway_orphan_rows.py` | 13 tests |
+| `docs/lanes/ye80b-teardown-orphan-rows/PROPOSED-evals-lane-teardown-near-miss.patch` | sub-finding 1's fix |
+| `docs/lanes/ye80b-teardown-orphan-rows/test_lane_teardown_near_miss.sh` | its proof harness |
+| `docs/lanes/ye80b-teardown-orphan-rows/evidence/` | fail-before / pass-after transcripts, incident replay, both suite runs, lint |

--- a/docs/lanes/ye80b-teardown-orphan-rows/PROPOSED-evals-lane-teardown-near-miss.patch
+++ b/docs/lanes/ye80b-teardown-orphan-rows/PROPOSED-evals-lane-teardown-near-miss.patch
@@ -1,0 +1,79 @@
+--- a/.amplifier/evaluation/tools/lane_teardown.sh
++++ b/.amplifier/evaluation/tools/lane_teardown.sh
+@@ -299,7 +299,75 @@
+ if [ "$CMD" = "list" ]; then exit 0; fi
+ 
+ if [ "${#sel_ids[@]}" -eq 0 ]; then
+-  echo; echo "${CMD^^}: lane '$LANE' owns no open rows — nothing to do"; exit 0
++  # ---- NEAR-MISS GUARD (model_performance-ye80) ----------------------------
++  # A lane name that ALMOST matches must never exit 0 having done nothing.
++  #
++  # Observed 2026-09-05, mid-recovery, with six containers still billing:
++  #     lane_teardown.sh <batch> drbf teardown --yes
++  #       -> "TEARDOWN: lane 'drbf' owns no open rows - nothing to do"  (exit 0)
++  # while SIX rows were open under the full name `drbf-compaction-notice-ab`.
++  #
++  # WHY it looked clean: the ids (val-drbf-a...) are exactly what inference
++  # WOULD have selected for lane `drbf`, but classify() consults claims FIRST
++  # and those rows carry a claim under the LONG name, so classify() returned
++  # OTHER:drbf-compaction-notice-ab and every candidate landed in PROTECTED.
++  # Empty selection then printed a success message. This is the one path an
++  # operator reaches for in an emergency: on it, a near miss must be an ERROR
++  # that names the candidates. (Same class as 2nz's: a guard that reports
++  # success while doing nothing.)
++  #
++  # Deliberately NOT "any protected row is an error": a lane that provisioned
++  # nothing runs teardown as a matter of course, and failing it merely because
++  # some unrelated lane holds rows would make every clean lane look broken.
++  # Only a NEAR MISS -- prefix-related on a token boundary, or an id inference
++  # would have claimed -- is treated as an operator typo.
++  near_owner=(); near_count=()
++  for i in "${!prot_ids[@]}"; do
++    pid=${prot_ids[$i]}; pwhy=${prot_why[$i]}
++    powner=""; case "$pwhy" in OTHER:*) powner=${pwhy#OTHER:} ;; esac
++    hit=0
++    # (a) an id inference WOULD have selected for this lane, had no claim won.
++    if [ "$pid" = "val-$LANE" ] || [[ "$pid" == "val-$LANE-"* ]]; then hit=1; fi
++    # (b) owner name and LANE are prefix-related on a token boundary -- covers
++    #     BOTH directions, because this batch's ledger genuinely carries both
++    #     short work-item ids and long manifest names as owners.
++    if [ -n "$powner" ] && { [[ "$powner" == "$LANE-"* ]] || [[ "$LANE" == "$powner-"* ]]; }; then hit=1; fi
++    [ "$hit" = 1 ] || continue
++    label=${powner:-<unattributed>}
++    found=0
++    for j in "${!near_owner[@]}"; do
++      if [ "${near_owner[$j]}" = "$label" ]; then
++        near_count[$j]=$(( near_count[j] + 1 )); found=1; break
++      fi
++    done
++    [ "$found" = 0 ] && { near_owner+=("$label"); near_count+=(1); }
++  done
++
++  if [ "${#near_owner[@]}" -gt 0 ]; then
++    {
++      echo
++      echo "ERROR: lane '$LANE' owns no open rows, but open rows ARE held under a NEAR-MISS lane name."
++      echo "       Refusing to report success for a teardown that would do nothing."
++      echo
++      for j in "${!near_owner[@]}"; do
++        printf "   candidate: %-32s %s open row(s)\n" "${near_owner[$j]}" "${near_count[$j]}"
++      done
++      echo
++      echo "Re-run with the EXACT owner name, e.g.:"
++      echo "   lane_teardown.sh \"$BATCH_DIR\" ${near_owner[0]} $CMD --yes"
++      echo "Or inspect first (read-only, destroys nothing):"
++      echo "   lane_teardown.sh \"$BATCH_DIR\" $LANE audit"
++    } >&2
++    exit 4
++  fi
++
++  echo
++  echo "${CMD^^}: lane '$LANE' owns no open rows - nothing to do"
++  if [ "${#prot_ids[@]}" -gt 0 ]; then
++    echo "  (${#prot_ids[@]} open row(s) belong to other lanes; none resemble '$LANE')"
++  fi
++  exit 0
++  # ---- end near-miss guard -------------------------------------------------
+ fi
+ 
+ # ---- decide, per row, whether it may leave `open` --------------------------

--- a/docs/lanes/ye80b-teardown-orphan-rows/evidence/00-near-miss-fail-before.txt
+++ b/docs/lanes/ye80b-teardown-orphan-rows/evidence/00-near-miss-fail-before.txt
@@ -1,0 +1,39 @@
+FAIL-BEFORE — sub-finding 1, UNPATCHED upstream lane_teardown.sh
+file:   /home/bkrabach/dev/openai-evals-team-ci/.amplifier/evaluation/tools/lane_teardown.sh
+sha256: 40e6ee93575a784c34a24a9b91b0c871c975d1cc822923ad5e9a88c8f774cd9d
+date:   2026-09-06T10:13:48Z
+
+== SUT: /tmp/orphantest/lt/orig.sh
+
+CASE 1 — the incident: a NEAR-MISS lane name must FAIL LOUDLY
+         (2026-09-05: `lane_teardown.sh <batch> drbf teardown --yes`
+          exited 0 saying 'owns no open rows' while six were open)
+  FAIL  exited 0 on a near-miss name (the footgun: reports success, does nothing)
+  FAIL  did not name the candidate lane — an operator cannot act on this
+  PASS  destroyed nothing and flipped no row while refusing
+
+CASE 2 — the EXACT lane name still works, unchanged
+  PASS  exact name exits 0
+  PASS  verified-gone=6 (the transcript recorded that day)
+  PASS  rows-flipped=6
+
+CASE 3 — a LIVE lane's rows are NEVER touched by either path
+         (dead lane and two live lanes hold rows simultaneously)
+  PASS  protected-untouched=4 (the two live lanes' rows)
+  PASS  exactly the 4 live-lane rows remain open
+  PASS  every live-lane container still exists (observable, not inferred)
+
+CASE 4 — a genuinely idle lane still exits 0 (no new false failure)
+         a lane that provisioned nothing must not fail merely because
+         unrelated lanes hold rows
+  PASS  unrelated idle lane exits 0
+  PASS  and touched nothing
+
+CASE 5 — the MIRROR near miss: long name typed, rows claimed short
+         (this batch's ledger genuinely carries both conventions)
+  FAIL  mirror near miss exited 0 without naming a candidate
+
+==================================================
+RESULT: FAIL — 3 expectation(s) unmet
+
+harness exit: 1 (expected — this IS the fail-before)

--- a/docs/lanes/ye80b-teardown-orphan-rows/evidence/01-near-miss-pass-after.txt
+++ b/docs/lanes/ye80b-teardown-orphan-rows/evidence/01-near-miss-pass-after.txt
@@ -1,0 +1,37 @@
+PASS-AFTER — same harness, PROPOSED-evals-lane-teardown-near-miss.patch applied
+date: 2026-09-06T10:13:48Z
+
+== SUT: /tmp/orphantest/lt/fixed.sh
+
+CASE 1 — the incident: a NEAR-MISS lane name must FAIL LOUDLY
+         (2026-09-05: `lane_teardown.sh <batch> drbf teardown --yes`
+          exited 0 saying 'owns no open rows' while six were open)
+  PASS  exited non-zero (4) instead of reporting success
+  PASS  named the candidate lane that DOES own the open rows
+  PASS  destroyed nothing and flipped no row while refusing
+
+CASE 2 — the EXACT lane name still works, unchanged
+  PASS  exact name exits 0
+  PASS  verified-gone=6 (the transcript recorded that day)
+  PASS  rows-flipped=6
+
+CASE 3 — a LIVE lane's rows are NEVER touched by either path
+         (dead lane and two live lanes hold rows simultaneously)
+  PASS  protected-untouched=4 (the two live lanes' rows)
+  PASS  exactly the 4 live-lane rows remain open
+  PASS  every live-lane container still exists (observable, not inferred)
+
+CASE 4 — a genuinely idle lane still exits 0 (no new false failure)
+         a lane that provisioned nothing must not fail merely because
+         unrelated lanes hold rows
+  PASS  unrelated idle lane exits 0
+  PASS  and touched nothing
+
+CASE 5 — the MIRROR near miss: long name typed, rows claimed short
+         (this batch's ledger genuinely carries both conventions)
+  PASS  long name against short-claimed rows also fails loudly, naming 'vbs'
+
+==================================================
+RESULT: PASS — near-miss guard present, protection intact
+
+harness exit: 0

--- a/docs/lanes/ye80b-teardown-orphan-rows/evidence/02-orphan-rows-fail-before.txt
+++ b/docs/lanes/ye80b-teardown-orphan-rows/evidence/02-orphan-rows-fail-before.txt
@@ -1,0 +1,24 @@
+FAIL-BEFORE — sub-finding 2, new tests against pre-change highway_status.sh
+baseline: HEAD 569c9b8 (git checkout HEAD -- amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh)
+date:     2026-09-06T10:13:57Z
+
+>           assert got["orphan_rows"] == 1, "a REAL live lane's row was reported orphaned"
+                   ^^^^^^^^^^^^^^^^^^
+E           KeyError: 'orphan_rows'
+
+tests/test_ten_lane_highway_orphan_rows.py:406: KeyError
+=========================== short test summary info ============================
+FAILED tests/test_ten_lane_highway_orphan_rows.py::test_the_ye80_incident_is_now_visible
+FAILED tests/test_ten_lane_highway_orphan_rows.py::test_a_live_lanes_rows_are_never_reported_as_orphaned
+FAILED tests/test_ten_lane_highway_orphan_rows.py::test_every_lane_live_means_no_orphans
+FAILED tests/test_ten_lane_highway_orphan_rows.py::test_a_short_owner_id_resolves_to_its_live_lane_by_prefix
+FAILED tests/test_ten_lane_highway_orphan_rows.py::test_a_short_owner_id_still_orphans_when_its_lane_is_dead
+FAILED tests/test_ten_lane_highway_orphan_rows.py::test_an_ambiguous_owner_prefix_is_reported_not_guessed
+FAILED tests/test_ten_lane_highway_orphan_rows.py::test_an_owner_naming_no_lane_is_flagged_distinctly
+FAILED tests/test_ten_lane_highway_orphan_rows.py::test_an_unclaimed_row_is_an_orphan
+FAILED tests/test_ten_lane_highway_orphan_rows.py::test_closed_rows_are_never_counted
+FAILED tests/test_ten_lane_highway_orphan_rows.py::test_reporting_destroys_nothing
+FAILED tests/test_ten_lane_highway_orphan_rows.py::test_a_batch_with_no_ledger_reports_zero
+FAILED tests/test_ten_lane_highway_orphan_rows.py::test_the_human_summary_names_the_owning_lane
+FAILED tests/test_ten_lane_highway_orphan_rows.py::test_real_tmux_agrees_with_the_stub
+13 failed in 0.70s

--- a/docs/lanes/ye80b-teardown-orphan-rows/evidence/03-orphan-rows-pass-after.txt
+++ b/docs/lanes/ye80b-teardown-orphan-rows/evidence/03-orphan-rows-pass-after.txt
@@ -1,0 +1,25 @@
+PASS-AFTER — same tests, orphan-row join in place
+date: 2026-09-06T10:13:59Z
+
+cachedir: .pytest_cache
+rootdir: /home/bkrabach/dev/hw-model-performance/lanes/ye80b-teardown-orphan-rows/amplifier-app-cli
+configfile: pyproject.toml
+plugins: amplifier-core-1.6.0, timeout-2.4.0, pytest_httpserver-1.1.4, anyio-4.12.1, asyncio-1.3.0
+asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
+collecting ... collected 13 items
+
+tests/test_ten_lane_highway_orphan_rows.py::test_the_ye80_incident_is_now_visible PASSED [  7%]
+tests/test_ten_lane_highway_orphan_rows.py::test_a_live_lanes_rows_are_never_reported_as_orphaned PASSED [ 15%]
+tests/test_ten_lane_highway_orphan_rows.py::test_every_lane_live_means_no_orphans PASSED [ 23%]
+tests/test_ten_lane_highway_orphan_rows.py::test_a_short_owner_id_resolves_to_its_live_lane_by_prefix PASSED [ 30%]
+tests/test_ten_lane_highway_orphan_rows.py::test_a_short_owner_id_still_orphans_when_its_lane_is_dead PASSED [ 38%]
+tests/test_ten_lane_highway_orphan_rows.py::test_an_ambiguous_owner_prefix_is_reported_not_guessed PASSED [ 46%]
+tests/test_ten_lane_highway_orphan_rows.py::test_an_owner_naming_no_lane_is_flagged_distinctly PASSED [ 53%]
+tests/test_ten_lane_highway_orphan_rows.py::test_an_unclaimed_row_is_an_orphan PASSED [ 61%]
+tests/test_ten_lane_highway_orphan_rows.py::test_closed_rows_are_never_counted PASSED [ 69%]
+tests/test_ten_lane_highway_orphan_rows.py::test_reporting_destroys_nothing PASSED [ 76%]
+tests/test_ten_lane_highway_orphan_rows.py::test_a_batch_with_no_ledger_reports_zero PASSED [ 84%]
+tests/test_ten_lane_highway_orphan_rows.py::test_the_human_summary_names_the_owning_lane PASSED [ 92%]
+tests/test_ten_lane_highway_orphan_rows.py::test_real_tmux_agrees_with_the_stub PASSED [100%]
+
+============================== 13 passed in 0.66s ==============================

--- a/docs/lanes/ye80b-teardown-orphan-rows/evidence/04-incident-replay.txt
+++ b/docs/lanes/ye80b-teardown-orphan-rows/evidence/04-incident-replay.txt
@@ -1,0 +1,32 @@
+INCIDENT REPLAY — the 2026-09-05 state, against a COPY of the real batch files
+date: 2026-09-06T10:14:18Z
+
+The live batch is never written to. Its three state files are copied to
+$TMPDIR and drbf's six rows are set back to 'open' — the state they were
+actually in when the lane died and the containers kept running.
+
+$ HIGHWAY_JSON=1 highway_status.sh /home/bkrabach/dev/hw-model-performance 10 1   # the LIVE batch today
+{"ts":"2026-09-06T10:14:19Z","batch":"hw-model-performance","live":1,"ended":147,"done_marker":146,"stalled":0,"gone":0,"width":1,"width_source":"file","ready":1,"deficit":0,"watchdog":"LIVE","orphan_rows":0,"orphan_owners":""}
+  -> 0 open rows today, so orphan_rows:0. The report is not crying wolf.
+
+reopened rows (as they were on 2026-09-05):
+   val-drbf-a	open
+   val-drbf-b	open
+   val-drbf-c	open
+   val-drbf-a2	open
+   val-drbf-b2	open
+   val-drbf-c2	open
+
+$ HIGHWAY_JSON=1 highway_status.sh <replay-copy> 10 1
+{"ts":"2026-09-06T10:14:21Z","batch":"replay2","live":1,"ended":147,"done_marker":146,"stalled":0,"gone":0,"width":10,"width_source":"arg","ready":1,"deficit":1,"watchdog":"DEAD","orphan_rows":6,"orphan_owners":"drbf-compaction-notice-ab(6)"}
+
+human form:
+ACTION: launch 1 lane(s) NOW - refill before anything else.
+WARNING: watchdog hw-watchdog__replay2 is not running - do not end the turn until it is.
+WARNING: orphan_rows=6 owned by: drbf-compaction-notice-ab(6)
+  Open infra-ledger rows whose owning lane is NOT live - infrastructure
+  with nothing driving it (Rule 14). Nothing was destroyed; reclaim each
+  with: lane_teardown.sh /tmp/orphantest/replay2 <lane> teardown --yes
+
+ledger unchanged by the report (byte-identical):
+   OK — highway_status.sh wrote nothing

--- a/docs/lanes/ye80b-teardown-orphan-rows/evidence/05-full-suite-with-changes.txt
+++ b/docs/lanes/ye80b-teardown-orphan-rows/evidence/05-full-suite-with-changes.txt
@@ -1,0 +1,17 @@
+FULL SUITE — with this lane's changes
+date: 2026-09-06T10:14:31Z
+
+        """Pins the foundation contract this CLI handler depends on.
+    
+        If foundation ever moves ``ModuleActivationError`` back out of the
+        ``BundleError`` hierarchy, the generic handler stops covering it and
+        tracebacks return. Fail here rather than in a user's terminal.
+        """
+>       assert issubclass(ModuleActivationError, BundleError)
+E       assert False
+E        +  where False = issubclass(ModuleActivationError, BundleError)
+
+tests/test_fail_loud_bundle_activation.py:93: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_fail_loud_bundle_activation.py::TestActivationFailureIsRenderedNotTracebacked343::test_error_is_a_bundle_error
+1 failed, 1818 passed, 2 skipped, 13 deselected, 1 xfailed in 12.86s

--- a/docs/lanes/ye80b-teardown-orphan-rows/evidence/06-full-suite-clean-head.txt
+++ b/docs/lanes/ye80b-teardown-orphan-rows/evidence/06-full-suite-clean-head.txt
@@ -1,0 +1,14 @@
+FULL SUITE — clean HEAD, this lane's changes stashed
+Proves the one failure is PRE-EXISTING and not this lane's.
+Written to $TMPDIR first: 'git stash -u' would delete an open untracked
+file mid-write, and silently lose exactly the evidence being captured.
+date: 2026-09-06T10:15:25Z
+
+E        +  where False = issubclass(ModuleActivationError, BundleError)
+
+tests/test_fail_loud_bundle_activation.py:93: AssertionError
+=========================== short test summary info ============================
+FAILED tests/test_fail_loud_bundle_activation.py::TestActivationFailureIsRenderedNotTracebacked343::test_error_is_a_bundle_error
+1 failed, 1805 passed, 2 skipped, 13 deselected, 1 xfailed in 12.24s
+
+restored working tree:  M amplifier_app_cli/data/skills/ten-lane-highway/SKILL.md  M amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh ?? docs/lanes/ye80b-teardown-orphan-rows/ ?? tests/test_ten_lane_highway_orphan_rows.py 

--- a/docs/lanes/ye80b-teardown-orphan-rows/evidence/07-lint.txt
+++ b/docs/lanes/ye80b-teardown-orphan-rows/evidence/07-lint.txt
@@ -1,0 +1,11 @@
+LINT — date: 2026-09-06T10:15:38Z
+
+$ ruff check tests/test_ten_lane_highway_orphan_rows.py
+All checks passed!
+
+$ ruff format --check tests/test_ten_lane_highway_orphan_rows.py
+1 file already formatted
+
+NOTE: `ruff check tests/` reports 6 PRE-EXISTING errors in
+test_message_renderer.py and test_pre_turn_repair.py (unused imports).
+Not this lane; not touched.

--- a/docs/lanes/ye80b-teardown-orphan-rows/test_lane_teardown_near_miss.sh
+++ b/docs/lanes/ye80b-teardown-orphan-rows/test_lane_teardown_near_miss.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Proof harness for model_performance-ye80 SUB-FINDING 1 — lane_teardown.sh's
+# near-miss footgun.
+#
+# WHY THIS IS A STANDALONE SCRIPT AND NOT A pytest FILE
+#   lane_teardown.sh lives in ANOTHER repo (openai-evals-team-ci) and is
+#   untracked even there. This lane owns only amplifier-app-cli, so the fix
+#   cannot land here and a pytest file here must not depend on a path outside
+#   this repo. This harness therefore takes the script under test as an
+#   argument, runs it against a throwaway batch dir in $TMPDIR, and proves
+#   fail-before / pass-after without editing anything it does not own.
+#
+# USAGE
+#   test_lane_teardown_near_miss.sh /path/to/lane_teardown.sh
+#
+#   Exit 0  = the script under test HAS the near-miss guard and still protects
+#             other lanes' rows (pass-after).
+#   Exit 1  = one or more expectations failed (this is what the UNPATCHED
+#             script does — that failure IS the fail-before evidence).
+#
+# The DTU CLI is stubbed through the script's own AMPLIFIER_DT_CLI seam, so
+# nothing real is ever probed or destroyed. Every destroy is observable: the
+# stub deletes a state file, so "ran nothing" is proven by the file still being
+# there rather than inferred from an exit code (the tests/test_ten_lane_highway_
+# infra_ledger.py standard — the buggy path prints a success message, so an
+# exit code alone cannot tell "refused" from "ran and failed").
+set -uo pipefail
+
+SUT=${1:?usage: $0 /path/to/lane_teardown.sh}
+[ -r "$SUT" ] || { echo "ERROR: cannot read $SUT" >&2; exit 2; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+fails=0
+
+pass() { printf '  PASS  %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; fails=$(( fails + 1 )); }
+
+# --- stub DTU CLI: a container exists iff $DT_STATE/<id> exists -------------
+mkdir -p "$WORK/bin" "$WORK/state"
+cat > "$WORK/bin/dt-stub" <<'STUB'
+#!/usr/bin/env bash
+verb=${1:-}; id=${2:-}
+case "$verb" in
+  status)  [ -f "$DT_STATE/$id" ] && { echo "running"; exit 0; }
+           echo "Environment '$id' not found" >&2; exit 1 ;;
+  destroy) rm -f "$DT_STATE/$id"; echo "destroyed $id"; exit 0 ;;
+  *) echo "unknown verb $verb" >&2; exit 2 ;;
+esac
+STUB
+chmod +x "$WORK/bin/dt-stub"
+export AMPLIFIER_DT_CLI="$WORK/bin/dt-stub"
+export DT_STATE="$WORK/state"
+
+# --- the ledger, reproducing the 2026-09-05 state ---------------------------
+# Six rows owned by the DEAD lane under its LONG name, four owned by two LIVE
+# lanes. Ids use the short form `val-drbf-*`, exactly as recorded that day.
+build_batch() {
+  local b="$1"; rm -rf "$b"; mkdir -p "$b"
+  : > "$b/infra.tsv"; : > "$b/infra.owners.tsv"
+  add_row() { # id owner
+    printf '2026-09-06T02:18:49Z\tdtu\t%s\topen\tamplifier-digital-twin destroy %s\n' "$1" "$1" >> "$b/infra.tsv"
+    printf '2026-09-06T02:18:49Z\t%s\t%s\n' "$1" "$2" >> "$b/infra.owners.tsv"
+    : > "$DT_STATE/$1"
+  }
+  for s in a b c a2 b2 c2; do add_row "val-drbf-$s" "drbf-compaction-notice-ab"; done
+  for s in a b; do add_row "val-vbs-$s" "vbs-cache-residency"; done
+  for s in a b; do add_row "val-otr-$s" "otr-armb-medium-root"; done
+}
+
+open_rows() { awk -F'\t' '$4=="open"' "$1/infra.tsv" | wc -l | tr -d ' '; }
+alive()     { ls "$DT_STATE" | wc -l | tr -d ' '; }
+
+echo "== SUT: $SUT"
+echo
+
+# ---------------------------------------------------------------------------
+echo "CASE 1 — the incident: a NEAR-MISS lane name must FAIL LOUDLY"
+echo "         (2026-09-05: \`lane_teardown.sh <batch> drbf teardown --yes\`"
+echo "          exited 0 saying 'owns no open rows' while six were open)"
+B="$WORK/b1"; build_batch "$B"
+out=$(bash "$SUT" "$B" drbf teardown --yes 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then
+  fail "exited 0 on a near-miss name (the footgun: reports success, does nothing)"
+else
+  pass "exited non-zero ($rc) instead of reporting success"
+fi
+# Deliberately requires the candidate on ONE line with its marker. The
+# UNPATCHED script also prints "drbf-compaction-notice-ab" -- in its PROTECTED
+# listing, right before exiting 0 -- so a bare name match would pass against
+# the very bug under test.
+if printf '%s\n' "$out" | grep -q "candidate:.*drbf-compaction-notice-ab"; then
+  pass "named the candidate lane that DOES own the open rows"
+else
+  fail "did not name the candidate lane — an operator cannot act on this"
+fi
+if [ "$(open_rows "$B")" = "10" ] && [ "$(alive)" = "10" ]; then
+  pass "destroyed nothing and flipped no row while refusing"
+else
+  fail "refusal was not inert (open=$(open_rows "$B") alive=$(alive), want 10/10)"
+fi
+echo
+
+# ---------------------------------------------------------------------------
+echo "CASE 2 — the EXACT lane name still works, unchanged"
+B="$WORK/b2"; build_batch "$B"
+out=$(bash "$SUT" "$B" drbf-compaction-notice-ab teardown --yes 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then pass "exact name exits 0"; else fail "exact name exits $rc: $out"; fi
+if printf '%s' "$out" | grep -q "verified-gone=6"; then
+  pass "verified-gone=6 (the transcript recorded that day)"
+else
+  fail "did not verify-tear-down its six rows"
+fi
+if printf '%s' "$out" | grep -q "rows-flipped=6"; then
+  pass "rows-flipped=6"
+else
+  fail "did not flip its six rows"
+fi
+echo
+
+# ---------------------------------------------------------------------------
+echo "CASE 3 — a LIVE lane's rows are NEVER touched by either path"
+echo "         (dead lane and two live lanes hold rows simultaneously)"
+if printf '%s' "$out" | grep -q "protected-untouched=4"; then
+  pass "protected-untouched=4 (the two live lanes' rows)"
+else
+  fail "protected-untouched is not 4 — the protection regressed"
+fi
+if [ "$(open_rows "$B")" = "4" ]; then
+  pass "exactly the 4 live-lane rows remain open"
+else
+  fail "wrong number of rows left open: $(open_rows "$B")"
+fi
+live_gone=0
+for s in val-vbs-a val-vbs-b val-otr-a val-otr-b; do
+  [ -f "$DT_STATE/$s" ] || { fail "LIVE lane's container $s was DESTROYED"; live_gone=1; }
+done
+[ "$live_gone" = 0 ] && pass "every live-lane container still exists (observable, not inferred)"
+echo
+
+# ---------------------------------------------------------------------------
+echo "CASE 4 — a genuinely idle lane still exits 0 (no new false failure)"
+echo "         a lane that provisioned nothing must not fail merely because"
+echo "         unrelated lanes hold rows"
+B="$WORK/b4"; build_batch "$B"
+out=$(bash "$SUT" "$B" zzz teardown --yes 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "unrelated idle lane exits 0"
+else
+  fail "unrelated idle lane now exits $rc — the guard is too broad"
+fi
+if [ "$(open_rows "$B")" = "10" ]; then
+  pass "and touched nothing"
+else
+  fail "an idle lane's teardown changed the ledger"
+fi
+echo
+
+# ---------------------------------------------------------------------------
+echo "CASE 5 — the MIRROR near miss: long name typed, rows claimed short"
+echo "         (this batch's ledger genuinely carries both conventions)"
+B="$WORK/b5"; rm -rf "$B"; mkdir -p "$B"; : > "$B/infra.tsv"; : > "$B/infra.owners.tsv"
+for s in a b; do
+  printf '2026-09-06T02:18:49Z\tdtu\tval-vbs-%s\topen\tamplifier-digital-twin destroy val-vbs-%s\n' "$s" "$s" >> "$B/infra.tsv"
+  printf '2026-09-06T02:18:49Z\tval-vbs-%s\tvbs\n' "$s" >> "$B/infra.owners.tsv"
+  : > "$DT_STATE/val-vbs-$s"
+done
+out=$(bash "$SUT" "$B" vbs-cache-residency teardown --yes 2>&1); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "candidate"; then
+  pass "long name against short-claimed rows also fails loudly, naming 'vbs'"
+else
+  fail "mirror near miss exited $rc without naming a candidate"
+fi
+echo
+
+echo "=================================================="
+if [ "$fails" -eq 0 ]; then
+  echo "RESULT: PASS — near-miss guard present, protection intact"
+  exit 0
+fi
+echo "RESULT: FAIL — $fails expectation(s) unmet"
+exit 1

--- a/tests/test_ten_lane_highway_orphan_rows.py
+++ b/tests/test_ten_lane_highway_orphan_rows.py
@@ -1,0 +1,415 @@
+"""``highway_status.sh`` must report infra-ledger rows no live lane owns.
+
+model_performance-ye80, second sub-finding. On 2026-09-05 a tmux server restart
+killed three lanes at once and left SIX DTU containers RUNNING with open ledger
+rows. Every component worked in isolation: the ledger recorded all six
+correctly, and ``highway_status.sh`` reported the lanes ENDED. Nothing joined
+the two, so "infrastructure with nothing driving it" (Rule 14) was invisible --
+the manager found the six containers only by running ``incus list`` by hand.
+
+The join is REPORTING ONLY. Nothing here destroys a row, and
+``test_reporting_destroys_nothing`` proves that observably rather than by
+inspection.
+
+Follows tests/test_ten_lane_highway_infra_ledger.py's standard: run the real
+script via subprocess, assert real exit codes and real output, and prove "ran
+nothing" with an observable ``touch <sentinel>`` destroy_cmd -- never a
+grep-for-a-marker, because the buggy path prints a success message.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# These are GNU/Linux shell scripts (`stat -c %Y`, tmux, bash); Windows runners
+# have no equivalent. Same precedent as the infra_ledger and socket-default
+# suites.
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason=(
+        "highway_status.sh is a GNU/Linux shell script (stat -c %Y, tmux); "
+        "requires bash"
+    ),
+)
+
+SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / "amplifier_app_cli/data/skills/ten-lane-highway/scripts"
+)
+STATUS = SCRIPTS / "highway_status.sh"
+LEDGER = SCRIPTS / "infra_ledger.sh"
+
+
+# ---------------------------------------------------------------------------
+# Scenario builder
+#
+# tmux is the liveness SENSOR. It is substituted with a stub on PATH for the
+# same reason lane_teardown.sh indirects the DTU CLI through AMPLIFIER_DT_CLI:
+# the subject under test is the JOIN, and a test that needed a real terminal
+# multiplexer to assert an arithmetic result would be both slower and less
+# deterministic. `test_real_tmux_agrees_with_the_stub` then runs the whole
+# thing against a REAL tmux server so the stub cannot hide an integration
+# break.
+# ---------------------------------------------------------------------------
+
+
+def _make_batch(tmp_path: Path, lanes: list[str]) -> Path:
+    """A batch dir with a manifest whose tmux session name is `hw__b__<lane>`."""
+    batch = tmp_path / "batch"
+    (batch / "wt").mkdir(parents=True)
+    (batch / "log").write_text("", encoding="utf-8")
+    rows = [
+        "\t".join(
+            [
+                "lane",
+                "worktree",
+                "branch",
+                "base_sha",
+                "tmux",
+                "goal",
+                "log",
+                "launched_at",
+            ]
+        )
+    ]
+    for lane in lanes:
+        rows.append(
+            "\t".join(
+                [
+                    lane,
+                    str(batch / "wt"),
+                    f"lane/{lane}",
+                    "HEAD",
+                    f"hw__b__{lane}",
+                    "goal.md",
+                    str(batch / "log"),
+                    "0",
+                ]
+            )
+        )
+    (batch / "manifest.tsv").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return batch
+
+
+def _stub_tmux(tmp_path: Path) -> Path:
+    """A `tmux` that answers has-session only for names in $LIVE_SESSIONS."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    stub = bindir / "tmux"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        'for a in "$@"; do [ "$a" = "has-session" ] && want=1; done\n'
+        'last="${@: -1}"\n'
+        'if [ "${want:-0}" = 1 ]; then\n'
+        '  case " ${LIVE_SESSIONS:-} " in *" $last "*) exit 0 ;; *) exit 1 ;; esac\n'
+        "fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    return bindir
+
+
+def _add_row(
+    batch: Path, ident: str, destroy: str = "true", owner: str | None = None
+) -> None:
+    proc = subprocess.run(
+        ["bash", str(LEDGER), str(batch), "add", "dtu", ident, *destroy.split()],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    if owner is not None:
+        with (batch / "infra.owners.tsv").open("a", encoding="utf-8") as fh:
+            fh.write(f"2026-09-06T00:00:00Z\t{ident}\t{owner}\n")
+
+
+def _status(
+    batch: Path,
+    *,
+    bindir: Path | None = None,
+    live: tuple[str, ...] = (),
+    socket: str | None = None,
+    as_json: bool = True,
+) -> subprocess.CompletedProcess:
+    """Run the real script with an EXPLICITLY built environment.
+
+    model_performance-etuz: a highway lane exports HIGHWAY_TMUX_SOCKET, so an
+    inherited environment makes these tests pass in CI and fail inside every
+    lane -- the worst possible direction for a test to be wrong in.
+    """
+    env = {k: v for k, v in os.environ.items() if k != "HIGHWAY_TMUX_SOCKET"}
+    if bindir is not None:
+        env["PATH"] = f"{bindir}{os.pathsep}{env.get('PATH', '')}"
+        env["LIVE_SESSIONS"] = " ".join(f"hw__b__{lane}" for lane in live)
+    if socket is not None:
+        env["HIGHWAY_TMUX_SOCKET"] = socket
+    if as_json:
+        env["HIGHWAY_JSON"] = "1"
+    else:
+        env.pop("HIGHWAY_JSON", None)
+    return subprocess.run(
+        ["bash", str(STATUS), str(batch), "4", "0"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env=env,
+    )
+
+
+def _report(proc: subprocess.CompletedProcess) -> dict:
+    assert proc.returncode == 0, f"stdout={proc.stdout}\nstderr={proc.stderr}"
+    return json.loads(proc.stdout.strip().splitlines()[-1])
+
+
+# ---------------------------------------------------------------------------
+# The incident itself.
+# ---------------------------------------------------------------------------
+
+
+def test_the_ye80_incident_is_now_visible(tmp_path: Path) -> None:
+    """Six rows, owning lane dead: the exact 2026-09-05 condition.
+
+    Before this join the same batch reported `ended=1` and said nothing at all
+    about the six containers still running and still billing.
+    """
+    batch = _make_batch(tmp_path, ["drbf-compaction-notice-ab"])
+    bindir = _stub_tmux(tmp_path)
+    for suffix in ("a", "b", "c", "a2", "b2", "c2"):
+        _add_row(batch, f"val-drbf-{suffix}", owner="drbf-compaction-notice-ab")
+
+    got = _report(_status(batch, bindir=bindir, live=()))
+
+    assert got["orphan_rows"] == 6
+    assert "drbf-compaction-notice-ab(6)" in got["orphan_owners"]
+
+
+def test_a_live_lanes_rows_are_never_reported_as_orphaned(tmp_path: Path) -> None:
+    """The deliverable that can be faked by making everything pass.
+
+    A live lane and a dead lane hold rows SIMULTANEOUSLY. Counting every open
+    row would also make the test above pass, so this is the case that
+    distinguishes a real join from a row count.
+    """
+    batch = _make_batch(tmp_path, ["alive-lane-long", "drbf-compaction-notice-ab"])
+    bindir = _stub_tmux(tmp_path)
+    for suffix in ("a", "b"):
+        _add_row(batch, f"val-alive-{suffix}", owner="alive-lane-long")
+    for suffix in ("a", "b", "c", "a2", "b2", "c2"):
+        _add_row(batch, f"val-drbf-{suffix}", owner="drbf-compaction-notice-ab")
+
+    got = _report(_status(batch, bindir=bindir, live=("alive-lane-long",)))
+
+    assert got["live"] == 1 and got["ended"] == 1
+    assert got["orphan_rows"] == 6, "the live lane's two rows were counted as orphans"
+    assert "alive-lane-long" not in got["orphan_owners"]
+    assert "drbf-compaction-notice-ab(6)" in got["orphan_owners"]
+
+
+def test_every_lane_live_means_no_orphans(tmp_path: Path) -> None:
+    batch = _make_batch(tmp_path, ["alive-lane-long", "drbf-compaction-notice-ab"])
+    bindir = _stub_tmux(tmp_path)
+    _add_row(batch, "val-alive-a", owner="alive-lane-long")
+    _add_row(batch, "val-drbf-a", owner="drbf-compaction-notice-ab")
+
+    got = _report(
+        _status(
+            batch, bindir=bindir, live=("alive-lane-long", "drbf-compaction-notice-ab")
+        )
+    )
+
+    assert got["orphan_rows"] == 0
+    assert got["orphan_owners"] == ""
+
+
+# ---------------------------------------------------------------------------
+# Owner-name resolution. The two sides of this join disagree about what a lane
+# is called, measured in the live batch's own files: infra.owners.tsv holds
+# SHORT work-item ids for 5 of 13 owners and LONG manifest names for the other
+# 8. An exact-match join would false-alarm on ~40% of owners, and a report that
+# cries wolf is a report nobody reads.
+# ---------------------------------------------------------------------------
+
+
+def test_a_short_owner_id_resolves_to_its_live_lane_by_prefix(tmp_path: Path) -> None:
+    """`vbs` owning a row while lane `vbs-cache-residency` is LIVE is not an orphan."""
+    batch = _make_batch(tmp_path, ["vbs-cache-residency"])
+    bindir = _stub_tmux(tmp_path)
+    _add_row(batch, "val-vbs-a", owner="vbs")
+
+    got = _report(_status(batch, bindir=bindir, live=("vbs-cache-residency",)))
+
+    assert got["orphan_rows"] == 0, (
+        "a short-id owner was not resolved to its live lane; every lane that "
+        "claimed with a work-item id would be reported as orphaned"
+    )
+
+
+def test_a_short_owner_id_still_orphans_when_its_lane_is_dead(tmp_path: Path) -> None:
+    """Prefix resolution must not become a blanket amnesty."""
+    batch = _make_batch(tmp_path, ["vbs-cache-residency"])
+    bindir = _stub_tmux(tmp_path)
+    _add_row(batch, "val-vbs-a", owner="vbs")
+
+    got = _report(_status(batch, bindir=bindir, live=()))
+
+    assert got["orphan_rows"] == 1
+    assert "vbs-cache-residency(1)" in got["orphan_owners"]
+
+
+def test_an_ambiguous_owner_prefix_is_reported_not_guessed(tmp_path: Path) -> None:
+    """`l1` against lanes `l1-alpha` and `l1-beta` cannot be attributed.
+
+    Reporting is non-destructive, so the safe direction is to surface the row
+    and say WHY it could not be attributed -- never to silently pick a lane.
+    """
+    batch = _make_batch(tmp_path, ["l1-alpha", "l1-beta"])
+    bindir = _stub_tmux(tmp_path)
+    _add_row(batch, "val-l1-a", owner="l1")
+
+    got = _report(_status(batch, bindir=bindir, live=("l1-alpha", "l1-beta")))
+
+    assert got["orphan_rows"] == 1
+    assert "l1(ambiguous-lane)(1)" in got["orphan_owners"]
+
+
+def test_an_owner_naming_no_lane_is_flagged_distinctly(tmp_path: Path) -> None:
+    batch = _make_batch(tmp_path, ["real-lane"])
+    bindir = _stub_tmux(tmp_path)
+    _add_row(batch, "val-ghost-a", owner="zzz-ghost")
+
+    got = _report(_status(batch, bindir=bindir, live=("real-lane",)))
+
+    assert got["orphan_rows"] == 1
+    assert "zzz-ghost(no-such-lane)(1)" in got["orphan_owners"]
+
+
+def test_an_unclaimed_row_is_an_orphan(tmp_path: Path) -> None:
+    """No claim means nothing demonstrably drives it -- the Rule 14 condition."""
+    batch = _make_batch(tmp_path, ["real-lane"])
+    bindir = _stub_tmux(tmp_path)
+    _add_row(batch, "val-nobody-a", owner=None)
+
+    got = _report(_status(batch, bindir=bindir, live=("real-lane",)))
+
+    assert got["orphan_rows"] == 1
+    assert "unclaimed" in got["orphan_owners"]
+
+
+# ---------------------------------------------------------------------------
+# Scope: only OPEN rows, and only reporting.
+# ---------------------------------------------------------------------------
+
+
+def test_closed_rows_are_never_counted(tmp_path: Path) -> None:
+    """A swept row is reclaimed infrastructure, not an orphan."""
+    batch = _make_batch(tmp_path, ["dead-lane"])
+    bindir = _stub_tmux(tmp_path)
+    _add_row(batch, "val-open-a", owner="dead-lane")
+    _add_row(batch, "val-closed-a", owner="dead-lane")
+    ledger = batch / "infra.tsv"
+    ledger.write_text(
+        ledger.read_text(encoding="utf-8").replace(
+            "val-closed-a\topen", "val-closed-a\tswept"
+        ),
+        encoding="utf-8",
+    )
+
+    got = _report(_status(batch, bindir=bindir, live=()))
+
+    assert got["orphan_rows"] == 1
+
+
+def test_reporting_destroys_nothing(tmp_path: Path) -> None:
+    """The observable proof, in the 2nz style.
+
+    An exit code cannot distinguish "reported and left alone" from "reported
+    and reaped". The sentinel can: if any destroy_cmd ran, the file exists.
+    Automatic reaping was deliberately not implemented -- a false positive that
+    prints is a nuisance, a false positive that destroys is another 0rg.
+    """
+    batch = _make_batch(tmp_path, ["dead-lane"])
+    bindir = _stub_tmux(tmp_path)
+    sentinel = tmp_path / "DESTROYED"
+    _add_row(batch, "val-dead-a", destroy=f"touch {sentinel}", owner="dead-lane")
+    before = (batch / "infra.tsv").read_bytes()
+
+    got = _report(_status(batch, bindir=bindir, live=()))
+
+    assert got["orphan_rows"] == 1
+    assert not sentinel.exists(), "highway_status.sh RAN a destroy_cmd"
+    assert (batch / "infra.tsv").read_bytes() == before, "the ledger was rewritten"
+
+
+def test_a_batch_with_no_ledger_reports_zero(tmp_path: Path) -> None:
+    """The common case -- most batches ledger nothing -- must not error."""
+    batch = _make_batch(tmp_path, ["some-lane"])
+    bindir = _stub_tmux(tmp_path)
+
+    got = _report(_status(batch, bindir=bindir, live=()))
+
+    assert got["orphan_rows"] == 0
+
+
+def test_the_human_summary_names_the_owning_lane(tmp_path: Path) -> None:
+    """A count alone is not actionable: teardown needs the lane NAME."""
+    batch = _make_batch(tmp_path, ["drbf-compaction-notice-ab"])
+    bindir = _stub_tmux(tmp_path)
+    for suffix in ("a", "b", "c"):
+        _add_row(batch, f"val-drbf-{suffix}", owner="drbf-compaction-notice-ab")
+
+    proc = _status(batch, bindir=bindir, live=(), as_json=False)
+
+    assert proc.returncode == 0, proc.stderr
+    assert "orphan_rows=3" in proc.stdout
+    assert "drbf-compaction-notice-ab" in proc.stdout
+    assert "lane_teardown.sh" in proc.stdout, "the report must name the reclaim path"
+
+
+# ---------------------------------------------------------------------------
+# The stub must not be hiding an integration break.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(shutil.which("tmux") is None, reason="requires a real tmux")
+def test_real_tmux_agrees_with_the_stub(tmp_path: Path) -> None:
+    """Same scenario, real tmux server, on a socket private to this test.
+
+    Kills the session mid-test: the SAME batch must flip from 0 orphans to 2
+    with nothing else changing. That transition is the whole feature.
+    """
+    batch = _make_batch(tmp_path, ["live-lane", "dead-lane"])
+    _add_row(batch, "val-live-a", owner="live-lane")
+    _add_row(batch, "val-dead-a", owner="dead-lane")
+    socket = f"hw-test-{os.getpid()}"
+
+    def tmux(*args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["tmux", "-L", socket, *args], capture_output=True, text=True, timeout=60
+        )
+
+    try:
+        started = tmux("new-session", "-d", "-s", "hw__b__live-lane", "sleep 300")
+        if started.returncode != 0:
+            pytest.skip(f"tmux could not start a server here: {started.stderr.strip()}")
+
+        got = _report(_status(batch, socket=socket))
+        assert got["live"] == 1
+        assert got["orphan_rows"] == 1, "a REAL live lane's row was reported orphaned"
+        assert "dead-lane(1)" in got["orphan_owners"]
+
+        tmux("kill-session", "-t", "hw__b__live-lane")
+
+        after = _report(_status(batch, socket=socket))
+        assert after["live"] == 0
+        assert after["orphan_rows"] == 2, "killing the lane did not orphan its row"
+    finally:
+        tmux("kill-server")

--- a/tests/test_ten_lane_highway_orphan_rows.py
+++ b/tests/test_ten_lane_highway_orphan_rows.py
@@ -32,10 +32,11 @@ import pytest
 # have no equivalent. Same precedent as the infra_ledger and socket-default
 # suites.
 pytestmark = pytest.mark.skipif(
-    sys.platform == "win32" or shutil.which("bash") is None,
+    sys.platform != "linux" or shutil.which("bash") is None,
     reason=(
-        "highway_status.sh is a GNU/Linux shell script (stat -c %Y, tmux); "
-        "requires bash"
+        "highway_status.sh is a GNU/Linux shell script: it uses `stat -c %Y`, a GNU "
+        "coreutils flag with no BSD/macOS equivalent -- the script documents "
+        "this itself at highway_status.sh:53. Requires Linux + bash."
     ),
 )
 


### PR DESCRIPTION
## What this is

The **second and third sub-findings** of the 2026-09-05 tmux-server incident
(`model_performance-ye80`). The headline fix — the per-batch tmux socket —
already landed in `3bb0104`; its tests were repaired in `569c9b8`. This PR
closes what was left open, both of which cost real money that day.

**Sub-finding 2 lands here as code. Sub-finding 1 ships as a lane artifact**,
because its only target lives in another repo — see "Goal defect" below.

---

## Sub-finding 2 — nothing joined lane liveness to row ownership

A tmux server restart killed three lanes at once and left **six DTU containers
RUNNING with open ledger rows**. Every component worked in isolation: the
ledger recorded all six correctly, and `highway_status.sh` reported the lanes
ENDED. **No code path read both**, so "infrastructure with nothing driving it"
(Rule 14) was invisible — the manager found the containers only by running
`incus list` by hand.

`highway_status.sh` now reports:

```
SUMMARY batch=… live=1 ended=1 … watchdog=DEAD orphan_rows=6
WARNING: orphan_rows=6 owned by: drbf-compaction-notice-ab(6)
  Open infra-ledger rows whose owning lane is NOT live - infrastructure
  with nothing driving it (Rule 14). Nothing was destroyed; reclaim each
  with: lane_teardown.sh <BATCH_DIR> <lane> teardown --yes
```

and in `HIGHWAY_JSON=1` mode: `"orphan_rows":6,"orphan_owners":"drbf-compaction-notice-ab(6)"`.

**Reporting only.** Reaping is deliberately not implemented: a false positive
that prints is a nuisance, a false positive that destroys is another `0rg`.
`test_reporting_destroys_nothing` proves inertness with a `touch <sentinel>`
destroy_cmd plus a byte-identical ledger — not inferred from an exit code.

### Replayed against the real incident data

A copy of the live batch's `manifest.tsv` / `infra.tsv` / `infra.owners.tsv`,
with drbf's six rows set back to `open` (`evidence/04-incident-replay.txt`):

```
{"batch":"replay","live":1,"ended":147,…,"orphan_rows":6,
 "orphan_owners":"drbf-compaction-notice-ab(6)"}
```

The live batch today reports `orphan_rows:0`, matching its zero open rows —
the report is not crying wolf.

### Why owner names are resolved, not string-compared

The two sides of this join genuinely disagree about what a lane is called.
Measured in the live batch's own files: `infra.owners.tsv` holds **short
work-item ids for 5 of 13 owners** (`vbs`, `127`, `3d2`, `6da`, `k64`) and
**long manifest names for the other 8**. Resolution is exact-name, else a
**unique** token-boundary prefix. An exact-match join would have false-alarmed
on ~40% of this batch's owners. Ambiguous (`l1` vs `l1-alpha`/`l1-beta`),
unresolvable, and unclaimed owners are each reported **as such**, never guessed.

### A live lane's rows are NEVER counted

The deliverable most easily faked by making everything pass. Pinned three ways:

- `test_a_live_lanes_rows_are_never_reported_as_orphaned` — live lane owns 2
  rows, dead lane owns 6, **simultaneously**; asserts `orphan_rows == 6` *and*
  the live lane's name is absent. Counting every open row would also pass the
  incident test; this is what separates a real join from a row count.
- `test_real_tmux_agrees_with_the_stub` — same scenario against a **real tmux
  server**, then kills the session mid-test and asserts the same batch flips
  1 → 2 orphans with nothing else changed.
- Harness CASE 3 — the live lanes' containers survive an exact-name teardown.

---

## Sub-finding 1 — `lane_teardown.sh`'s near-miss footgun (artifact, not code)

Measured during the recovery, with six containers still billing:

```
lane_teardown.sh <batch> drbf teardown --yes
  -> "TEARDOWN: lane 'drbf' owns no open rows -- nothing to do"    (exit 0)
```

**Root cause, traced through the code.** The rows are `val-drbf-a…c2`, claimed
to `drbf-compaction-notice-ab`. `classify()` consults **claims first**, returns
`OTHER:drbf-compaction-notice-ab`, and the **inference** rule that *would* have
matched `val-drbf-*` for lane `drbf` is never reached. Every candidate lands in
PROTECTED, `sel_ids` is empty, and the empty-selection branch prints a success
message and exits 0.

Fixed, and proven fail-before/pass-after — but **shipped as a patch**, see below.
The guard is narrow on purpose (an id inference would have selected, or an owner
name prefix-related to `$LANE` **in either direction**), exits **4**, and names
each candidate with its open-row count and the corrected command. It is *not*
"any protected row is an error": most lanes provision nothing and run teardown
anyway, and failing them because an unrelated lane holds rows would be a
regression. CASE 4 pins that.

```
FAIL-BEFORE (unpatched):  RESULT: FAIL -- 3 expectation(s) unmet
PASS-AFTER  (patched):    RESULT: PASS -- near-miss guard present, protection intact
```

The exact-name path is unchanged, reproducing the incident's own recovery
transcript: `verified-gone=6 rows-flipped=6 … protected-untouched=4`, with each
of the four live-lane containers asserted **still present** in the stub's state.

---

## One fix or two?

**One cause, two sites, and they must ship separately.** The cause is single:
nothing reconciles a lane's identity across `manifest.tsv`, `infra.owners.tsv`
and `infra.tsv`, so a lane-name lookup returns "nothing" instead of "I could
not tell". The blast radii are not single, and that decides the shape:

- **`lane_teardown.sh` DESTROYS.** Its fix must fail **closed** — refuse, exit
  non-zero, name the candidates — and stay conservative.
- **`highway_status.sh` only REPORTS.** Its fix can fail **open** — report,
  name the reason — because a false positive costs a printed line.

Merging them into one mechanism would force one policy onto the wrong side.

---

## Goal defect (reported, not absorbed)

`lane_teardown.sh` lives at
`/home/bkrabach/dev/openai-evals-team-ci/.amplifier/evaluation/tools/lane_teardown.sh`
— **a different repo, and untracked even there**:

```
$ git -C …/openai-evals-team-ci ls-files --error-unmatch \
      .amplifier/evaluation/tools/lane_teardown.sh
error: pathspec '…' did not match any file(s) known to git
```

This lane owns `amplifier-app-cli`, which ships `infra_ledger.sh`,
`highway_status.sh`, `launch_lane.sh`, `verify_lane.sh`, `highway_watchdog.sh`
— and no `lane_teardown.sh`. Per the goal's own rule, the fix is shipped as a
patch artifact and the other repo was not touched.

**The deeper defect** (lane `2nz` already flagged it): the shipped skill
**names a tool it does not ship**. `infra_ledger.sh`'s refusal message tells the
operator to run `.amplifier/evaluation/tools/lane_teardown.sh` — an evals-repo
path — and `SKILL.md` names it with no path at all. Until that tool is adopted
here, every fix to it is unversioned. Recommended as its own item; deliberately
not smuggled into this PR, since a second copy of a 409-line tool the manager
runs live from the other path is worse than the footgun.

---

## Tests

```
$ python -m pytest -q
1 failed, 1818 passed, 2 skipped, 13 deselected, 1 xfailed in 12.86s
```

The failure is `tests/test_fail_loud_bundle_activation.py::…::test_error_is_a_bundle_error`
(`assert issubclass(ModuleActivationError, BundleError)`), a foundation-contract
assertion. **Proven pre-existing** — `git stash -u`, clean HEAD:

```
1 failed, 1805 passed, 2 skipped, 13 deselected, 1 xfailed in 12.24s
```

Identical failure; the delta is exactly this PR's +13 tests.

**Two corrections to the goal's KNOWN section:** the failure it predicted
(`test_truststore_wrap_bio_shim.py::test_real_truststore_is_covered_at_cli_import`)
did **not** occur in either run — that prediction is stale — and the failure
that *does* occur is a different one the goal does not mention. A later lane
should not absorb it either.

New-file lint clean (`ruff check`, `ruff format --check`); the 6 `ruff check
tests/` errors are pre-existing unused imports in two untouched files.

## Spend

**$0.00** of the $0.00 authority. No container, no DTU, no eval, no API spend —
as the goal's arithmetic (`0 × 0 × $0 / 1.00 = $0.00`) predicted. No
infrastructure registered, claimed, or torn down; the live ledger was never
written to, and `sweep` was never run.

## Artifacts

`docs/lanes/ye80b-teardown-orphan-rows/` — `DONE-NOTE.md`,
`PROPOSED-evals-lane-teardown-near-miss.patch`,
`test_lane_teardown_near_miss.sh`, and `evidence/00…07`.
