### PR TITLE
fix(update): walk the include graph so a transitive @branch cache can't hide behind a green check (0yc)

### DIFF
--- a/amplifier_app_cli/commands/bundle.py
+++ b/amplifier_app_cli/commands/bundle.py
@@ -1205,6 +1205,84 @@ def bundle_update(
         )
 
 
+async def _augment_with_transitive(
+    status: "BundleStatus",
+    bundle_name: str,
+    bundle_obj,
+    registry,
+) -> dict[str, str]:
+    """Fold ``includes:``-only git sources into *status*, in place.
+
+    ``check_bundle_status()`` deliberately does not collect included bundles
+    (foundation ``updates/__init__.py:138-140``): it assumes every include is
+    also registered as a first-class bundle and gets checked independently.
+    For a bundle that only ever arrives through someone else's ``includes:``
+    that assumption does not hold, and the source drops out of every check --
+    while foundation's loader never refreshes a cached ``@<branch>`` source on
+    its own (``sources/git.py:697-709``). Result: a permanently stale cache
+    under a green "All sources are up to date."
+
+    Returns:
+        source_uri -> including bundle name, for annotating the display.
+        Empty when nothing transitive was found.
+    """
+    from amplifier_foundation.paths.resolution import get_amplifier_home
+
+    from ..utils.include_graph import strip_uri_fragment
+    from ..utils.include_graph import transitive_statuses_for
+
+    seed_uri = getattr(bundle_obj, "_source_uri", None) or registry.find(bundle_name)
+    if not seed_uri:
+        return {}
+
+    known = {strip_uri_fragment(s.source_uri) for s in status.sources}
+    known.add(strip_uri_fragment(seed_uri))
+
+    try:
+        entries = await transitive_statuses_for(
+            {bundle_name: seed_uri},
+            registry=registry,
+            cache_dir=get_amplifier_home() / "cache",
+            known_uris=known,
+        )
+    except Exception:
+        return {}  # A failed walk must not take the whole check down with it
+
+    annotations: dict[str, str] = {}
+    for entry in entries.values():
+        status.sources.append(entry.status)
+        annotations[entry.status.source_uri] = entry.parent
+    return annotations
+
+
+async def _refresh_transitive(
+    annotations: dict[str, str], status: "BundleStatus"
+) -> list[str]:
+    """Re-clone every transitive source that actually has an update.
+
+    ``update_bundle()`` re-derives its own work list from the bundle object,
+    so it never sees the rows appended by ``_augment_with_transitive``.
+    Refresh them with the same ``GitSourceHandler.update()`` a direct refresh
+    bottoms out in. A pinned ref never lands here: ``get_status()`` already
+    reports ``has_update=False`` for it.
+    """
+    from amplifier_foundation.paths.resolution import get_amplifier_home
+
+    from ..utils.include_graph import refresh_transitive_source
+
+    if not annotations:
+        return []
+
+    cache_dir = get_amplifier_home() / "cache"
+    refreshed: list[str] = []
+    for source in status.sources:
+        if source.source_uri not in annotations or source.has_update is not True:
+            continue
+        await refresh_transitive_source(source.source_uri, cache_dir=cache_dir)
+        refreshed.append(source.source_uri)
+    return refreshed
+
+
 async def _bundle_update_async(
     name: str | None, check_only: bool, auto_confirm: bool, specific_source: str | None
 ) -> None:
@@ -1249,9 +1327,12 @@ async def _bundle_update_async(
     # Check status
     console.print("\n[dim]Checking for updates...[/dim]")
     status: BundleStatus = await check_bundle_status(bundle_obj)
+    transitive = await _augment_with_transitive(
+        status, bundle_name, bundle_obj, registry
+    )
 
     # Display status table
-    _display_bundle_status(status)
+    _display_bundle_status(status, transitive)
 
     # Summary
     console.print(f"\n{status.summary}")
@@ -1289,6 +1370,9 @@ async def _bundle_update_async(
             console.print(f"[green]✓ Updated:[/green] {specific_source}")
         else:
             await update_bundle(bundle_obj)
+            refreshed = await _refresh_transitive(transitive, status)
+            for uri in refreshed:
+                console.print(f"[green]✓ Updated (transitive):[/green] {uri}")
             console.print(
                 f"[green]✓ Updated {len(status.updateable_sources)} source(s)[/green]"
             )
@@ -1321,6 +1405,7 @@ async def _bundle_update_all_async(check_only: bool, auto_confirm: bool) -> None
     results: dict[str, BundleStatus] = {}
     errors: dict[str, str] = {}
     bundles_with_updates: list[str] = []
+    transitive_by_bundle: dict[str, dict[str, str]] = {}
 
     # Check each bundle
     for bundle_name in bundle_names:
@@ -1332,6 +1417,9 @@ async def _bundle_update_all_async(check_only: bool, auto_confirm: bool) -> None
             bundle_obj = loaded
 
             status: BundleStatus = await check_bundle_status(bundle_obj)
+            transitive_by_bundle[bundle_name] = await _augment_with_transitive(
+                status, bundle_name, bundle_obj, registry
+            )
             results[bundle_name] = status
 
             if status.has_updates:
@@ -1443,6 +1531,9 @@ async def _bundle_update_all_async(check_only: bool, auto_confirm: bool) -> None
             bundle_obj = loaded
 
             await update_bundle(bundle_obj)
+            await _refresh_transitive(
+                transitive_by_bundle.get(bundle_name, {}), results[bundle_name]
+            )
             updated_count += 1
             console.print(f"[green]✓[/green] {bundle_name}")
         except Exception as exc:
@@ -1461,8 +1552,16 @@ async def _bundle_update_all_async(check_only: bool, auto_confirm: bool) -> None
             console.print(f"  [green]✓[/green] {name}")
 
 
-def _display_bundle_status(status: BundleStatus) -> None:
-    """Display bundle status in a formatted table."""
+def _display_bundle_status(
+    status: BundleStatus, transitive: dict[str, str] | None = None
+) -> None:
+    """Display bundle status in a formatted table.
+
+    *transitive* maps a source URI to the bundle whose ``includes:`` reaches
+    it. Those rows are annotated rather than shown bare: a source with no
+    registry entry of its own, printed unlabelled, reads as something the
+    user added and forgot.
+    """
     if not status.sources:
         console.print("[dim]No sources to check.[/dim]")
         return
@@ -1478,9 +1577,14 @@ def _display_bundle_status(status: BundleStatus) -> None:
 
     for source in status.sources:
         # Truncate long URIs
+        included_by = (transitive or {}).get(source.source_uri)
         uri = source.source_uri
         if len(uri) > 57:
             uri = uri[:54] + "..."
+        # The attribution goes in Details, not in front of the URI: this
+        # column is already narrow enough that Rich ellipsizes it, and a
+        # prefix here just pushes the URI onto a second line where it is
+        # harder to read, not easier.
 
         # Status indicator
         if source.has_update:
@@ -1492,6 +1596,8 @@ def _display_bundle_status(status: BundleStatus) -> None:
 
         # Details
         details_parts = []
+        if included_by:
+            details_parts.append(f"via {included_by}")
         if source.cached_commit and source.remote_commit:
             local_short = source.cached_commit[:7]
             remote_short = source.remote_commit[:7]
@@ -1502,7 +1608,9 @@ def _display_bundle_status(status: BundleStatus) -> None:
         elif source.error:
             details_parts.append(f"error: {source.error[:30]}")
 
-        details = " ".join(details_parts) if details_parts else source.summary[:40]
+        if not details_parts:
+            details_parts.append(source.summary[:40])
+        details = " ".join(details_parts)
 
         table.add_row(uri, status_text, details)
 

--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -2,12 +2,15 @@
 
 import asyncio
 from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import click
 from rich.console import Console
 from rich.table import Table
 from rich.text import Text
+
+from amplifier_foundation.updates import BundleStatus as _BundleStatus
 
 from ..lib.bundle_loader import AppBundleDiscovery
 
@@ -31,6 +34,29 @@ if TYPE_CHECKING:
     from amplifier_foundation import BundleStatus
 
 console = Console()
+
+
+@dataclass
+class TransitiveBundleStatus(_BundleStatus):
+    """A bundle reachable only through another bundle's ``includes:``.
+
+    A plain ``BundleStatus`` cannot say *why* a source is in the closure, and
+    a transitive source needs exactly that: it has no registry entry and no
+    settings entry, so without an attribution the row would appear from
+    nowhere. Carrying it on the status object keeps
+    ``_check_all_bundle_status()``'s return type unchanged -- several tests
+    substitute a plain ``dict[str, BundleStatus]`` for it -- while letting the
+    renderer and the executor branch on ``included_by``.
+    """
+
+    included_by: str = ""
+    """Immediate includer -- the honest answer to 'who pulls this in?'."""
+
+    included_under: str = ""
+    """Registered root the walk started from -- what the table groups by."""
+
+    is_pinned: bool = False
+    """Ref is a commit SHA or version tag: reported, never refreshed."""
 
 
 def _normalize_git_url(url: str) -> str:
@@ -97,6 +123,26 @@ def _bundle_display_names(bundle_keys: Iterable[str]) -> dict[str, str]:
     return {
         key: (label if seen[label] == 1 else key) for key, label in labels.items()
     }
+
+
+def _bundle_row_sort_key(
+    key: str,
+    status: "BundleStatus",
+    display_names: dict[str, str],
+) -> tuple[str, int, str]:
+    """Order the Bundles table so a transitive row sits under its parent row.
+
+    Grouped by the *registered root* rather than the immediate includer:
+    ``digital-twin-universe-behavior`` is the truthful parent of the gitea
+    bundle, but it has no row of its own, so grouping on it would scatter the
+    child under a heading that is not there. The annotation still names the
+    real includer -- grouping and attribution answer different questions.
+    """
+    label = display_names.get(key, key)
+    root = getattr(status, "included_under", "") or ""
+    if root:
+        return (root.lower(), 1, label.lower())
+    return (label.lower(), 0, label.lower())
 
 
 def _extract_module_name_from_uri(source_uri: str) -> str:
@@ -469,7 +515,75 @@ async def _check_all_bundle_status() -> dict[str, "BundleStatus"]:
         except Exception:
             continue  # Skip bundles that fail status check
 
+    # Everything above enumerates sources somebody REGISTERED: registry roots
+    # and app-bundle settings entries. A bundle that reaches the active
+    # closure only through another bundle's `includes:` is in neither place,
+    # so its cache was never checked -- and because the loader never refreshes
+    # a cached @<branch> source on its own (foundation
+    # sources/git.py:697-709), the only thing that would ever move it is this
+    # command. Skipping it here is what let a transitively-included @main
+    # bundle sit indefinitely behind a green "All sources up to date".
+    results.update(await _check_transitive_bundle_status(checked_uris, results))
+
     return results
+
+
+async def _check_transitive_bundle_status(
+    checked_uris: set[str],
+    direct_results: dict[str, "BundleStatus"],
+) -> dict[str, "BundleStatus"]:
+    """Status-check every git source reachable via ``includes:`` from *checked_uris*.
+
+    Never returns a row for a source already covered directly -- a repo the
+    user has registered is not "transitive", and two rows for one cache would
+    misreport which one carries the update.
+    """
+    from amplifier_foundation.paths.resolution import get_amplifier_home
+
+    from ..utils.include_graph import check_transitive_sources
+    from ..utils.include_graph import collect_transitive_git_sources
+
+    if not checked_uris:
+        return {}
+
+    cache_dir = get_amplifier_home() / "cache"
+    registry = create_bundle_registry()
+
+    # Seed the walk with the label each direct row already displays, so a
+    # transitive row can name a parent the user can actually find in the table.
+    seed_labels = _bundle_display_names(direct_results.keys())
+    roots = {
+        seed_labels.get(key, key): status.bundle_source
+        for key, status in direct_results.items()
+        if status.bundle_source
+    }
+
+    known = {_strip_uri_fragment(uri) for uri in checked_uris}
+    known.update(
+        _strip_uri_fragment(s.bundle_source)
+        for s in direct_results.values()
+        if s.bundle_source
+    )
+
+    try:
+        found = await collect_transitive_git_sources(
+            roots, registry=registry, cache_dir=cache_dir, known_uris=known
+        )
+        statuses = await check_transitive_sources(found, cache_dir=cache_dir)
+    except Exception:
+        return {}  # A failed walk must not take the whole report down with it
+
+    return {
+        key: TransitiveBundleStatus(
+            bundle_name=key,
+            bundle_source=key,
+            sources=[entry.status],
+            included_by=entry.parent,
+            included_under=entry.root,
+            is_pinned=entry.is_pinned,
+        )
+        for key, entry in statuses.items()
+    }
 
 
 async def _get_file_bundle_status(
@@ -753,7 +867,8 @@ def _show_concise_report(
         display_names = _bundle_display_names(bundle_results.keys())
 
         for bundle_name in sorted(
-            bundle_results.keys(), key=lambda key: display_names[key]
+            bundle_results.keys(),
+            key=lambda n: _bundle_row_sort_key(n, bundle_results[n], display_names),
         ):
             bundle_status = bundle_results[bundle_name]
             # Get the bundle repo's own SHA info from its sources
@@ -779,10 +894,27 @@ def _show_concise_report(
             if active_bundle and bundle_name == active_bundle:
                 display_name = f"{display_name} [green](active)[/green]"
 
+            # A transitive source has no registry entry and no settings entry
+            # of its own, so an unannotated row would look like something the
+            # user added and forgot. Indent it and name what pulls it in.
+            included_by = getattr(bundle_status, "included_by", "")
+            if included_by:
+                display_name = (
+                    f"  \u21b3 {display_name} "
+                    f"[dim](via {escape_markup(included_by)})[/dim]"
+                )
+
+            if getattr(bundle_status, "is_pinned", False):
+                # A pinned ref cannot move. "pinned" is the honest cell; a SHA
+                # here would imply an upstream comparison never made.
+                remote_cell: Any = Text("pinned", style="dim")
+            else:
+                remote_cell = create_sha_text(remote_sha)
+
             table.add_row(
                 display_name,
                 create_sha_text(cached_sha),
-                create_sha_text(remote_sha),
+                remote_cell,
                 status_symbol,
             )
 
@@ -960,12 +1092,16 @@ def _show_verbose_report(
         active_bundle = _get_active_bundle_name()
         display_names = _bundle_display_names(bundle_results.keys())
         for bundle_name in sorted(
-            bundle_results.keys(), key=lambda key: display_names[key]
+            bundle_results.keys(),
+            key=lambda n: _bundle_row_sort_key(n, bundle_results[n], display_names),
         ):
             status = bundle_results[bundle_name]
             if status.sources:
                 # Add "(active)" marker if this is the active bundle
                 title_suffix = " (active)" if bundle_name == active_bundle else ""
+                included_by = getattr(status, "included_by", "")
+                if included_by:
+                    title_suffix += f" (via {included_by})"
                 console.print(
                     f"[bold cyan]Bundle: {display_names[bundle_name]}"
                     f"{title_suffix}[/bold cyan]"
@@ -1341,10 +1477,31 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
             # bundle_source below has to round-trip into update_bundle.
             update_labels = _bundle_display_names(bundles_to_update)
 
+            from amplifier_foundation.paths.resolution import get_amplifier_home
+
+            from ..utils.include_graph import refresh_transitive_source
+
+            transitive_cache_dir = get_amplifier_home() / "cache"
+
             for bundle_name in bundles_to_update:
                 try:
                     _on_update_progress(update_labels[bundle_name], "updating_bundle")
-                    source_uri = bundle_results[bundle_name].bundle_source
+                    bundle_status_obj = bundle_results[bundle_name]
+                    source_uri = bundle_status_obj.bundle_source
+
+                    # A transitive source is a cache, not a bundle we compose
+                    # here: load_bundle() would resolve and re-register a
+                    # bundle nobody asked for. Refresh the cache with the same
+                    # GitSourceHandler.update() a direct refresh bottoms out
+                    # in -- same mechanism, none of the extra machinery.
+                    if getattr(bundle_status_obj, "included_by", "") and source_uri:
+                        asyncio.run(
+                            refresh_transitive_source(
+                                source_uri, cache_dir=transitive_cache_dir
+                            )
+                        )
+                        bundle_updated.append(bundle_name)
+                        continue
                     # Intentional: check_all_sources(include_all_cached=True) handles
                     # cached modules separately. Load only the root bundle here to
                     # prevent redundant include/module refreshes and write amplification.

--- a/amplifier_app_cli/utils/include_graph.py
+++ b/amplifier_app_cli/utils/include_graph.py
@@ -1,0 +1,322 @@
+"""Walk a bundle's include graph to find sources the update path would miss.
+
+Why this exists
+---------------
+``amplifier update`` and ``amplifier bundle update`` enumerate update targets
+from *registered* sources: registry roots (``registry.json`` entries with
+``is_root: true``) plus app bundles from settings.  A bundle that enters the
+active closure only through another bundle's ``includes:`` list is not in
+either place, so its cache was never checked -- and both commands printed a
+green "All sources up to date" over a cache that had silently fallen behind
+its ``@<branch>`` upstream.
+
+That gap is not cosmetic.  Foundation's ``GitSourceHandler.resolve()``
+(``sources/git.py:697-709``) returns an existing cache verbatim whenever it
+passes the integrity check: no TTL, no fetch, no refresh, ever.  A cached
+``@main`` include is therefore frozen at whatever commit it was first cloned
+at until something explicitly calls ``GitSourceHandler.update()``.  The update
+commands are the only thing that does -- so a source they do not enumerate is
+a source that never updates.
+
+What it does
+------------
+Walks the include graph from a set of seed URIs, cycle-safe, and returns every
+transitively-included git source that is not already a direct update target.
+
+Resolution is *reused*, never reimplemented: the loader's own
+``BundleRegistry._parse_include`` / ``_resolve_include_source`` /
+``_load_from_path`` do the parsing, so ``@namespace:path``, ``git+...`` and
+``#subdirectory=`` forms resolve exactly the way a real session resolves them.
+A second copy of those rules here would drift from the loader and reintroduce
+the same class of silent miss.
+
+The walk is read-only.  It reads caches that already exist (via the handler's
+own ``_get_cache_path``) and never resolves a missing one, because resolving
+downloads -- and a download would make a deleted cache look "up to date", the
+exact side effect ``_check_all_bundle_status`` was written to avoid.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Mapping
+
+if TYPE_CHECKING:
+    from amplifier_foundation import BundleRegistry
+    from amplifier_foundation.sources.protocol import SourceStatus
+
+logger = logging.getLogger(__name__)
+
+
+def strip_uri_fragment(uri: str) -> str:
+    """Drop a URI's ``#fragment``, keeping the ``@ref`` intact.
+
+    The subdirectory fragment names a file *inside* a repo; the repo at a ref
+    is the update target.  ``@main`` and ``@v2`` of the same repo are two
+    different targets, so the ref must survive.
+    """
+    return uri.split("#", 1)[0]
+
+
+@dataclass(frozen=True)
+class TransitiveSource:
+    """A git source reachable only through another bundle's ``includes:``."""
+
+    uri: str
+    """Fragment-stripped git URI -- the update target's identity."""
+
+    parent: str
+    """Display name of the bundle whose ``includes:`` reaches it."""
+
+    root: str
+    """Display name of the registered source the walk started from.
+
+    Distinct from *parent* on purpose.  ``parent`` is the honest immediate
+    includer (``digital-twin-universe-behavior``); ``root`` is the row the
+    user actually has registered (``foundation``), which is the only thing a
+    table can group under.  Collapsing the two would either lie about who
+    includes what or scatter rows under names that have no row of their own.
+    """
+
+    via: str
+    """The full resolved include URI, fragment and all (for diagnostics)."""
+
+
+@dataclass
+class TransitiveStatus:
+    """A transitive source's update status, with the parent that pulls it in."""
+
+    source: TransitiveSource
+    status: "SourceStatus"
+
+    @property
+    def uri(self) -> str:
+        return self.source.uri
+
+    @property
+    def parent(self) -> str:
+        return self.source.parent
+
+    @property
+    def root(self) -> str:
+        return self.source.root
+
+    @property
+    def is_pinned(self) -> bool:
+        """True when the ref is a commit SHA or version tag.
+
+        Reuses foundation's own ``SourceStatus.is_pinned`` rather than
+        re-deriving "what counts as pinned" here.
+        """
+        return self.status.is_pinned
+
+    @property
+    def has_update(self) -> bool:
+        return self.status.has_update is True
+
+
+def _local_path_for(uri: str, cache_dir: Path) -> Path | None:
+    """Best-available on-disk path for *uri*, WITHOUT touching the network.
+
+    Returns None when the source is not a readable local/cached thing --
+    which is the correct answer for a source whose cache has been deleted.
+    Resolving it would clone, and a clone here would report a missing cache
+    as healthy.
+    """
+    from amplifier_foundation.paths.resolution import parse_uri
+    from amplifier_foundation.sources.git import GitSourceHandler
+
+    try:
+        parsed = parse_uri(uri)
+    except Exception:  # noqa: BLE001 - an unparseable URI is simply not walkable
+        return None
+
+    git_handler = GitSourceHandler()
+    if git_handler.can_handle(parsed):
+        cache_path = git_handler._get_cache_path(parsed, cache_dir)
+        if not cache_path.exists():
+            return None
+        active = cache_path / parsed.subpath if parsed.subpath else cache_path
+        return active if active.exists() else None
+
+    if parsed.is_file:
+        path = Path(parsed.path)
+        return path if path.exists() else None
+
+    return None
+
+
+def _is_git_uri(uri: str) -> bool:
+    return uri.startswith("git+") or uri.startswith("git://")
+
+
+async def collect_transitive_git_sources(
+    roots: Mapping[str, str],
+    *,
+    registry: "BundleRegistry",
+    cache_dir: Path,
+    known_uris: set[str] | None = None,
+    max_depth: int = 16,
+) -> dict[str, TransitiveSource]:
+    """Walk ``includes:`` from *roots* and return the git sources found.
+
+    Args:
+        roots: Display name -> configured URI for every direct update target.
+        registry: Loader registry -- supplies include parsing/resolution and
+            the bundle-file parser.  Namespace includes resolve against its
+            state, so pass the same registry the CLI builds elsewhere.
+        cache_dir: Cache root (``<amplifier home>/cache``).
+        known_uris: Fragment-stripped URIs already covered by a direct row.
+            Anything here is skipped -- it is not "transitive", it is the
+            source that was already going to be checked.
+        max_depth: Belt-and-braces bound on graph depth.  Cycles are already
+            handled by the visited set; this only caps a pathological chain.
+
+    Returns:
+        Fragment-stripped URI -> TransitiveSource, in discovery order.
+    """
+    known = set(known_uris or set())
+    found: dict[str, TransitiveSource] = {}
+
+    # Visited on the FULL uri (fragment included): two behaviors in one repo
+    # are different files with different includes, so collapsing them on the
+    # repo URI would skip half the graph.  This set is also what makes a
+    # cycle (B includes C includes B) terminate.
+    visited: set[str] = set()
+
+    queue: list[tuple[str, str, str, int]] = []
+    for label, uri in roots.items():
+        if uri in visited:
+            continue
+        visited.add(uri)
+        queue.append((label, label, uri, 0))
+
+    while queue:
+        root_label, label, uri, depth = queue.pop(0)
+        if depth >= max_depth:
+            logger.debug(f"Include walk hit max depth at: {uri}")
+            continue
+
+        path = _local_path_for(uri, cache_dir)
+        if path is None:
+            continue
+
+        try:
+            bundle = await registry._load_from_path(path)
+        except Exception as exc:  # noqa: BLE001 - an unreadable bundle is not fatal
+            logger.debug(f"Could not read includes from {uri}: {exc}")
+            continue
+
+        parent_label = bundle.name or label
+
+        for raw_include in bundle.includes or []:
+            spec = registry._parse_include(raw_include)
+            if not spec:
+                continue
+
+            try:
+                resolved = registry._resolve_include_source(spec)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug(f"Could not resolve include '{spec}': {exc}")
+                continue
+
+            if not resolved:
+                continue
+
+            # A plain name is a registry alias; the loader lets _load_single
+            # look it up, so look it up the same way here.
+            if "://" not in resolved and not resolved.startswith("git+"):
+                looked_up = registry.find(resolved)
+                if not looked_up:
+                    continue
+                resolved = looked_up
+
+            if resolved in visited:
+                continue
+            visited.add(resolved)
+
+            if _is_git_uri(resolved):
+                key = strip_uri_fragment(resolved)
+                if key not in known and key not in found:
+                    found[key] = TransitiveSource(
+                        uri=key, parent=parent_label, root=root_label, via=resolved
+                    )
+
+            queue.append((root_label, parent_label, resolved, depth + 1))
+
+    return found
+
+
+async def check_transitive_sources(
+    sources: Mapping[str, TransitiveSource],
+    *,
+    cache_dir: Path,
+) -> dict[str, TransitiveStatus]:
+    """Status-check each transitive source the same way a direct source is checked.
+
+    Uses foundation's ``GitSourceHandler.get_status`` -- the identical call
+    ``_check_all_bundle_status`` makes for a registered bundle -- so a
+    transitive row carries the same cached/remote commit truth, and the same
+    pinned handling, as a direct one.
+    """
+    from amplifier_foundation.paths.resolution import parse_uri
+    from amplifier_foundation.sources.git import GitSourceHandler
+
+    git_handler = GitSourceHandler()
+    results: dict[str, TransitiveStatus] = {}
+
+    for key, source in sources.items():
+        try:
+            parsed = parse_uri(source.uri)
+            if not git_handler.can_handle(parsed):
+                continue
+            status = await git_handler.get_status(parsed, cache_dir)
+        except Exception as exc:  # noqa: BLE001 - one bad source must not sink the report
+            logger.debug(f"Status check failed for {source.uri}: {exc}")
+            continue
+        results[key] = TransitiveStatus(source=source, status=status)
+
+    return results
+
+
+async def transitive_statuses_for(
+    roots: Mapping[str, str],
+    *,
+    registry: "BundleRegistry",
+    cache_dir: Path,
+    known_uris: set[str] | None = None,
+) -> dict[str, TransitiveStatus]:
+    """Collect + status-check in one call: the shape both update commands want."""
+    found = await collect_transitive_git_sources(
+        roots, registry=registry, cache_dir=cache_dir, known_uris=known_uris
+    )
+    return await check_transitive_sources(found, cache_dir=cache_dir)
+
+
+async def refresh_transitive_source(uri: str, *, cache_dir: Path) -> None:
+    """Re-clone *uri*'s cache -- the same mechanism a direct source refresh uses.
+
+    ``GitSourceHandler.update()`` removes the cache and re-resolves, which is
+    exactly what ``update_bundle`` ends up doing for a bundle's own source.
+    Calling it directly skips composing a bundle whose content we do not need.
+    """
+    from amplifier_foundation.paths.resolution import parse_uri
+    from amplifier_foundation.sources.git import GitSourceHandler
+
+    git_handler = GitSourceHandler()
+    parsed = parse_uri(uri)
+    await git_handler.update(parsed, cache_dir)
+
+
+__all__ = [
+    "TransitiveSource",
+    "TransitiveStatus",
+    "check_transitive_sources",
+    "collect_transitive_git_sources",
+    "refresh_transitive_source",
+    "strip_uri_fragment",
+    "transitive_statuses_for",
+]

--- a/tests/test_transitive_include_updates.py
+++ b/tests/test_transitive_include_updates.py
@@ -1,0 +1,661 @@
+"""Transitively-included bundles must be checked, listed, and refreshed.
+
+The defect these cover: `amplifier update` and `amplifier bundle update`
+enumerated update targets from *registered* sources only -- registry roots
+plus app-bundle settings. A bundle that reaches the active closure solely
+through another bundle's `includes:` was in neither place, so its cache was
+never checked. Combined with foundation's loader never refreshing a cached
+`@<branch>` source on its own (`sources/git.py:697-709`, cache hit returns
+verbatim, no TTL, no fetch), that cache could sit arbitrarily far behind
+upstream while both commands printed a green "All sources up to date".
+
+Fixtures build REAL git repos and use `git+file://` URIs so the whole path --
+cache-key derivation, `git ls-remote` comparison, re-clone -- runs for real
+rather than against a mock that cannot reproduce the bug.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "git+file:// URIs built from Windows drive-letter paths take a "
+        "different resolution path; the behaviour under test is "
+        "platform-independent and is covered on POSIX runners."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Git fixtures
+# ---------------------------------------------------------------------------
+
+
+def _git(*args: str, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git("add", "-A", cwd=repo)
+    _git(
+        "-c",
+        "user.email=test@example.invalid",
+        "-c",
+        "user.name=Test",
+        "commit",
+        "-q",
+        "-m",
+        message,
+        cwd=repo,
+    )
+    return _git("rev-parse", "HEAD", cwd=repo)
+
+
+def _make_repo(path: Path, bundle_text: str) -> str:
+    """Create a git repo on branch ``main`` holding a one-file bundle."""
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "bundle.md").write_text(bundle_text, encoding="utf-8")
+    _git("init", "-q", cwd=path)
+    _git("checkout", "-q", "-b", "main", cwd=path)
+    return _commit(path, "initial")
+
+
+def _bundle_md(name: str, includes: list[str] | None = None) -> str:
+    lines = ["---", "bundle:", f"  name: {name}", "  version: 1.0.0"]
+    if includes:
+        lines.append("includes:")
+        lines.extend(f"  - bundle: {uri}" for uri in includes)
+    lines.append("---")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _git_uri(path: Path, ref: str) -> str:
+    return f"git+{path.as_uri()}@{ref}"
+
+
+@pytest.fixture
+def amplifier_home(tmp_path, monkeypatch) -> Path:
+    """Isolate BOTH `AMPLIFIER_HOME` and `Path.home()`.
+
+    `get_amplifier_home()` reads AMPLIFIER_HOME, but parts of discovery still
+    read `Path.home() / ".amplifier"` directly. Setting only one leaves the
+    other pointed at the developer's real installation.
+    """
+    home = tmp_path / "home"
+    amp_home = home / ".amplifier"
+    amp_home.mkdir(parents=True)
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("AMPLIFIER_HOME", str(amp_home))
+    return amp_home
+
+
+async def _prime_cache(uri: str, cache_dir: Path) -> Path:
+    """Clone *uri* into the cache exactly the way a real session would."""
+    from amplifier_foundation.paths.resolution import parse_uri
+    from amplifier_foundation.sources.git import GitSourceHandler
+
+    handler = GitSourceHandler()
+    parsed = parse_uri(uri)
+    await handler.resolve(parsed, cache_dir)
+    return handler._get_cache_path(parsed, cache_dir)
+
+
+def _cached_head(cache_path: Path) -> str:
+    return _git("rev-parse", "HEAD", cwd=cache_path)
+
+
+def _direct_status(name: str, uri: str):
+    from amplifier_foundation.updates import BundleStatus
+
+    return BundleStatus(bundle_name=name, bundle_source=uri, sources=[])
+
+
+# ---------------------------------------------------------------------------
+# The core defect: an @main include that only a walk can find
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_transitive_include_is_checked_and_names_its_parent(
+    tmp_path, amplifier_home
+):
+    """B is registered, C is not -- C must still be checked, attributed to B."""
+    from amplifier_app_cli.commands import update as update_module
+
+    repo_c = tmp_path / "repo-c"
+    _make_repo(repo_c, _bundle_md("c"))
+    c_uri = _git_uri(repo_c, "main")
+
+    repo_b = tmp_path / "repo-b"
+    _make_repo(repo_b, _bundle_md("b", includes=[c_uri]))
+    b_uri = _git_uri(repo_b, "main")
+
+    cache_dir = amplifier_home / "cache"
+    await _prime_cache(b_uri, cache_dir)
+    c_cache = await _prime_cache(c_uri, cache_dir)
+    stale_sha = _cached_head(c_cache)
+
+    # Advance C's remote -- the cache is now behind and nothing says so.
+    (repo_c / "NEW.md").write_text("moved on\n", encoding="utf-8")
+    new_sha = _commit(repo_c, "advance main")
+    assert new_sha != stale_sha
+
+    results = await update_module._check_transitive_bundle_status(
+        {b_uri}, {"b": _direct_status("b", b_uri)}
+    )
+
+    assert c_uri in results, (
+        "C reaches the closure only through B's includes: -- it must not be "
+        f"silently omitted. Got: {sorted(results)}"
+    )
+    entry = results[c_uri]
+    assert entry.included_by == "b"
+    assert entry.included_under == "b"
+    assert entry.has_updates is True
+    source = entry.sources[0]
+    assert source.cached_commit == stale_sha
+    assert source.remote_commit == new_sha
+
+
+@pytest.mark.asyncio
+async def test_refreshing_a_transitive_source_advances_its_cache(
+    tmp_path, amplifier_home
+):
+    """Reporting is not enough -- the refresh must actually move the cache."""
+    from amplifier_app_cli.utils.include_graph import refresh_transitive_source
+
+    repo_c = tmp_path / "repo-c"
+    _make_repo(repo_c, _bundle_md("c"))
+    c_uri = _git_uri(repo_c, "main")
+
+    cache_dir = amplifier_home / "cache"
+    c_cache = await _prime_cache(c_uri, cache_dir)
+    stale_sha = _cached_head(c_cache)
+
+    (repo_c / "NEW.md").write_text("moved on\n", encoding="utf-8")
+    new_sha = _commit(repo_c, "advance main")
+    assert _cached_head(c_cache) == stale_sha, "cache must not move on its own"
+
+    await refresh_transitive_source(c_uri, cache_dir=cache_dir)
+
+    assert _cached_head(c_cache) == new_sha
+
+
+@pytest.mark.asyncio
+async def test_a_source_already_registered_directly_is_not_duplicated(
+    tmp_path, amplifier_home
+):
+    """A repo the user registered is a direct row, never also a transitive one."""
+    from amplifier_app_cli.commands import update as update_module
+
+    repo_c = tmp_path / "repo-c"
+    _make_repo(repo_c, _bundle_md("c"))
+    c_uri = _git_uri(repo_c, "main")
+
+    repo_b = tmp_path / "repo-b"
+    _make_repo(repo_b, _bundle_md("b", includes=[c_uri]))
+    b_uri = _git_uri(repo_b, "main")
+
+    cache_dir = amplifier_home / "cache"
+    await _prime_cache(b_uri, cache_dir)
+    await _prime_cache(c_uri, cache_dir)
+
+    results = await update_module._check_transitive_bundle_status(
+        {b_uri, c_uri},
+        {"b": _direct_status("b", b_uri), "c": _direct_status("c", c_uri)},
+    )
+
+    assert results == {}
+
+
+# ---------------------------------------------------------------------------
+# Pinned includes: reported, never moved
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pinned_sha_include_is_reported_pinned_and_not_moved(
+    tmp_path, amplifier_home
+):
+    from amplifier_app_cli.commands import update as update_module
+
+    repo_e = tmp_path / "repo-e"
+    pinned_sha = _make_repo(repo_e, _bundle_md("e"))
+    e_uri = _git_uri(repo_e, pinned_sha)
+
+    repo_d = tmp_path / "repo-d"
+    _make_repo(repo_d, _bundle_md("d", includes=[e_uri]))
+    d_uri = _git_uri(repo_d, "main")
+
+    cache_dir = amplifier_home / "cache"
+    await _prime_cache(d_uri, cache_dir)
+    e_cache = await _prime_cache(e_uri, cache_dir)
+
+    # Upstream moves. A pinned ref must be unmoved by that, and must not be
+    # dressed up as an available update.
+    (repo_e / "NEW.md").write_text("moved on\n", encoding="utf-8")
+    _commit(repo_e, "advance main")
+
+    results = await update_module._check_transitive_bundle_status(
+        {d_uri}, {"d": _direct_status("d", d_uri)}
+    )
+
+    assert e_uri in results, "a pinned include is still reported, just not refreshed"
+    entry = results[e_uri]
+    assert entry.is_pinned is True
+    assert entry.has_updates is False
+    assert _cached_head(e_cache) == pinned_sha
+
+
+@pytest.mark.asyncio
+async def test_pinned_tag_include_is_reported_pinned(tmp_path, amplifier_home):
+    from amplifier_app_cli.commands import update as update_module
+
+    repo_g = tmp_path / "repo-g"
+    tagged_sha = _make_repo(repo_g, _bundle_md("g"))
+    _git("tag", "v1.0.0", cwd=repo_g)
+    g_uri = _git_uri(repo_g, "v1.0.0")
+
+    repo_f = tmp_path / "repo-f"
+    _make_repo(repo_f, _bundle_md("f", includes=[g_uri]))
+    f_uri = _git_uri(repo_f, "main")
+
+    cache_dir = amplifier_home / "cache"
+    await _prime_cache(f_uri, cache_dir)
+    g_cache = await _prime_cache(g_uri, cache_dir)
+
+    (repo_g / "NEW.md").write_text("moved on\n", encoding="utf-8")
+    _commit(repo_g, "advance main")
+
+    results = await update_module._check_transitive_bundle_status(
+        {f_uri}, {"f": _direct_status("f", f_uri)}
+    )
+
+    assert g_uri in results
+    assert results[g_uri].is_pinned is True
+    assert results[g_uri].has_updates is False
+    assert _cached_head(g_cache) == tagged_sha
+
+
+# ---------------------------------------------------------------------------
+# Cycle safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_include_cycle_terminates(tmp_path, amplifier_home):
+    """B includes C, C includes B. The walk must finish, not spin."""
+    from amplifier_app_cli.commands import update as update_module
+
+    repo_b = tmp_path / "repo-b"
+    repo_c = tmp_path / "repo-c"
+    b_uri = _git_uri(repo_b, "main")
+    c_uri = _git_uri(repo_c, "main")
+
+    _make_repo(repo_c, _bundle_md("c", includes=[b_uri]))
+    _make_repo(repo_b, _bundle_md("b", includes=[c_uri]))
+
+    cache_dir = amplifier_home / "cache"
+    await _prime_cache(b_uri, cache_dir)
+    await _prime_cache(c_uri, cache_dir)
+
+    results = await update_module._check_transitive_bundle_status(
+        {b_uri}, {"b": _direct_status("b", b_uri)}
+    )
+
+    # C is found once; B is the already-known root and never re-added.
+    assert set(results) == {c_uri}
+
+
+# ---------------------------------------------------------------------------
+# The table has to SAY so
+# ---------------------------------------------------------------------------
+
+
+def test_report_lists_transitive_source_under_its_parent(monkeypatch):
+    """A transitive row is indented and names its includer -- never bare."""
+    import io
+
+    from rich.console import Console
+
+    from amplifier_app_cli.commands import update as update_module
+    from amplifier_app_cli.commands.update import TransitiveBundleStatus
+    from amplifier_app_cli.utils.source_status import UpdateReport
+    from amplifier_foundation.sources.protocol import SourceStatus
+    from amplifier_foundation.updates import BundleStatus
+
+    parent_uri = "git+https://example.invalid/parent@main"
+    child_uri = "git+https://example.invalid/child@main"
+
+    parent = BundleStatus(
+        bundle_name="parent",
+        bundle_source=parent_uri,
+        sources=[
+            SourceStatus(
+                source_uri=parent_uri,
+                is_cached=True,
+                has_update=False,
+                cached_commit="aaaaaaaa11111111",
+                remote_commit="aaaaaaaa11111111",
+            )
+        ],
+    )
+    child = TransitiveBundleStatus(
+        bundle_name=child_uri,
+        bundle_source=child_uri,
+        sources=[
+            SourceStatus(
+                source_uri=child_uri,
+                is_cached=True,
+                has_update=True,
+                cached_commit="c03a88b0000000",
+                remote_commit="28588b90000000",
+            )
+        ],
+        included_by="parent",
+        included_under="parent",
+    )
+
+    buffer = io.StringIO()
+    monkeypatch.setattr(update_module, "console", Console(file=buffer, width=200))
+    monkeypatch.setattr(update_module, "_get_active_bundle_name", lambda: None)
+
+    update_module._show_concise_report(
+        UpdateReport(local_file_sources=[], cached_git_sources=[]),
+        check_only=True,
+        has_umbrella_updates=False,
+        umbrella_deps=[],
+        bundle_results={parent_uri: parent, child_uri: child},
+    )
+
+    output = buffer.getvalue()
+    assert "↳" in output, output
+    assert "(via parent)" in output, output
+    assert "c03a88b" in output and "28588b9" in output, output
+    # Indented child follows its parent row, not sorted away from it.
+    assert output.index("parent") < output.index("(via parent)")
+
+
+def test_pinned_transitive_row_shows_pinned_not_a_remote_sha(monkeypatch):
+    import io
+
+    from rich.console import Console
+
+    from amplifier_app_cli.commands import update as update_module
+    from amplifier_app_cli.commands.update import TransitiveBundleStatus
+    from amplifier_app_cli.utils.source_status import UpdateReport
+    from amplifier_foundation.sources.protocol import SourceStatus
+
+    child_uri = "git+https://example.invalid/child@v1.2.3"
+    child = TransitiveBundleStatus(
+        bundle_name=child_uri,
+        bundle_source=child_uri,
+        sources=[
+            SourceStatus(
+                source_uri=child_uri,
+                is_cached=True,
+                has_update=False,
+                cached_ref="v1.2.3",
+                cached_commit="deadbeef00000000",
+            )
+        ],
+        included_by="parent",
+        included_under="parent",
+        is_pinned=True,
+    )
+
+    buffer = io.StringIO()
+    monkeypatch.setattr(update_module, "console", Console(file=buffer, width=200))
+    monkeypatch.setattr(update_module, "_get_active_bundle_name", lambda: None)
+
+    update_module._show_concise_report(
+        UpdateReport(local_file_sources=[], cached_git_sources=[]),
+        check_only=True,
+        has_umbrella_updates=False,
+        umbrella_deps=[],
+        bundle_results={child_uri: child},
+    )
+
+    assert "pinned" in buffer.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# The executor has to ACT on it
+# ---------------------------------------------------------------------------
+
+
+def test_update_refreshes_transitive_rows_via_the_git_handler(monkeypatch):
+    """`amplifier update` must refresh a transitive row, not skip or reload it."""
+    from unittest.mock import patch
+
+    from click.testing import CliRunner
+
+    from amplifier_app_cli.commands.update import TransitiveBundleStatus
+    from amplifier_app_cli.commands.update import update
+    from amplifier_app_cli.utils.source_status import UpdateReport
+    from amplifier_app_cli.utils.update_executor import ExecutionResult
+    from amplifier_foundation.sources.protocol import SourceStatus
+
+    child_uri = "git+https://example.invalid/child@main"
+    child = TransitiveBundleStatus(
+        bundle_name=child_uri,
+        bundle_source=child_uri,
+        sources=[
+            SourceStatus(
+                source_uri=child_uri,
+                is_cached=True,
+                has_update=True,
+                cached_commit="c03a88b0000000",
+                remote_commit="28588b90000000",
+            )
+        ],
+        included_by="foundation",
+        included_under="foundation",
+    )
+
+    refreshed: list[str] = []
+
+    async def fake_refresh(uri, *, cache_dir):
+        refreshed.append(uri)
+
+    async def fake_check_all_sources(**kwargs):
+        return UpdateReport(local_file_sources=[], cached_git_sources=[])
+
+    async def fake_check_all_bundle_status():
+        return {child_uri: child}
+
+    async def fake_execute_updates(
+        report, umbrella_info=None, progress_callback=None, force=False
+    ):
+        return ExecutionResult(success=True, updated=[], messages=[])
+
+    with (
+        patch(
+            "amplifier_app_cli.utils.umbrella_discovery.discover_umbrella_source",
+            return_value=None,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.check_all_sources",
+            side_effect=fake_check_all_sources,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update._check_all_bundle_status",
+            side_effect=fake_check_all_bundle_status,
+        ),
+        patch(
+            "amplifier_app_cli.utils.include_graph.refresh_transitive_source",
+            side_effect=fake_refresh,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update._refresh_skills_cache",
+            return_value=None,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.save_update_last_check",
+            return_value=None,
+        ),
+    ):
+        result = CliRunner().invoke(update, ["--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert refreshed == [child_uri], (
+        "a transitive row with an available update must be refreshed; "
+        f"refreshed={refreshed} output={result.output}"
+    )
+
+
+def test_all_sources_up_to_date_is_not_printed_over_a_stale_transitive_cache(
+    monkeypatch,
+):
+    """The green line is a claim about the whole closure, includes and all."""
+    from unittest.mock import patch
+
+    from click.testing import CliRunner
+
+    from amplifier_app_cli.commands.update import TransitiveBundleStatus
+    from amplifier_app_cli.commands.update import update
+    from amplifier_app_cli.utils.source_status import UpdateReport
+    from amplifier_app_cli.utils.update_executor import ExecutionResult
+    from amplifier_foundation.sources.protocol import SourceStatus
+
+    child_uri = "git+https://example.invalid/child@main"
+    child = TransitiveBundleStatus(
+        bundle_name=child_uri,
+        bundle_source=child_uri,
+        sources=[
+            SourceStatus(
+                source_uri=child_uri,
+                is_cached=True,
+                has_update=True,
+                cached_commit="c03a88b0000000",
+                remote_commit="28588b90000000",
+            )
+        ],
+        included_by="foundation",
+        included_under="foundation",
+    )
+
+    async def fake_check_all_sources(**kwargs):
+        return UpdateReport(local_file_sources=[], cached_git_sources=[])
+
+    async def fake_check_all_bundle_status():
+        return {child_uri: child}
+
+    async def fake_execute_updates(
+        report, umbrella_info=None, progress_callback=None, force=False
+    ):
+        return ExecutionResult(success=True, updated=[], messages=[])
+
+    async def fake_refresh(uri, *, cache_dir):
+        return None
+
+    with (
+        patch(
+            "amplifier_app_cli.utils.umbrella_discovery.discover_umbrella_source",
+            return_value=None,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.check_all_sources",
+            side_effect=fake_check_all_sources,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update._check_all_bundle_status",
+            side_effect=fake_check_all_bundle_status,
+        ),
+        patch(
+            "amplifier_app_cli.utils.include_graph.refresh_transitive_source",
+            side_effect=fake_refresh,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update._refresh_skills_cache",
+            return_value=None,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.save_update_last_check",
+            return_value=None,
+        ),
+    ):
+        result = CliRunner().invoke(update, ["--check-only"])
+
+    assert "All sources up to date" not in result.output, result.output
+
+
+# ---------------------------------------------------------------------------
+# End-to-end wiring: the walk must actually be reachable from the real
+# enumeration, not just callable on its own.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_check_all_bundle_status_includes_transitive_sources(
+    tmp_path, amplifier_home, monkeypatch
+):
+    """`_check_all_bundle_status()` -- the enumeration `amplifier update` calls."""
+    import json
+    from types import SimpleNamespace
+
+    from amplifier_app_cli.commands import update as update_module
+
+    repo_c = tmp_path / "repo-c"
+    _make_repo(repo_c, _bundle_md("c"))
+    c_uri = _git_uri(repo_c, "main")
+
+    repo_b = tmp_path / "repo-b"
+    _make_repo(repo_b, _bundle_md("b", includes=[c_uri]))
+    b_uri = _git_uri(repo_b, "main")
+
+    cache_dir = amplifier_home / "cache"
+    await _prime_cache(b_uri, cache_dir)
+    c_cache = await _prime_cache(c_uri, cache_dir)
+    stale_sha = _cached_head(c_cache)
+
+    (repo_c / "NEW.md").write_text("moved on\n", encoding="utf-8")
+    new_sha = _commit(repo_c, "advance main")
+
+    (amplifier_home / "registry.json").write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "bundles": {
+                    "b": {
+                        "uri": b_uri,
+                        "name": "b",
+                        "version": "1.0.0",
+                        "is_root": True,
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Only "b" is registered. Left unstubbed, discovery would also fold in
+    # every WELL_KNOWN_BUNDLE and hit the network from a unit test.
+    monkeypatch.setattr(
+        update_module,
+        "AppBundleDiscovery",
+        lambda *a, **k: SimpleNamespace(list_cached_root_bundles=lambda: ["b"]),
+    )
+    monkeypatch.setattr(
+        update_module, "AppSettings", lambda: SimpleNamespace(get_app_bundles=list)
+    )
+
+    results = await update_module._check_all_bundle_status()
+
+    assert "b" in results
+    assert c_uri in results, (
+        "the include walk is not wired into the enumeration -- this is the "
+        f"exact silent omission the fix exists for. Got: {sorted(results)}"
+    )
+    assert results[c_uri].included_by == "b"
+    assert results[c_uri].sources[0].cached_commit == stale_sha
+    assert results[c_uri].sources[0].remote_commit == new_sha


### PR DESCRIPTION
## Defect

`amplifier update` and `amplifier bundle update` both printed a green **"All sources up to date"** while a cache in the active closure sat behind its `@main` upstream.

Measured on this host 2026-09-06: `~/.amplifier/cache/amplifier-d1dda27a16518560` (`git_url https://github.com/microsoft/amplifier`, `ref main`) was pinned at **c03a88b** while upstream `main` was **28588b9** — 28588b9 was not even a fetched object there. `microsoft/amplifier` is not a registered source; it enters the closure only through amplifier-foundation's `bundle.md:16`:

```
- bundle: git+https://github.com/microsoft/amplifier@main#subdirectory=behaviors/amplifier-expert.yaml
```

## Root cause (found first, as required)

Two independent facts combine into a permanent silent staleness.

**1. Enumeration is registration-shaped, not closure-shaped.**

`amplifier_app_cli/commands/update.py:364` `_check_all_bundle_status()` enumerates exactly two things: `discovery.list_cached_root_bundles()` and `AppSettings().get_app_bundles()`. `list_cached_root_bundles()` keeps only registry entries with `is_root: true` — `amplifier_app_cli/lib/bundle_loader/discovery.py:679-685` sorts every non-root entry into `nested_bundles`, and `discovery.py:496-497` discards that half. A `#subdirectory=` include registers with `is_root: false` (`amplifier_foundation/registry.py:520-545`), so a repo whose only registry presence is such an entry is checked by nobody. On the day of the report, `amplifier-expert-behavior` was registered (`is_root: false`, `root_name: "amplifier"`) with **no** `amplifier` root entry — that entry only appeared later, at 08:43, after the cache had already been refreshed by other means at 07:48.

`amplifier bundle update` fails the same way from the other end: `check_bundle_status()` → `_collect_source_uris()` (`amplifier_foundation/updates/__init__.py:138-140`) deliberately skips includes on the comment *"Included bundles are now registered as first-class bundles and will be checked independently."* That premise does not hold for an include with no root entry.

**2. The loader never refreshes a cached `@<branch>` include — no TTL, ever.**

`amplifier_foundation/sources/git.py:697-709`: `GitSourceHandler.resolve()` returns the existing cache verbatim whenever it passes `_verify_clone_integrity()`. There is no fetch, no age check, no revalidation. Refresh happens **only** via `GitSourceHandler.update()` (`git.py:877-899`), which only the update commands call.

So the answer to "does the loader ever refresh on session start?" is **never** — which is what makes a missed enumeration permanent rather than merely late. That decides the fix location: the update side, here. The foundation side is filed separately as **recipes-72y** (naming `updates/__init__.py:138-140` and the exact fix), because fixing `check_bundle_status()` upstream would make every host correct, not just this CLI.

## Change

New `amplifier_app_cli/utils/include_graph.py` — a cycle-safe BFS over `includes:`:

- **Reuses the loader's resolution, does not reimplement it**: `BundleRegistry._parse_include`, `_resolve_include_source` (handles `@namespace:path`, `git+`, `#subdirectory=` identically to a real session), `_load_from_path` to parse bundle files, `GitSourceHandler._get_cache_path` / `get_status` / `update`, and foundation's own `SourceStatus.is_pinned`.
- **Read-only walk**: reads caches that already exist and never resolves a missing one — resolving downloads, and a download would make a deleted cache report as healthy, the exact side effect `_check_all_bundle_status` was written to avoid.
- **Cycle-safe** on the full URI (fragment included, so two behaviors in one repo are not collapsed).
- Skips anything already covered by a direct row — a registered repo is not "transitive", and two rows for one cache would misreport which carries the update.

Wired into both commands:

| | before | after |
|---|---|---|
| `update.py:_check_all_bundle_status` | registry roots + app bundles | ` + _check_transitive_bundle_status()` |
| `update.py` Bundles table | transitive rows absent | indented `↳ <name> (via <parent>)`, grouped under the registered root, cached vs remote SHA |
| `update.py` executor | n/a | transitive rows refreshed via `GitSourceHandler.update()` |
| `bundle.py:_bundle_update_async` / `_bundle_update_all_async` | `check_bundle_status()` only | `+ _augment_with_transitive()` / `_refresh_transitive()` |

Pinned `@sha` / `@v1.2.3` includes render `pinned` in the Remote column and are never refreshed (`get_status()` already reports `has_update=False` for them). Because transitive rows fold into `bundle_results`, `has_bundle_updates` picks them up automatically — **"All sources up to date" can no longer print over a stale transitive cache.**

## Tests

`tests/test_transitive_include_updates.py` — 12 tests, real local git repos over `git+file://` so cache-key derivation, `git ls-remote` comparison and re-clone all run for real:

1. B registered / C not → C checked, attributed to B, correct stale-vs-remote SHAs
2. refresh actually advances C's cache
3. a directly-registered repo is never duplicated as a transitive row
4. pinned `@sha` reported pinned, `has_update=False`, cache unmoved
5. pinned `@v1.0.0` tag likewise
6. cycle (B ↔ C) terminates, C found once
7–8. table renders `↳ … (via parent)` with both SHAs; pinned row shows `pinned`
9. executor refreshes a transitive row via the git handler
10. `--check-only` does not print "All sources up to date" over a stale transitive row
11. **`_check_all_bundle_status()` end-to-end** — verified to FAIL with the walk disabled: `AssertionError: the include walk is not wired into the enumeration … Got: ['b']`

## Gates

- `uv run pytest -q` → **1877 passed, 1 skipped, 13 deselected, 1 xfailed**
- `uv run ruff check` on all four touched files → **All checks passed**
- Windows: the `git+file://` fixtures are `skipif`'d (drive-letter URIs take a different resolution path); the behaviour under test is platform-independent and covered on POSIX runners. The render/executor tests run everywhere.

## Live proof (this host, isolated `HOME` + `AMPLIFIER_HOME` copy)

Isolated because refreshing against the real `~/.amplifier` would destroy the reproduction. The copy carries the real `registry.json`, `settings.yaml` and full 403 MB cache; `~/.amplifier/cache/amplifier-d1dda27a16518560` was restored to **c03a88b** with matching `.amplifier_cache_meta.json`, and the (later-added) `amplifier` root entry removed — i.e. exactly the registry state at the time of the report.

**Before — installed CLI (`amplifier update --check-only`):**
```
│ foundation            │ 2ef5e12 │ 2ef5e12 │ ✓ │
...
Legend: ✓ up to date  ● update available  ◦ local changes
✓ All sources up to date
```
`microsoft/amplifier` appears nowhere in the table. Cache: `c03a88b`.

**After — this branch (`amplifier update --check-only`):**
```
│ foundation                     │ 2ef5e12 │ 2ef5e12 │ ✓ │
│   ↳ amplifier (via foundation) │ c03a88b │ 28588b9 │ ● │
...
Updates available:
  • 1 bundle(s)
```

**Apply — `yes | amplifier update`:**
```
BEFORE: c03a88b Merge pull request #396 from microsoft/lane/am-content
✓ Update complete
  ✓ Bundle: git+https://github.com/microsoft/amplifier@main
AFTER:  28588b9 Merge pull request #397 from microsoft/lane/am-7vl
```
```json
{"cached_at": "2026-09-06T10:32:40.613082", "ref": "main",
 "commit": "28588b93886dd4b134f131294ca98e944d71cbfd",
 "git_url": "https://github.com/microsoft/amplifier"}
```

**The other command — `amplifier bundle update foundation`:**

Installed CLI, cache at `c03a88b`: `All sources are up to date.`

This branch:
```
│ git+https://github.com/microsoft/amplifier@main │ 🔄 Update │ via foundation c03a88b → 28588b9 │
...
✓ Updated (transitive): git+https://github.com/microsoft/amplifier@main
AFTER:  28588b9 Merge pull request #397 from microsoft/lane/am-7vl
```

The measured symptom, fixed, on both commands.

## Filed alongside

- **recipes-72y** — foundation: `check_bundle_status()` drops includes on a false premise (`updates/__init__.py:138-140`), with the exact fix.
- **recipes-j48** — app-cli: bundle discovery hardcodes `Path.home()/.amplifier/registry.json` (`discovery.py:668`, `:537`, `paths.py:47`), ignoring `AMPLIFIER_HOME`. Latent split-brain, surfaced while building the isolated-home proof.

Work item: **recipes-0yc**

Generated with Amplifier

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
