### PR TITLE
fix(config): compose notify's BEHAVIORS, not the notify ROOT bundle

### DIFF
--- a/amplifier_app_cli/runtime/config.py
+++ b/amplifier_app_cli/runtime/config.py
@@ -1321,6 +1321,32 @@ def _build_notification_behaviors(flags: NotificationFlags) -> list[str]:
     sibling consumer ``AppSettings.get_notification_hook_overrides()`` reads
     the same flags, so the two paths cannot drift apart on defaults.
 
+    Only the behaviors, NEVER the root ``bundle.md`` — same reasoning as
+    ``_build_modes_behaviors`` / ``_build_skills_behaviors`` /
+    ``_build_wayfinder_behaviors`` / ``_build_app_cli_behaviors``, all of
+    which already compose behavior-only URIs. notify's root ``bundle.md``
+    carries an 82-line README body, and ``Bundle.compose()`` replaces the
+    instruction whenever the composed bundle has a non-empty markdown body.
+
+    The root URI used to be composed here anyway, as "a minimal marker …
+    ensures the bundle gets cached with proper SHA metadata (fixes the
+    'unknown' version issue during `amplifier update`)". It is not needed
+    for that, and it never was: ``GitSourceHandler._get_cache_path()`` keys
+    the clone on ``sha256("<git_url>@<ref>")``, which does NOT include the
+    ``#subdirectory=`` fragment. Fetching a behavior URI therefore populates
+    the exact same cache entry that ``amplifier update``'s status check for
+    the ROOT URI reads (``update.py::_check_bundle_uri`` →
+    ``GitSourceHandler.get_status``, resolving "notify" through
+    ``WELL_KNOWN_BUNDLES``). Measured on the real repo in an isolated
+    ``AMPLIFIER_HOME``: with only the two behavior URIs fetched and the root
+    never composed, ``amplifier update --check-only`` reports notify at
+    ``7f5ff46``, not ``unknown``.
+
+    That invariant is pinned by
+    ``tests/test_notify_behaviors_not_root.py`` so a future
+    fragment-sensitive cache key in amplifier-foundation fails loudly here
+    instead of silently reintroducing the "unknown" version.
+
     Args:
         flags: Resolved notification enablement.
 
@@ -1332,12 +1358,6 @@ def _build_notification_behaviors(flags: NotificationFlags) -> list[str]:
         return []
 
     behaviors: list[str] = []
-
-    # Root bundle first — a minimal marker that just identifies the repo
-    # and ensures the bundle gets cached with proper SHA metadata (fixes
-    # the "unknown" version issue during `amplifier update`). The actual
-    # functionality comes from the subdirectory behaviors below.
-    behaviors.append("git+https://github.com/microsoft/amplifier-bundle-notify@main")
 
     if flags.desktop_enabled:
         behaviors.append(

--- a/docs/lanes/ozbw-notify-behaviors-not-root/DONE-NOTE.md
+++ b/docs/lanes/ozbw-notify-behaviors-not-root/DONE-NOTE.md
@@ -1,0 +1,318 @@
+# Lane `ozbw` — compose the notify BEHAVIORS, not the notify ROOT
+
+**Item:** `model_performance-ozbw` · **Repo:** `microsoft/amplifier-app-cli` ·
+**Branch:** `lane/ozbw-notify-behaviors-not-root` ·
+**PR:** [#316](https://github.com/microsoft/amplifier-app-cli/pull/316) (READY, not draft) ·
+**Head:** `9ff57c3f01e44dd846325580299e9ce3a8f9bf15`
+
+**Outcome: branch A — RESOLVED.** All eight deliverables DONE. Nothing NOT-POSSIBLE,
+nothing blocked. Spend authority `$0` was correct and was not exceeded.
+
+---
+
+## 1. Deliverables
+
+| # | Deliverable | State |
+|---|---|---|
+| 1 | `_build_notification_behaviors()` returns ONLY behavior URIs, never a bare root; pinned by a test | **DONE** |
+| 2 | `amplifier update` SHA motivation preserved, fail-before reproduced first | **DONE** |
+| 3 | #315 guard tests still pass; guard untouched; stated in the PR body | **DONE** (5/5) |
+| 4 | Real-session check + `amplifier update --check-only` real SHA | **DONE** |
+| 5 | Audit the rest of `config.py` for the same pattern | **DONE** (0 remaining) |
+| 6 | Update notify PR #10's description; do not merge | **DONE** |
+| 7 | PR left READY with a verification comment | **DONE** ([comment](https://github.com/microsoft/amplifier-app-cli/pull/316#issuecomment-5559861684)) |
+| 8 | Full suite green, pasted in the PR body | **DONE** (1853 passed) |
+
+---
+
+## 2. The change
+
+One deletion in `amplifier_app_cli/runtime/config.py`:
+
+```diff
+-    # Root bundle first — a minimal marker that just identifies the repo
+-    # and ensures the bundle gets cached with proper SHA metadata (fixes
+-    # the "unknown" version issue during `amplifier update`). The actual
+-    # functionality comes from the subdirectory behaviors below.
+-    behaviors.append("git+https://github.com/microsoft/amplifier-bundle-notify@main")
+```
+
+plus a docstring recording *why* the removal is safe, and 12 new tests.
+
+---
+
+## 3. The hard part — the `amplifier update` SHA motivation
+
+This is deliverable 2, and the goal was right to make it the gate.
+
+### What the original bug actually was
+
+`git log -L` on the line leads to **`2fa2c47`** — *"fix: resolve 'unknown' SHA for bundles
+during update check"*. Its own message says the update check "looks for ROOT bundle cache
+entries. Since only subdirectory entries were cached, the root bundles showed 'unknown'".
+The same commit added the root URI to **both** `_build_notification_behaviors()` and
+`_build_modes_behaviors()`.
+
+**`modes` already lost its root URI**, in `91e1beb` (*"load modes behavior only, not root
+bundle"*), with no replacement for the SHA motivation and no reported regression. notify
+was the last survivor. That was the first hint the stated motivation did not hold.
+
+### Why it does not hold
+
+`amplifier update` never depended on the composition. It resolves `notify` through
+`WELL_KNOWN_BUNDLES` (`discovery.py:82`, which registers the **root** remote URI and is
+added unconditionally by `list_cached_root_bundles()` step 2), then asks
+`GitSourceHandler.get_status()` for the root URI's cached commit
+(`commands/update.py::_check_bundle_uri`).
+
+And `GitSourceHandler._get_cache_path()` is:
+
+```python
+cache_key = sha256(f"{git_url}@{ref}".encode()).hexdigest()[:16]
+```
+
+`git_url` comes from `_build_git_url()` = `scheme://host/path` — **the `#subdirectory=`
+fragment is not in the key.** Measured:
+
+```
+ROOT     cache_path = amplifier-bundle-notify-a1c452253c0fb2e2   subpath=''
+DESKTOP  cache_path = amplifier-bundle-notify-a1c452253c0fb2e2   subpath='behaviors/desktop-notifications.yaml'
+PUSH     cache_path = amplifier-bundle-notify-a1c452253c0fb2e2   subpath='behaviors/push-notifications.yaml'
+```
+
+One clone, one metadata file, one `git rev-parse HEAD`. Fetching a behavior fills the
+entry the root's status check reads. The root composition contributed **nothing**.
+
+### Fail-before / pass-after — and an honest note on what "before" can mean
+
+The deliverable asks for the symptom "with the root line removed and *no* replacement".
+**That state is not reachable in the running system**: remove the root line and the two
+behavior URIs are still composed, and they fetch the repo. So the honest report is —
+
+> The symptom does **not** reproduce with the root line removed, because the behavior
+> fetch already populates the same cache entry. No replacement was needed, and none was
+> written.
+
+Which is a stronger result than "I found a replacement", but only if the symptom itself is
+demonstrated rather than asserted. It was, three ways, all with the **real** repo or a
+real git repo, never a mock:
+
+**(a) Live, real CLI, real repo, isolated `AMPLIFIER_HOME`** — `evidence/live-update-sha.txt`
+
+```
+BEFORE (nothing from the notify repo fetched):
+│ modes  │ unknown │ 3e2a9e6 │ ● │
+│ notify │ unknown │ 7f5ff46 │ ● │     <-- the reported symptom, reproduced
+
+… fetch ONLY the two #subdirectory=behaviors/*.yaml URIs; the ROOT is never resolved …
+
+AFTER (same command, same isolated home):
+│ modes  │ unknown │ 3e2a9e6 │ ● │     <-- CONTROL, unchanged
+│ notify │ 7f5ff46 │ 7f5ff46 │ ✓ │     <-- real SHA
+```
+
+The `modes` control matters: it rules out "the second invocation just works". `modes` is
+behavior-only in code and nothing fetched it in this experiment, so it stays `unknown`
+while `notify` moves. The only difference between the two rows is the fetch.
+
+**(b) End-to-end through the changed code** — `evidence/e2e-branch-update-sha.txt`.
+Feed `_build_notification_behaviors(desktop=True, push=True)`'s own output into a fresh
+isolated cache, assert no bare-root URI leaked, fetch exactly those URIs, then run the
+real `amplifier update --check-only`: `notify │ 7f5ff46 │ 7f5ff46 │ ✓`.
+Same result against the real `~/.amplifier` from the branch build.
+
+**(c) Hermetic, no network** — `evidence/fail-before-pass-after-hermetic.txt`, and now a
+test. A throwaway git repo shaped like notify (root `bundle.md` **with** a body):
+
+| state | root's `cached_commit` |
+|---|---|
+| nothing fetched | `unknown` (None) |
+| behaviors only, root never composed | `571599d6…` = real HEAD |
+| control: root + behaviors (today's code) | `571599d6…`, byte-identical |
+
+### The invariant is now pinned, not assumed
+
+Removing the workaround means depending on foundation's cache key staying
+fragment-insensitive — a cross-repo assumption. So it is a test, with the failure message
+saying exactly what broke and what to do:
+`test_behavior_uri_and_root_uri_share_one_git_cache_entry`. If amplifier-foundation ever
+keys on the fragment, this repo fails loudly instead of silently reporting `unknown`.
+
+---
+
+## 4. Real-session check (deliverable 4)
+
+`amplifier run "hi" -B anchors-amp-dev`, same host, same `~/.amplifier` settings
+(`notifications.desktop.enabled: true`, `notifications.ntfy.enabled: true`), scratch build
+(`uv run`) of each tree. `evidence/real-session-before-after.txt`.
+
+| | BEFORE — worktree at `dab0f7c` | AFTER — this branch |
+|---|---|---|
+| session | `10d7a2e8-1295-481f-881d-c4c5f95c92e7` | `05457635-b553-4559-8815-55306e3bfd59` |
+| `raw.system` chars | 97,978 | 98,339 |
+| first line | `@anchors-amp-dev:context/system.md` | same |
+| marker `configured for development OF` | **true** | **true** |
+| `# Notify Bundle` anywhere | **false** | **false** |
+| `<context_file>` blocks | **23** | **23** |
+| `mentions:resolved` | 23 | 23 |
+| **#315 drop-warning naming `amplifier-bundle-notify`** | **1** | **0** |
+
+`amplifier update --check-only` from the branch build against the real home:
+`notify │ 7f5ff46 │ 7f5ff46 │ ✓`.
+
+**Reading this honestly.** `raw.system` is already correct on `dab0f7c` — that is #315
+doing its job, and this lane must not claim credit for it. The line that moves is the
+last one: on `dab0f7c` the guard fires **every session**, because notify's root body still
+enters `compose()` and has to be dropped. After this change it never enters compose at all,
+so there is nothing to drop and users stop seeing that warning. That is precisely the
+deliverable's *"it is no longer even entering compose"*.
+
+23 = the 22 app-bundle context includes + the root bundle's own
+`@anchors-amp-dev:context/system.md`, matching f26u's measured `mentions:resolved = 23`.
+
+---
+
+## 5. Audit (deliverable 5) — one bug, not a pattern, and now guarded
+
+`evidence/config-audit.txt`. Every always-on behavior builder, checked by **running** it:
+
+| builder | verdict |
+|---|---|
+| `_build_modes_behaviors` | behavior-only (fixed earlier, `91e1beb`) |
+| `_build_skills_behaviors` | behavior-only |
+| `_build_wayfinder_behaviors` | behavior-only |
+| `_build_app_cli_behaviors` | behavior-only (`file://…#subdirectory=behaviors/cli-expertise.yaml`) |
+| `_build_notification_behaviors` | **was the last root-composer — fixed here** |
+
+**Bare-root URIs composed as behaviors: 0.** Four of the five already carried a docstring
+saying "only the behavior, NOT the root bundle.md"; notify was the one that said the
+opposite and did the opposite. The finding is therefore *"it was a known hazard with no
+enforcement"* — so enforcement is what was added:
+`test_no_always_on_behavior_builder_composes_a_bare_root_bundle` covers all five.
+
+The sixth `compose_behaviors` source is the user's own `bundle.app` list
+(`config.py:127`). That is user-authored and not app-cli's to police — and it is exactly
+what #315's guard protects. Left alone, deliberately.
+
+---
+
+## 6. Tests and suite
+
+New `tests/test_notify_behaviors_not_root.py` — **+12**, covering: no bare root across all
+three flag combinations; every URI carries `#subdirectory=behaviors/` and ends `.yaml`;
+exact per-combination lists; the five-builder pattern guard; the shared-cache-path
+invariant; and the hermetic end-to-end fail-before/pass-after.
+
+The end-to-end test builds a `git+file://` URI, so it carries
+`skipif(sys.platform == "win32")` with the reason stated in the decorator (a `C:/…`
+drive-letter path is not expressible in `_build_git_url()`'s `scheme://host+path` split),
+and notes that the same invariant is pinned platform-independently by the
+cache-path test. CI runs Windows and macOS; nothing else in the change is
+platform-dependent.
+
+Two stale comments in `tests/test_notification_hook_overrides_defaults.py` ("composes the
+root bundle + …") were corrected. **No assertion in that file changed** — its checks were
+already `any(... in b ...)`, which is why they did not catch this.
+
+| | baseline (worktree at `dab0f7c`) | this branch |
+|---|---|---|
+| `uv run pytest -q` | 1841 passed, 1 skipped, 13 deselected, 1 xfailed | **1853 passed**, 1 skipped, 13 deselected, 1 xfailed |
+
+Delta = +12, all new, all passing. `evidence/full-suite.txt`.
+
+**The known failure, reported rather than hidden.** An earlier full-suite run of **both**
+trees produced one failure —
+`tests/test_truststore_wrap_bio_shim.py::test_real_truststore_is_covered_at_cli_import`,
+*"skipped: truststore is not importable"* — at 1 failed/1840 (baseline) and 1 failed/1852
+(branch). Identical failure, identical cause, present with and without this change; it is
+the collection-order dependency the goal names, and it passes in isolation (11 passed). It
+did not reproduce on the recorded capture. Either way the failure set is the same in both
+trees and the only delta is +12 passes. Not absorbed.
+
+**Baseline method:** a `git worktree` at HEAD rather than `git stash`, so the comparison
+tree is a real independent checkout and there is no window in which the work could be lost.
+
+---
+
+## 7. Spend
+
+**Authority: `$0` — arithmetic `0 runs × 0 arms × $0 / 1.00 = $0.00`, slack `$0.00`.**
+
+Checked on first read, as the authoring rule requires: the arithmetic **closes**. This
+item buys zero runs; it is a pure code/test change. There is no validity rate to divide
+by and nothing to under-fund. **No branch-B finding on cap sizing.**
+
+| Item | Cost |
+|---|---|
+| API/DTU purchases against the authority | **$0.00** |
+| `amplifier run "hi"` ×2 — BEFORE $0.27, AFTER $0.75 | $1.02 (local verification invocations) |
+| `amplifier update --check-only` ×4, hermetic probes, full suite ×4 | $0.00 (no LLM) |
+
+The two `amplifier run "hi"` invocations are the deliverable-4 real-session check. Per the
+item's own wording these are normal local invocations, not purchases, and are recorded
+anyway — same treatment as lane f26u ($1.02 for the same two calls, coincidentally
+identical).
+
+**Residue:** the authority is `$0.00` and nothing needed buying, so there is no unspendable
+residue to report. **Infrastructure created: none** — no DTU, no Gitea, no containers. No
+`infra_ledger.sh` rows, nothing to tear down. `sweep` was never run.
+
+---
+
+## 8. Deviations and corrections, all named
+
+1. **PR is READY, not draft.** Procedure step 4 says `gh pr create --draft`; the
+   DELIVERABLES list says *"A PR left READY (not draft) with a verification comment"* and
+   explains why (owner pre-authorized admin merge; manager merges next cycle after
+   re-running the fail-befores). The item-specific deliverable is the more specific
+   instruction, so the PR is open and ready. Recorded here as the goal requires.
+2. **Correction to the goal's KNOWN section.** It states *"this host's installed CLI is a
+   git install pinned at `6afcae3d`"*. It is not: `amplifier --version` reports
+   `2026.09.06-dab0f7c (core 1.6.1)` — i.e. f26u's own commit, **with** the #315 fix. This
+   changed nothing about the work (the scratch builds are what was measured), but the note
+   as written would mislead the next reader. Consistent with it: the BEFORE session shows
+   `# Notify Bundle` **absent** and the drop-warning **present**, which is the fixed
+   build's signature, not the broken one's.
+3. **The fail-before is the symptom, not the literal state.** Stated in §3 rather than
+   quietly satisfied: "root line removed, no replacement" is unreachable, so what is
+   reproduced is the underlying `unknown`, plus a control proving the behavior fetch is
+   what clears it.
+4. **`_preserve_root_instruction()` untouched.** Not weakened, not removed, still five
+   passing tests. Said explicitly in the PR body, as the deliverable requires.
+5. **notify PR #10 not merged.** Only its description was edited, to record that after
+   #316 the root body is inert twice over and #10 is hygiene rather than a fix. No file in
+   `amplifier-bundle-notify` was touched. (`gh pr edit` emitted a Projects-classic
+   deprecation error and did **not** write; the edit was completed with
+   `gh api -X PATCH` and then read back to confirm it landed.)
+
+---
+
+## 9. Open, for whoever picks this up
+
+1. **`modes`, `skills`, `wayfinder` and `routing-matrix` can report `unknown` in
+   `amplifier update` on a fresh install** — visible in `evidence/live-update-sha.txt`,
+   where every uncached bundle shows `unknown`. That is the *general* form of the bug
+   `2fa2c47` was chasing, and it is orthogonal to this change: a bundle whose repo has
+   never been fetched has no cached commit. Whether `amplifier update` should show
+   `not cached` rather than `unknown` there is a display question this lane did not touch.
+2. **f26u's §6 follow-ups still stand** — the composed bundle inheriting the last
+   behavior's `name`/`base_path`, and the owner-last compose ordering. Neither is affected
+   by this change.
+
+---
+
+## 10. Files
+
+```
+amplifier_app_cli/runtime/config.py                      (the change + rationale docstring)
+tests/test_notify_behaviors_not_root.py                  (new, +12 tests)
+tests/test_notification_hook_overrides_defaults.py       (2 stale comments corrected)
+docs/lanes/ozbw-notify-behaviors-not-root/DONE-NOTE.md   (this file)
+docs/lanes/ozbw-notify-behaviors-not-root/evidence/
+    live-update-sha.txt                  live CLI fail-before/pass-after, real repo
+    e2e-branch-update-sha.txt            end-to-end through the changed code
+    fail-before-pass-after-hermetic.txt  hermetic 3-state probe + cache-path identity
+    real-session-before-after.txt        amplifier run "hi", before/after
+    config-audit.txt                     all five builders, verdict per URI
+    full-suite.txt                       baseline vs branch, plus the known failure
+```

--- a/docs/lanes/ozbw-notify-behaviors-not-root/DONE-NOTE.md
+++ b/docs/lanes/ozbw-notify-behaviors-not-root/DONE-NOTE.md
@@ -229,6 +229,20 @@ the collection-order dependency the goal names, and it passes in isolation (11 p
 did not reproduce on the recorded capture. Either way the failure set is the same in both
 trees and the only delta is +12 passes. Not absorbed.
 
+### CI on PR #316 — all green
+
+All 9 checks pass: `pytest` on ubuntu/macOS/Windows × py3.11/py3.12, both
+`pytest -m integration` jobs (ubuntu, macOS), and `license/cla`.
+
+The first attempt showed `pytest (macos-latest, py3.11)` red at 18s. That was **not a
+test failure** — the job died in the `Install uv` step with
+`API rate limit exceeded for 13.105.117.96` (`astral-sh/setup-uv@v5` falling back to
+anonymous GitHub API access). The suite never ran. Re-running the failed job passed in
+30s. Recorded rather than quietly re-run, because "macOS red" on a PR that adds a
+platform-guarded test is exactly the shape a real skipif bug would take — it was checked
+before being dismissed. Windows py3.11 and py3.12 both pass, which is the check that
+matters for the `skipif(win32)` decorator.
+
 **Baseline method:** a `git worktree` at HEAD rather than `git stash`, so the comparison
 tree is a real independent checkout and there is no window in which the work could be lost.
 

--- a/docs/lanes/ozbw-notify-behaviors-not-root/evidence/config-audit.txt
+++ b/docs/lanes/ozbw-notify-behaviors-not-root/evidence/config-audit.txt
@@ -1,0 +1,37 @@
+AUDIT -- every URI that config.py composes as a behavior onto the user's root bundle.
+Method: read compose_behaviors assembly (config.py:86-127), then every _build_*_behaviors().
+
+$ grep -n 'compose_behaviors' amplifier_app_cli/runtime/config.py
+86:        compose_behaviors: list[str] = []
+90:        compose_behaviors.extend(_build_modes_behaviors())
+97:        compose_behaviors.extend(_build_app_cli_behaviors())
+104:        compose_behaviors.extend(_build_skills_behaviors())
+113:        compose_behaviors.extend(_build_wayfinder_behaviors())
+119:        compose_behaviors.extend(
+127:            compose_behaviors = compose_behaviors + app_bundles
+156:        # If compose_behaviors is provided, those behaviors are composed onto the bundle
+162:            compose_behaviors=compose_behaviors if compose_behaviors else None,
+383:    # Note: Notification hooks are now composed via compose_behaviors parameter
+
+$ grep -n 'git+https\|file://' amplifier_app_cli/runtime/config.py
+1161:        "git+https://github.com/microsoft/amplifier-bundle-modes@main#subdirectory=behaviors/modes.yaml",
+1181:        "git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=behaviors/skills.yaml",
+1205:        "git+https://github.com/microsoft/amplifier-bundle-wayfinder@main#subdirectory=behaviors/wayfinder.yaml",
+1308:    return [f"file://{bundle_root}#subdirectory={_APP_CLI_BEHAVIOR_RELPATH}"]
+1364:            "git+https://github.com/microsoft/amplifier-bundle-notify@main#subdirectory=behaviors/desktop-notifications.yaml"
+1369:            "git+https://github.com/microsoft/amplifier-bundle-notify@main#subdirectory=behaviors/push-notifications.yaml"
+
+VERDICT per builder (does every URI it returns carry #subdirectory= ?):
+  [OK ] _build_modes_behaviors           git+https://github.com/microsoft/amplifier-bundle-modes@main#subdirectory=behaviors/modes.yaml
+  [OK ] _build_app_cli_behaviors         file:///home/bkrabach/dev/hw-model-performance/lanes/ozbw-notify-behaviors-not-root/amplifier-app-cli#subdirectory=behaviors/cli-expertise.yaml
+  [OK ] _build_skills_behaviors          git+https://github.com/microsoft/amplifier-bundle-skills@main#subdirectory=behaviors/skills.yaml
+  [OK ] _build_wayfinder_behaviors       git+https://github.com/microsoft/amplifier-bundle-wayfinder@main#subdirectory=behaviors/wayfinder.yaml
+  [OK ] _build_notification_behaviors    git+https://github.com/microsoft/amplifier-bundle-notify@main#subdirectory=behaviors/desktop-notifications.yaml
+  [OK ] _build_notification_behaviors    git+https://github.com/microsoft/amplifier-bundle-notify@main#subdirectory=behaviors/push-notifications.yaml
+
+bare-root URIs composed as behaviors: 0
+
+The 6th source of compose_behaviors is settings' bundle.app list (config.py:127),
+which is user-authored, not app-cli's to police -- and #315's guard is exactly
+what protects the user there. Pinned by tests/test_notify_behaviors_not_root.py::
+test_no_always_on_behavior_builder_composes_a_bare_root_bundle.

--- a/docs/lanes/ozbw-notify-behaviors-not-root/evidence/e2e-branch-update-sha.txt
+++ b/docs/lanes/ozbw-notify-behaviors-not-root/evidence/e2e-branch-update-sha.txt
@@ -1,0 +1,9 @@
+Uninstalled 1 package in 1ms
+Installed 1 package in 21ms
+_build_notification_behaviors(desktop=True, push=True) returned:
+    git+https://github.com/microsoft/amplifier-bundle-notify@main#subdirectory=behaviors/desktop-notifications.yaml
+    git+https://github.com/microsoft/amplifier-bundle-notify@main#subdirectory=behaviors/push-notifications.yaml
+
+cache before: []
+cache after : ['amplifier-bundle-notify-a1c452253c0fb2e2']
+│ notify                                               │ 7f5ff46 │ 7f5ff46 │ ✓ │

--- a/docs/lanes/ozbw-notify-behaviors-not-root/evidence/fail-before-pass-after-hermetic.txt
+++ b/docs/lanes/ozbw-notify-behaviors-not-root/evidence/fail-before-pass-after-hermetic.txt
@@ -1,0 +1,38 @@
+local repo HEAD (ground truth) = 1b327bfc81d44423a21925945bee5cafa9efbc20
+
+STATE 1  FAIL-BEFORE -- nothing from the repo fetched (the original symptom)
+    cache entries      : []
+    root is_cached     : False
+    root cached_commit : unknown
+    `amplifier update` would show: unknown
+
+    fetched behavior-only URI -> active_path ends with: .../desktop-notifications.yaml
+    fetched behavior-only URI -> active_path ends with: .../push-notifications.yaml
+
+STATE 2  PASS-AFTER -- ONLY behaviors/*.yaml composed, root NEVER composed
+    cache entries      : ['amplifier-bundle-notify-2b4c86a1610c36e0']
+    root is_cached     : True
+    root cached_commit : 1b327bfc81d44423a21925945bee5cafa9efbc20
+    `amplifier update` would show: 1b327bf
+
+STATE 3  CONTROL (today's code) -- root URI composed first, then behaviors
+    cache entries      : ['amplifier-bundle-notify-2b4c86a1610c36e0']
+    root is_cached     : True
+    root cached_commit : 1b327bfc81d44423a21925945bee5cafa9efbc20
+    `amplifier update` would show: 1b327bf
+
+==============================================================================
+STATE 1 (nothing fetched)      -> unknown   <-- the reported symptom, reproduced
+STATE 2 (behaviors only)       -> 1b327bfc81d44423a21925945bee5cafa9efbc20
+STATE 3 (root + behaviors)     -> 1b327bfc81d44423a21925945bee5cafa9efbc20
+
+STATE 2 == STATE 3 == real HEAD : True
+CONCLUSION: composing the ROOT URI contributes NOTHING to the SHA metadata.
+The cache key is sha256('<git_url>@<ref>') -- the #subdirectory fragment is not
+part of it -- so fetching a behavior URI populates the very cache entry that
+get_status() on the ROOT URI reads. Removing the root line needs no replacement.
+ROOT     cache_path = amplifier-bundle-notify-a1c452253c0fb2e2   subpath=''
+DESKTOP  cache_path = amplifier-bundle-notify-a1c452253c0fb2e2   subpath='behaviors/desktop-notifications.yaml'
+PUSH     cache_path = amplifier-bundle-notify-a1c452253c0fb2e2   subpath='behaviors/push-notifications.yaml'
+
+identical: True

--- a/docs/lanes/ozbw-notify-behaviors-not-root/evidence/full-suite.txt
+++ b/docs/lanes/ozbw-notify-behaviors-not-root/evidence/full-suite.txt
@@ -1,0 +1,29 @@
+FULL SUITE -- uv run pytest -q
+
+=== BASELINE (git worktree at HEAD dab0f7c, unmodified) ===
+........................................................................ [ 97%]
+...........................................                              [100%]
+1841 passed, 1 skipped, 13 deselected, 1 xfailed in 18.21s
+
+=== THIS BRANCH ===
+........................................................................ [ 97%]
+.......................................................                  [100%]
+1853 passed, 1 skipped, 13 deselected, 1 xfailed in 18.36s
+
+Both trees GREEN on this capture. Delta = +12 tests, all new, all passing.
+
+Reported honestly: an EARLIER full-suite run of BOTH trees produced one failure --
+tests/test_truststore_wrap_bio_shim.py::test_real_truststore_is_covered_at_cli_import,
+"skipped: truststore is not importable" -- at 1 failed/1840 passed (baseline) and
+1 failed/1852 passed (branch). Identical failure, identical cause, present with and
+without this change. It is the known collection-order dependency named in the goal;
+it did not reproduce on this capture. Either way it is not this lane's and was not
+absorbed: the failure set is the same in both trees, and the only delta is +12 passes.
+
+=== that test in isolation, on this branch ===
+...........                                                              [100%]
+11 passed in 0.47s
+
+=== the new + guard tests, this branch ===
+..............................                                           [100%]
+30 passed in 0.24s

--- a/docs/lanes/ozbw-notify-behaviors-not-root/evidence/live-update-sha.txt
+++ b/docs/lanes/ozbw-notify-behaviors-not-root/evidence/live-update-sha.txt
@@ -1,0 +1,45 @@
+LIVE fail-before / pass-after -- real amplifier-bundle-notify repo, real `amplifier update --check-only`
+Isolated AMPLIFIER_HOME=/tmp/ozbw/home-live (the shared ~/.amplifier cache was never touched).
+CLI under test: amplifier, version 2026.09.06-dab0f7c (core 1.6.1)
+
+--- BEFORE: nothing from the notify repo fetched into this cache ---
+$ AMPLIFIER_HOME=/tmp/ozbw/home-live amplifier update --check-only
+│ dot-graph             │ unknown │ 8f50273 │ ● │
+│ evaluation            │ unknown │ 3531ccd │ ● │
+│ foundation            │ unknown │ e681764 │ ● │
+│ infographic           │ unknown │ 4bbe7f7 │ ● │
+│ ios-tester            │ unknown │ a1fe589 │ ● │
+│ jarvis                │ unknown │ unknown │ ✓ │
+│ made-support          │ unknown │ cac05dd │ ● │
+│ modes                 │ unknown │ 3e2a9e6 │ ● │
+│ notify                │ unknown │ 7f5ff46 │ ● │
+│ reality-check         │ unknown │ 683f518 │ ● │
+│ recipes               │ unknown │ 342760d │ ● │
+│ routing-matrix        │ unknown │ 8f51709 │ ● │
+│ stories               │ unknown │ 1f2019e │ ● │
+
+--- ACTION: fetch ONLY the two #subdirectory=behaviors/*.yaml URIs. The ROOT URI is never resolved. ---
+fetched (behavior URI only): behaviors/desktop-notifications.yaml
+fetched (behavior URI only): behaviors/push-notifications.yaml
+cache entries now: ['amplifier-bundle-notify-a1c452253c0fb2e2']
+
+--- AFTER: same command, same isolated home ---
+│ dot-graph             │ unknown │ 8f50273 │ ● │
+│ evaluation            │ unknown │ 3531ccd │ ● │
+│ foundation            │ unknown │ e681764 │ ● │
+│ infographic           │ unknown │ 4bbe7f7 │ ● │
+│ ios-tester            │ unknown │ a1fe589 │ ● │
+│ jarvis                │ unknown │ unknown │ ✓ │
+│ made-support          │ unknown │ cac05dd │ ● │
+│ modes                 │ unknown │ 3e2a9e6 │ ● │
+│ notify                │ 7f5ff46 │ 7f5ff46 │ ✓ │
+│ reality-check         │ unknown │ 683f518 │ ● │
+│ recipes               │ unknown │ 342760d │ ● │
+│ routing-matrix        │ unknown │ 8f51709 │ ● │
+│ stories               │ unknown │ 1f2019e │ ● │
+
+READ THE TWO TABLES TOGETHER:
+  notify  unknown -> 7f5ff46  (matches remote, marked up-to-date) -- caused ONLY by fetching behavior URIs
+  modes   unknown -> unknown  (CONTROL: behavior-only in code today, nothing fetched it here)
+The control rules out 'the second run just works'. The SHA appears because the behavior
+fetch populates the same cache entry the ROOT URI's status check reads.

--- a/docs/lanes/ozbw-notify-behaviors-not-root/evidence/real-session-before-after.txt
+++ b/docs/lanes/ozbw-notify-behaviors-not-root/evidence/real-session-before-after.txt
@@ -1,0 +1,42 @@
+REAL-SESSION CHECK -- amplifier run "hi" -B anchors-amp-dev, from a scratch build (uv run) of each tree.
+Same host, same ~/.amplifier settings (notifications.desktop.enabled=true, notifications.ntfy.enabled=true), same bundle.
+
+SESSION: 10d7a2e8-1295-481f-881d-c4c5f95c92e7   (BEFORE -- baseline worktree at HEAD dab0f7c, notify ROOT still composed)
+
+raw.system chars                                : 97978
+raw.system first line                           : @anchors-amp-dev:context/system.md
+marker 'configured for development OF' present  : true
+  the marker line                               : You are Amplifier, configured for development OF the Amplifier ecosyst
+'# Notify Bundle' present anywhere              : false
+<context_file  blocks (app-bundle includes)     : 23
+mentions:resolved count                         : 23
+
+#315 guard warning in the run's own output ("carries a markdown body; dropping it"):
+  occurrences                                   : 1
+  naming amplifier-bundle-notify                : 1
+
+--------------------------------------------------------------------------
+
+SESSION: 05457635-b553-4559-8815-55306e3bfd59   (AFTER -- this branch, behavior-only compose)
+
+raw.system chars                                : 98339
+raw.system first line                           : @anchors-amp-dev:context/system.md
+marker 'configured for development OF' present  : true
+  the marker line                               : You are Amplifier, configured for development OF the Amplifier ecosyst
+'# Notify Bundle' present anywhere              : false
+<context_file  blocks (app-bundle includes)     : 23
+mentions:resolved count                         : 23
+
+#315 guard warning in the run's own output ("carries a markdown body; dropping it"):
+  occurrences                                   : 0
+  naming amplifier-bundle-notify                : 0
+
+==========================================================================
+The ONLY line that moves is the last one.
+  BEFORE: the #315 guard fires once per session, naming amplifier-bundle-notify.
+          The root body enters compose() and is dropped with a warning.
+  AFTER : 0 occurrences. The root bundle never enters compose at all.
+raw.system is correct in BOTH (marker true, '# Notify Bundle' false) -- that is
+#315 doing its job, and it is left untouched. This change removes the trigger.
+The 23 <context_file> blocks = 22 app-bundle context includes + the root bundle's
+own @anchors-amp-dev:context/system.md, matching f26u's measured mentions:resolved=23.

--- a/tests/test_notification_hook_overrides_defaults.py
+++ b/tests/test_notification_hook_overrides_defaults.py
@@ -188,7 +188,7 @@ def test_consumers_agree_on_desktop_enabled(tmp_path):
     behaviors = _build_notification_behaviors(flags)
     overrides = settings.get_notification_hook_overrides()
 
-    # Behavior path composes the root bundle + the desktop behavior.
+    # Behavior path composes the desktop behavior URI (never the root bundle).
     assert any("amplifier-bundle-notify" in b for b in behaviors)
     assert any("desktop-notifications" in b for b in behaviors)
     # Hook-override path emits exactly the hooks-notify override.
@@ -233,7 +233,7 @@ def test_consumers_agree_when_both_desktop_and_push_enabled(tmp_path):
     behaviors = _build_notification_behaviors(flags)
     overrides = settings.get_notification_hook_overrides()
 
-    # Behavior path composes root + both per-notification behaviors.
+    # Behavior path composes both per-notification behavior URIs (never the root).
     assert any("desktop-notifications" in b for b in behaviors)
     assert any("push-notifications" in b for b in behaviors)
     # Hook-override path emits both overrides.

--- a/tests/test_notify_behaviors_not_root.py
+++ b/tests/test_notify_behaviors_not_root.py
@@ -1,0 +1,283 @@
+"""Regression tests: compose notify's BEHAVIORS, never its ROOT bundle.
+
+Background
+----------
+``_build_notification_behaviors()`` used to prepend the notify ROOT URI
+(``git+https://github.com/microsoft/amplifier-bundle-notify@main``) before the
+two body-less behavior YAMLs, described in-code as "a minimal marker that just
+identifies the repo and ensures the bundle gets cached with proper SHA metadata
+(fixes the 'unknown' version issue during `amplifier update`)".
+
+That marker was not minimal. notify's root ``bundle.md`` carries an 82-line
+README body, and ``Bundle.compose()`` replaces the root instruction whenever a
+composed bundle has a non-empty markdown body -- the defect fixed in #315 by
+``_preserve_root_instruction()``. #315 removed the *damage*; this removes the
+*trigger*. Both stay: the guard is defense in depth for every OTHER
+body-carrying behavior a user might compose.
+
+Two things are pinned here, because removing the root URI is only safe if the
+second one holds:
+
+1. Every URI this builder returns is a ``#subdirectory=behaviors/`` URI --
+   never a bare root. Same rule every sibling builder already follows.
+2. A behavior URI and the root URI resolve to ONE cache entry, so fetching a
+   behavior populates the very entry ``amplifier update`` reads for the root.
+   The root composition was never what supplied the SHA.
+
+If amplifier-foundation ever makes its git cache key fragment-sensitive,
+test (2) fails loudly here instead of silently reintroducing "unknown".
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from amplifier_app_cli.lib.settings import NotificationFlags
+from amplifier_app_cli.runtime.config import (
+    _build_app_cli_behaviors,
+    _build_modes_behaviors,
+    _build_notification_behaviors,
+    _build_skills_behaviors,
+    _build_wayfinder_behaviors,
+)
+
+NOTIFY_ROOT_URI = "git+https://github.com/microsoft/amplifier-bundle-notify@main"
+
+ALL_FLAG_COMBOS = [
+    NotificationFlags(desktop_enabled=True, push_enabled=False),
+    NotificationFlags(desktop_enabled=False, push_enabled=True),
+    NotificationFlags(desktop_enabled=True, push_enabled=True),
+]
+
+
+# ---------------------------------------------------------------------------
+# 1. Behavior URIs only -- never a bare root
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("flags", ALL_FLAG_COMBOS, ids=["desktop", "push", "both"])
+def test_notification_behaviors_never_return_a_bare_root_uri(flags):
+    """No enablement combination may emit the notify ROOT bundle URI.
+
+    The root bundle.md carries a README body; composing it is what made
+    #315 necessary in the first place.
+    """
+    behaviors = _build_notification_behaviors(flags)
+
+    assert NOTIFY_ROOT_URI not in behaviors, (
+        f"_build_notification_behaviors({flags!r}) returned the bare notify ROOT "
+        f"URI: {behaviors!r}. That bundle's markdown body enters compose() and "
+        "is only made harmless by _preserve_root_instruction() (#315). Compose "
+        "the #subdirectory=behaviors/*.yaml URIs instead -- they carry no body, "
+        "and they populate the same git cache entry `amplifier update` reads."
+    )
+
+
+@pytest.mark.parametrize("flags", ALL_FLAG_COMBOS, ids=["desktop", "push", "both"])
+def test_every_notification_uri_targets_a_behavior_subdirectory(flags):
+    """Stronger than the bare-root check: every URI must name a behavior file.
+
+    Catches a future regression that composes some *other* body-carrying
+    entry point of the same repo rather than the exact root string.
+    """
+    behaviors = _build_notification_behaviors(flags)
+
+    assert behaviors, "expected at least one behavior URI when a flag is enabled"
+    for uri in behaviors:
+        assert "#subdirectory=behaviors/" in uri, (
+            f"{uri!r} does not point at a behavior file. Only body-less "
+            "behavior YAMLs may be composed onto the user's root bundle."
+        )
+        assert uri.endswith(".yaml"), f"{uri!r} is not a behavior YAML"
+
+
+def test_desktop_only_composes_exactly_the_desktop_behavior():
+    behaviors = _build_notification_behaviors(
+        NotificationFlags(desktop_enabled=True, push_enabled=False)
+    )
+    assert behaviors == [
+        NOTIFY_ROOT_URI + "#subdirectory=behaviors/desktop-notifications.yaml"
+    ]
+
+
+def test_push_only_composes_exactly_the_push_behavior():
+    behaviors = _build_notification_behaviors(
+        NotificationFlags(desktop_enabled=False, push_enabled=True)
+    )
+    assert behaviors == [
+        NOTIFY_ROOT_URI + "#subdirectory=behaviors/push-notifications.yaml"
+    ]
+
+
+def test_both_enabled_composes_both_behaviors_and_nothing_else():
+    behaviors = _build_notification_behaviors(
+        NotificationFlags(desktop_enabled=True, push_enabled=True)
+    )
+    assert behaviors == [
+        NOTIFY_ROOT_URI + "#subdirectory=behaviors/desktop-notifications.yaml",
+        NOTIFY_ROOT_URI + "#subdirectory=behaviors/push-notifications.yaml",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 2. The pattern, not just the one instance
+# ---------------------------------------------------------------------------
+
+
+def test_no_always_on_behavior_builder_composes_a_bare_root_bundle():
+    """Audit guard: every always-composed builder must be behavior-only.
+
+    One root-composed bundle is a bug; the same shape appearing again is the
+    finding. modes/skills/wayfinder/app-cli were already behavior-only when
+    this was written -- this keeps them that way.
+    """
+    builders = {
+        "_build_modes_behaviors": _build_modes_behaviors(),
+        "_build_skills_behaviors": _build_skills_behaviors(),
+        "_build_wayfinder_behaviors": _build_wayfinder_behaviors(),
+        "_build_app_cli_behaviors": _build_app_cli_behaviors(),
+        "_build_notification_behaviors": _build_notification_behaviors(
+            NotificationFlags(desktop_enabled=True, push_enabled=True)
+        ),
+    }
+
+    offenders = {
+        name: [uri for uri in uris if "#subdirectory=" not in uri]
+        for name, uris in builders.items()
+    }
+    offenders = {name: uris for name, uris in offenders.items() if uris}
+
+    assert not offenders, (
+        f"These builders compose a ROOT bundle URI: {offenders!r}. A root "
+        "bundle.md with a non-empty body replaces the user's system prompt in "
+        "Bundle.compose(); _preserve_root_instruction() (#315) then drops it "
+        "with a warning. Compose the behavior file directly instead."
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. The invariant that makes removing the root URI safe
+# ---------------------------------------------------------------------------
+
+
+def test_behavior_uri_and_root_uri_share_one_git_cache_entry():
+    """The SHA-metadata motivation, preserved without composing a body.
+
+    ``amplifier update`` resolves "notify" through WELL_KNOWN_BUNDLES to the
+    ROOT URI and asks ``GitSourceHandler.get_status()`` for its cached commit.
+    That lookup keys on ``sha256("<git_url>@<ref>")`` -- the ``#subdirectory=``
+    fragment is not part of the key -- so a behavior fetch fills the entry the
+    root's status check reads.
+
+    Pure path arithmetic: no clone, no network, no filesystem writes.
+    """
+    from amplifier_foundation.paths.resolution import parse_uri
+    from amplifier_foundation.sources.git import GitSourceHandler
+
+    handler = GitSourceHandler()
+    cache_dir = Path("/tmp/does-not-need-to-exist")
+
+    behavior_uris = _build_notification_behaviors(
+        NotificationFlags(desktop_enabled=True, push_enabled=True)
+    )
+    root_path = handler._get_cache_path(parse_uri(NOTIFY_ROOT_URI), cache_dir)
+
+    for uri in behavior_uris:
+        behavior_path = handler._get_cache_path(parse_uri(uri), cache_dir)
+        assert behavior_path == root_path, (
+            f"{uri} caches to {behavior_path.name} but `amplifier update` reads "
+            f"{root_path.name} for the notify root. The git cache key has become "
+            "fragment-sensitive, so composing behaviors no longer supplies the "
+            "root's SHA metadata and `amplifier update` will report 'unknown' "
+            "for notify. Restore SHA tracking WITHOUT composing the root "
+            "bundle.md (its body would clobber the user's system prompt)."
+        )
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "Builds a git+file:// URI from a filesystem path; a Windows drive-letter "
+        "path ('C:/...') is not expressible in the host/path split that "
+        "GitSourceHandler._build_git_url() performs. The fragment-insensitive "
+        "cache-key invariant this test exercises end-to-end is also pinned "
+        "platform-independently by "
+        "test_behavior_uri_and_root_uri_share_one_git_cache_entry."
+    ),
+)
+def test_behavior_only_fetch_supplies_the_root_sha_end_to_end(tmp_path):
+    """Fail-before / pass-after for the original "unknown" symptom.
+
+    Reproduces the reported symptom (root status with nothing fetched ->
+    cached_commit None -> rendered "unknown"), then shows that fetching ONLY
+    the behavior subdirectory URIs -- never the root -- clears it.
+    """
+    import asyncio
+
+    from amplifier_foundation.paths.resolution import parse_uri
+    from amplifier_foundation.sources.git import GitSourceHandler
+
+    repo = tmp_path / "amplifier-bundle-notify"
+    (repo / "behaviors").mkdir(parents=True)
+    # Shaped like the real thing: a root bundle.md that DOES carry a body.
+    (repo / "bundle.md").write_text(
+        "---\nname: notify\n---\n\n# Notify Bundle\n\nREADME body.\n",
+        encoding="utf-8",
+    )
+    (repo / "behaviors" / "desktop-notifications.yaml").write_text(
+        "name: notify-desktop\nhooks: []\n", encoding="utf-8"
+    )
+
+    def git(*args):
+        subprocess.run(
+            ["git", "-c", "user.email=t@example.com", "-c", "user.name=t", *args],
+            cwd=repo,
+            check=True,
+            capture_output=True,
+        )
+
+    git("init", "-q", "-b", "main")
+    git("add", "-A")
+    git("commit", "-qm", "initial")
+    real_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+    root_uri = f"git+file://{repo.as_posix()}@main"
+    behavior_uri = root_uri + "#subdirectory=behaviors/desktop-notifications.yaml"
+
+    handler = GitSourceHandler()
+
+    async def scenario():
+        # FAIL-BEFORE: nothing from this repo fetched at all.
+        empty_cache = tmp_path / "cache-empty"
+        empty_cache.mkdir()
+        before = await handler.get_status(parse_uri(root_uri), empty_cache)
+
+        # PASS-AFTER: ONLY the behavior URI is fetched. The root never is.
+        behaviors_cache = tmp_path / "cache-behaviors-only"
+        behaviors_cache.mkdir()
+        await handler.resolve(parse_uri(behavior_uri), behaviors_cache)
+        after = await handler.get_status(parse_uri(root_uri), behaviors_cache)
+        return before, after
+
+    before, after = asyncio.run(scenario())
+
+    assert before.cached_commit is None, (
+        "Expected the original symptom: with nothing fetched, the notify root "
+        f"has no cached commit and renders as 'unknown'. Got {before.cached_commit!r}."
+    )
+    assert after.cached_commit == real_sha, (
+        "Fetching only the behavior subdirectory URI must populate the root's "
+        f"cache entry. Expected {real_sha}, got {after.cached_commit!r}. Without "
+        "this, removing the root URI from _build_notification_behaviors() would "
+        "reintroduce the 'unknown' version in `amplifier update`."
+    )


### PR DESCRIPTION
## What

`_build_notification_behaviors()` now returns **only** `#subdirectory=behaviors/*.yaml`
URIs. The bare notify **root** URI is gone.

```diff
-    # Root bundle first — a minimal marker that just identifies the repo
-    # and ensures the bundle gets cached with proper SHA metadata (fixes
-    # the "unknown" version issue during `amplifier update`). The actual
-    # functionality comes from the subdirectory behaviors below.
-    behaviors.append("git+https://github.com/microsoft/amplifier-bundle-notify@main")
-
     if flags.desktop_enabled:
         behaviors.append(
             "…amplifier-bundle-notify@main#subdirectory=behaviors/desktop-notifications.yaml"
         )
```

## Why

That "minimal marker" is not minimal: notify's root `bundle.md` carries an 82-line
README body, and `Bundle.compose()` replaces the root instruction whenever a composed
bundle has a non-empty markdown body. That is the defect #315 fixed.

**#315's guard is untouched, and stays.** `_preserve_root_instruction()`
(`lib/bundle_loader/prepare.py:71`) removed the *damage*; this PR removes the
*trigger*. Defense in depth is the point — the guard still protects every other
body-carrying bundle a user composes, including their own `bundle.app` entries, which
app-cli does not control. All five #315 guard tests pass unchanged.

## The `amplifier update` SHA motivation — preserved, and it needed no replacement

The root line existed to fix a real symptom (`2fa2c47`, "fix: resolve 'unknown' SHA
for bundles during update check"). Removing it without understanding that would trade
a fixed bug for a reintroduced one, so the symptom was reproduced first.

**The root composition was never what supplied the SHA.**
`GitSourceHandler._get_cache_path()` keys the clone on `sha256("<git_url>@<ref>")` —
the `#subdirectory=` fragment is **not** part of the key. So all three notify URIs
resolve to one cache directory:

```
ROOT     cache_path = amplifier-bundle-notify-a1c452253c0fb2e2   subpath=''
DESKTOP  cache_path = amplifier-bundle-notify-a1c452253c0fb2e2   subpath='behaviors/desktop-notifications.yaml'
PUSH     cache_path = amplifier-bundle-notify-a1c452253c0fb2e2   subpath='behaviors/push-notifications.yaml'
```

`amplifier update` resolves `notify` through `WELL_KNOWN_BUNDLES` → the ROOT URI →
`GitSourceHandler.get_status()`, which reads that same entry. Fetching a behavior
fills it.

### Fail-before / pass-after — real repo, real CLI, isolated `AMPLIFIER_HOME`

```
$ AMPLIFIER_HOME=<empty> amplifier update --check-only
│ modes   │ unknown │ 3e2a9e6 │ ● │
│ notify  │ unknown │ 7f5ff46 │ ● │      <-- symptom reproduced

# fetch ONLY the two #subdirectory=behaviors/*.yaml URIs; the ROOT is never resolved
$ AMPLIFIER_HOME=<same> amplifier update --check-only
│ modes   │ unknown │ 3e2a9e6 │ ● │      <-- CONTROL: behavior-only in code, not fetched here
│ notify  │ 7f5ff46 │ 7f5ff46 │ ✓ │      <-- real SHA, up to date
```

The `modes` control rules out "the second run just works". End-to-end through the
changed code (feed `_build_notification_behaviors()`'s own output into a fresh cache,
then run the real command) gives the same `notify │ 7f5ff46 │ 7f5ff46 │ ✓`.

Evidence: `docs/lanes/ozbw-notify-behaviors-not-root/evidence/`
(`live-update-sha.txt`, `e2e-branch-update-sha.txt`, `fail-before-pass-after-hermetic.txt`).

## Real-session check — `amplifier run "hi" -B anchors-amp-dev`

Same host, same settings (`desktop` + `ntfy` enabled), same bundle; scratch build of
each tree.

| | BEFORE (`dab0f7c`) | AFTER (this branch) |
|---|---|---|
| `raw.system` first line | `@anchors-amp-dev:context/system.md` | same |
| marker `configured for development OF` | true | true |
| `# Notify Bundle` anywhere in `raw.system` | false | false |
| `<context_file>` blocks | 23 | 23 |
| `mentions:resolved` | 23 | 23 |
| **#315 drop-warning naming `amplifier-bundle-notify`** | **1** | **0** |

`raw.system` is correct in *both* — that is #315 doing its job. The one line that
moves is the last: the root body no longer enters `compose()` at all, so the guard
has nothing to drop and users stop seeing that warning every session.
(23 = 22 app-bundle context includes + the root bundle's own `system.md`, matching
f26u's measured `mentions:resolved=23`.)

## Audit: is this a bug or a pattern?

Every always-on behavior builder in `runtime/config.py`, checked by running them:

| builder | verdict |
|---|---|
| `_build_modes_behaviors` | behavior-only |
| `_build_skills_behaviors` | behavior-only |
| `_build_wayfinder_behaviors` | behavior-only |
| `_build_app_cli_behaviors` | behavior-only |
| `_build_notification_behaviors` | **was the last root-composer — fixed here** |

**Bare-root URIs composed as behaviors: 0.** `modes` was the other one and was already
fixed in `91e1beb`; notify was the last survivor. The 6th `compose_behaviors` source is
the user's own `bundle.app` list, which is not app-cli's to police — that is exactly
what #315's guard is for. See `evidence/config-audit.txt`.

## Tests

New `tests/test_notify_behaviors_not_root.py` (+12):

1. **No bare root URI**, and every returned URI carries `#subdirectory=behaviors/` and
   ends in `.yaml` — across all three enablement combinations.
2. **Exact-list assertions** per combination.
3. **Pattern guard** — *no* always-on builder may return a fragment-less URI, so this
   cannot silently come back in a sibling.
4. **The invariant that makes the removal safe** — the behavior URIs and the root URI
   resolve to the same git cache path. If amplifier-foundation ever makes its cache key
   fragment-sensitive, this fails loudly here with an explanatory message instead of
   silently reintroducing `unknown`.
5. **End-to-end fail-before/pass-after** against a throwaway local git repo shaped like
   notify (root `bundle.md` *with* a body): nothing fetched → `cached_commit is None`
   (the "unknown"); behavior URI only → the real SHA. `skipif(win32)` with a stated
   reason (a `C:/…` drive-letter path is not expressible in `_build_git_url`'s
   host/path split); the same invariant is pinned platform-independently by test 4.

Two stale comments in `test_notification_hook_overrides_defaults.py` ("composes the
root bundle + …") corrected; no assertions changed.

### Full suite

```
BASELINE (worktree at HEAD dab0f7c):  1841 passed, 1 skipped, 13 deselected, 1 xfailed
THIS BRANCH:                          1853 passed, 1 skipped, 13 deselected, 1 xfailed
```

Delta = **+12**, all new, all passing. Reported honestly: an earlier run of *both*
trees produced one failure —
`tests/test_truststore_wrap_bio_shim.py::test_real_truststore_is_covered_at_cli_import`
(1 failed/1840 baseline, 1 failed/1852 branch) — the known collection-order dependency
that passes in isolation (11 passed). Present with and without this change; not
absorbed. See `evidence/full-suite.txt`.

## Related

`microsoft/amplifier-bundle-notify#10` empties notify's root `bundle.md` body. After
this PR the root body is inert **twice over** — never composed *and* guarded — so #10
becomes hygiene rather than a fix. Not merged here; the maintainer's call.

Generated with Amplifier

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
