### PR TITLE
fix(paths): resolve every ~/.amplifier path through get_amplifier_home() (j48)

### DIFF
--- a/amplifier_app_cli/commands/reset.py
+++ b/amplifier_app_cli/commands/reset.py
@@ -38,6 +38,7 @@ from pathlib import Path
 
 import click
 
+from amplifier_foundation.paths.resolution import get_amplifier_home
 from ..console import console
 from ..utils.error_format import escape_markup
 from ..utils.fs_utils import rmtree_robust
@@ -88,7 +89,7 @@ UV_TOOL_PACKAGES = ("amplifier", "amplifier-app-cli")
 
 def _get_amplifier_dir() -> Path:
     """Get the ~/.amplifier directory path."""
-    return Path.home() / ".amplifier"
+    return get_amplifier_home()
 
 
 def _get_known_files() -> set[str]:

--- a/amplifier_app_cli/commands/routing.py
+++ b/amplifier_app_cli/commands/routing.py
@@ -14,6 +14,7 @@ from rich.console import Console
 from rich.prompt import Confirm, Prompt
 from rich.table import Table
 
+from amplifier_foundation.paths.resolution import get_amplifier_home
 from ..lib.bundle_loader.discovery import WELL_KNOWN_BUNDLES
 from ..lib.routing_provenance import resolve_matrix_origins, resolve_winning_paths
 from ..lib.settings import AppSettings, Scope, get_custom_routing_dir
@@ -110,11 +111,10 @@ def _discover_matrix_files() -> list[Path]:
     routing list` work out of the box instead of silently returning an
     empty list and telling the user to run a different command.
     """
-    home = Path.home()
     files: list[Path] = []
 
     # Bundle cache matrices (lazy-fetch on first use)
-    cache_base = home / ".amplifier" / "cache"
+    cache_base = get_amplifier_home() / "cache"
     bundle_dirs = (
         list(cache_base.glob("amplifier-bundle-routing-matrix-*"))
         if cache_base.exists()
@@ -1475,7 +1475,7 @@ def _pick_base_matrix(
     active_matrix = routing_config.get("matrix", "balanced")
 
     # Custom matrices live under ~/.amplifier/routing/
-    custom_dir = Path.home() / ".amplifier" / "routing"
+    custom_dir = get_amplifier_home() / "routing"
 
     matrix_names = sorted(matrices.keys())
 
@@ -1691,7 +1691,7 @@ def _routing_create_interactive(settings: AppSettings) -> None:
         )
         return
 
-    output_dir = Path.home() / ".amplifier" / "routing"
+    output_dir = get_amplifier_home() / "routing"
     saved = save_custom_matrix(matrix_name, assignments, output_dir)
     console.print(f"\n[green]\u2713 Saved to {saved}[/green]")
 
@@ -1897,7 +1897,7 @@ def _routing_edit_matrix(settings: AppSettings) -> None:
         )
         return
 
-    output_dir = Path.home() / ".amplifier" / "routing"
+    output_dir = get_amplifier_home() / "routing"
     output_file = output_dir / f"{matrix_name}.yaml"
 
     # Check for overwrite

--- a/amplifier_app_cli/commands/session.py
+++ b/amplifier_app_cli/commands/session.py
@@ -16,6 +16,7 @@ from rich.panel import Panel
 from rich.prompt import Prompt
 from rich.table import Table
 
+from amplifier_foundation.paths.resolution import get_amplifier_home
 from ..console import console
 from ..ui.item_renderer import ItemRenderer
 from ..ui.view_policy import resolve_view, view_flags
@@ -622,7 +623,7 @@ def register_session_commands(
             )
             return
         if all_projects:
-            projects_dir = Path.home() / ".amplifier" / "projects"
+            projects_dir = get_amplifier_home() / "projects"
             if not projects_dir.exists():
                 console.print("[yellow]No sessions found.[/yellow]")
                 return
@@ -716,9 +717,7 @@ def register_session_commands(
             if not project_slug.startswith("-"):
                 project_slug = "-" + project_slug
 
-            sessions_dir = (
-                Path.home() / ".amplifier" / "projects" / project_slug / "sessions"
-            )
+            sessions_dir = get_amplifier_home() / "projects" / project_slug / "sessions"
             if not sessions_dir.exists():
                 console.print(
                     f"[yellow]No sessions found for project: {project}[/yellow]"

--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -12,6 +12,7 @@ from rich.text import Text
 
 from amplifier_foundation.updates import BundleStatus as _BundleStatus
 
+from amplifier_foundation.paths.resolution import get_amplifier_home
 from ..lib.bundle_loader import AppBundleDiscovery
 
 # Reused rather than reimplemented: bundle preparation already derives a
@@ -1183,11 +1184,10 @@ def _refresh_skills_cache(console: Console) -> None:
     import shutil
     import subprocess
     from datetime import datetime
-    from pathlib import Path
 
     _logger = logging.getLogger(__name__)
 
-    skills_cache_dir = Path.home() / ".amplifier" / "cache" / "skills"
+    skills_cache_dir = get_amplifier_home() / "cache" / "skills"
     if not skills_cache_dir.exists():
         return
 

--- a/amplifier_app_cli/key_manager.py
+++ b/amplifier_app_cli/key_manager.py
@@ -2,10 +2,10 @@
 
 import os
 import platform
-from pathlib import Path
 
 from filelock import FileLock
 
+from amplifier_foundation.paths.resolution import get_amplifier_home
 from .utils.atomic_write import atomic_write_text
 
 
@@ -13,7 +13,7 @@ class KeyManager:
     """Manage API keys in ~/.amplifier/keys.env file."""
 
     def __init__(self):
-        self.keys_file = Path.home() / ".amplifier" / "keys.env"
+        self.keys_file = get_amplifier_home() / "keys.env"
         # Advisory lock guarding the read-modify-write critical section in
         # save_key()/has_stored_key() -- two ordinary concurrent CLI
         # invocations (two terminals, or a script racing a human) must not

--- a/amplifier_app_cli/lib/bundle_loader/discovery.py
+++ b/amplifier_app_cli/lib/bundle_loader/discovery.py
@@ -20,6 +20,7 @@ import logging
 from pathlib import Path
 
 from amplifier_foundation import BundleRegistry
+from amplifier_foundation.paths.resolution import get_amplifier_home
 
 
 logger = logging.getLogger(__name__)
@@ -219,7 +220,7 @@ class AppBundleDiscovery:
             paths.append(project_bundles)
 
         # User
-        user_bundles = Path.home() / ".amplifier" / "bundles"
+        user_bundles = get_amplifier_home() / "bundles"
         if user_bundles.exists():
             paths.append(user_bundles)
 
@@ -425,7 +426,7 @@ class AppBundleDiscovery:
         """Get bundles that were explicitly requested by the user."""
         import json
 
-        registry_path = Path.home() / ".amplifier" / "registry.json"
+        registry_path = get_amplifier_home() / "registry.json"
         if not registry_path.exists():
             return set()
 
@@ -447,7 +448,7 @@ class AppBundleDiscovery:
         """Read ALL bundle names from persisted registry (no filtering)."""
         import json
 
-        registry_path = Path.home() / ".amplifier" / "registry.json"
+        registry_path = get_amplifier_home() / "registry.json"
         if not registry_path.exists():
             return []
 
@@ -534,7 +535,7 @@ class AppBundleDiscovery:
         #
         # URI priority for resolving a bundle's URI:
         #   registry data > user-added settings (added_bundles) > WELL_KNOWN_BUNDLES
-        registry_path = Path.home() / ".amplifier" / "registry.json"
+        registry_path = get_amplifier_home() / "registry.json"
         if registry_path.exists():
             try:
                 with open(registry_path, encoding="utf-8") as f:
@@ -618,7 +619,7 @@ class AppBundleDiscovery:
             )
 
         # Read persisted registry for dependencies and nested bundles
-        registry_path = Path.home() / ".amplifier" / "registry.json"
+        registry_path = get_amplifier_home() / "registry.json"
         if registry_path.exists():
             try:
                 with open(registry_path, encoding="utf-8") as f:
@@ -665,7 +666,7 @@ class AppBundleDiscovery:
         """
         import json
 
-        registry_path = Path.home() / ".amplifier" / "registry.json"
+        registry_path = get_amplifier_home() / "registry.json"
         if not registry_path.exists():
             return set(), set()
 

--- a/amplifier_app_cli/lib/bundle_loader/user_registry.py
+++ b/amplifier_app_cli/lib/bundle_loader/user_registry.py
@@ -19,13 +19,13 @@ from __future__ import annotations
 
 import logging
 import warnings
-from pathlib import Path
 from typing import Any
+from amplifier_foundation.paths.resolution import get_amplifier_home
 
 logger = logging.getLogger(__name__)
 
 # Legacy registry location (kept for migration)
-REGISTRY_PATH = Path.home() / ".amplifier" / "bundle-registry.yaml"
+REGISTRY_PATH = get_amplifier_home() / "bundle-registry.yaml"
 
 
 def _emit_deprecation_warning(func_name: str) -> None:

--- a/amplifier_app_cli/lib/dev_overrides.py
+++ b/amplifier_app_cli/lib/dev_overrides.py
@@ -39,6 +39,7 @@ from pathlib import Path
 from typing import Literal
 
 import yaml
+from amplifier_foundation.paths.resolution import get_amplifier_home
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +65,7 @@ def resolve_dev_override(resource_type: ResourceType, resource_id: str) -> Path 
     scope_paths = [
         (Path.cwd() / ".amplifier" / "settings.local.yaml", Path.cwd() / ".amplifier"),
         (Path.cwd() / ".amplifier" / "settings.yaml", Path.cwd() / ".amplifier"),
-        (Path.home() / ".amplifier" / "settings.yaml", Path.home() / ".amplifier"),
+        (get_amplifier_home() / "settings.yaml", get_amplifier_home()),
     ]
 
     for settings_file, scope_dir in scope_paths:

--- a/amplifier_app_cli/lib/mention_loading/app_resolver.py
+++ b/amplifier_app_cli/lib/mention_loading/app_resolver.py
@@ -13,6 +13,7 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING
 from typing import Protocol
+from amplifier_foundation.paths.resolution import get_amplifier_home
 
 if TYPE_CHECKING:
     from amplifier_foundation.mentions.resolver import BaseMentionResolver
@@ -131,7 +132,7 @@ class AppMentionResolver:
         if not path:
             return None
 
-        user_path = Path.home() / ".amplifier" / path
+        user_path = get_amplifier_home() / path
         if user_path.exists():
             logger.debug(f"User shortcut resolved: {mention} -> {user_path}")
             return user_path.resolve()

--- a/amplifier_app_cli/lib/settings.py
+++ b/amplifier_app_cli/lib/settings.py
@@ -14,6 +14,7 @@ import yaml
 from filelock import BaseFileLock
 from filelock import FileLock
 
+from amplifier_foundation.paths.resolution import get_amplifier_home
 from ..utils.atomic_write import atomic_write_yaml
 
 Scope = Literal["local", "project", "global", "session"]
@@ -34,7 +35,7 @@ def get_custom_routing_dir() -> Path:
     *loadable* -- the exact "Matrix file not found -- routing disabled" bug
     this function exists to prevent by construction.
     """
-    return Path.home() / ".amplifier" / "routing"
+    return get_amplifier_home() / "routing"
 
 
 @dataclass(frozen=True)
@@ -69,7 +70,7 @@ class SettingsPaths:
     def default(cls) -> SettingsPaths:
         """Create default paths for standard amplifier layout."""
         return cls(
-            global_settings=Path.home() / ".amplifier" / "settings.yaml",
+            global_settings=get_amplifier_home() / "settings.yaml",
             project_settings=Path.cwd() / ".amplifier" / "settings.yaml",
             local_settings=Path.cwd() / ".amplifier" / "settings.local.yaml",
             session_settings=None,
@@ -80,8 +81,7 @@ class SettingsPaths:
         """Create paths including session-scoped settings."""
         base = cls.default()
         base.session_settings = (
-            Path.home()
-            / ".amplifier"
+            get_amplifier_home()
             / "projects"
             / project_slug
             / "sessions"
@@ -292,8 +292,8 @@ class AppSettings:
 
         Migration is idempotent - skipped if already migrated.
         """
-        legacy_path = Path.home() / ".amplifier" / "bundle-registry.yaml"
-        migrated_marker = Path.home() / ".amplifier" / "bundle-registry.yaml.migrated"
+        legacy_path = get_amplifier_home() / "bundle-registry.yaml"
+        migrated_marker = get_amplifier_home() / "bundle-registry.yaml.migrated"
 
         # Skip if no legacy file or already migrated
         if not legacy_path.exists() or migrated_marker.exists():
@@ -1045,8 +1045,7 @@ class AppSettings:
         # Also check session-scoped settings if session context provided
         if session_id and project_slug:
             session_settings_path = (
-                Path.home()
-                / ".amplifier"
+                get_amplifier_home()
                 / "projects"
                 / project_slug
                 / "sessions"

--- a/amplifier_app_cli/lib/sources_compat.py
+++ b/amplifier_app_cli/lib/sources_compat.py
@@ -16,6 +16,7 @@ import urllib.error
 import urllib.request
 from datetime import datetime
 
+from amplifier_foundation.paths.resolution import get_amplifier_home
 from ..utils.atomic_write import atomic_write_json
 from pathlib import Path
 
@@ -95,7 +96,7 @@ class GitSource:
         self.ref = ref
         self.subdirectory = subdirectory
         # Use consolidated cache path
-        self.cache_dir = Path.home() / ".amplifier" / "cache"
+        self.cache_dir = get_amplifier_home() / "cache"
         self._cached_commit_sha: str | None = None
 
     def _get_effective_url(self) -> str:

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -48,6 +48,7 @@ else:
     _TERMINAL_UNUSABLE_ERRORS = ()
 
 
+from amplifier_foundation.paths.resolution import get_amplifier_home
 from .commands.agents import agents as agents_group
 from .commands.allowed_dirs import allowed_dirs as allowed_dirs_group
 from .commands.bundle import bundle as bundle_group
@@ -3210,7 +3211,7 @@ def get_module_search_paths() -> list[Path]:
         paths.append(project_modules)
 
     # Then user modules
-    user_modules = Path.home() / ".amplifier" / "modules"
+    user_modules = get_amplifier_home() / "modules"
     if user_modules.exists():
         paths.append(user_modules)
 
@@ -3463,9 +3464,7 @@ def _create_prompt_session(
     from amplifier_app_cli.project_utils import get_project_slug
 
     project_slug = get_project_slug()
-    history_path = (
-        Path.home() / ".amplifier" / "projects" / project_slug / "repl_history"
-    )
+    history_path = get_amplifier_home() / "projects" / project_slug / "repl_history"
 
     # Ensure project directory exists
     history_path.parent.mkdir(parents=True, exist_ok=True)

--- a/amplifier_app_cli/paths.py
+++ b/amplifier_app_cli/paths.py
@@ -11,6 +11,7 @@ from typing import Literal
 
 from amplifier_foundation import BundleRegistry
 
+from amplifier_foundation.paths.resolution import get_amplifier_home
 from .lib.settings import AppSettings
 
 # LEGACY: These imports are no longer available - bundles are the only supported mode
@@ -45,7 +46,7 @@ def get_install_state_path() -> Path:
     Returns:
         Path to ~/.amplifier/cache/install-state.json
     """
-    return Path.home() / ".amplifier" / "cache" / "install-state.json"
+    return get_amplifier_home() / "cache" / "install-state.json"
 
 
 # ===== COMMON PATH HELPERS =====
@@ -75,7 +76,7 @@ def _get_user_and_project_paths(
         paths.append(project_path)
 
     # User
-    user_path = Path.home() / ".amplifier" / resource_type
+    user_path = get_amplifier_home() / resource_type
     if not check_exists or user_path.exists():
         paths.append(user_path)
 

--- a/amplifier_app_cli/session_store.py
+++ b/amplifier_app_cli/session_store.py
@@ -21,6 +21,7 @@ from amplifier_foundation import sanitize_message
 from amplifier_foundation import write_with_backup
 
 from amplifier_app_cli.project_utils import get_project_slug
+from amplifier_foundation.paths.resolution import get_amplifier_home
 
 logger = logging.getLogger(__name__)
 
@@ -94,9 +95,7 @@ class SessionStore:
         """
         if base_dir is None:
             project_slug = get_project_slug()
-            base_dir = (
-                Path.home() / ".amplifier" / "projects" / project_slug / "sessions"
-            )
+            base_dir = get_amplifier_home() / "projects" / project_slug / "sessions"
         self.base_dir = base_dir
         self.base_dir.mkdir(parents=True, exist_ok=True)
 

--- a/amplifier_app_cli/utils/cache_management.py
+++ b/amplifier_app_cli/utils/cache_management.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
+from amplifier_foundation.paths.resolution import get_amplifier_home
 from .fs_utils import rmtree_robust
 
 logger = logging.getLogger(__name__)
@@ -22,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 def get_amplifier_dir() -> Path:
     """Return the ~/.amplifier directory path."""
-    return Path.home() / ".amplifier"
+    return get_amplifier_home()
 
 
 def get_cache_dir() -> Path:

--- a/amplifier_app_cli/utils/module_cache.py
+++ b/amplifier_app_cli/utils/module_cache.py
@@ -27,6 +27,7 @@ except ImportError:
     import tomli as tomllib  # type: ignore[import-not-found]
 
 import yaml
+from amplifier_foundation.paths.resolution import get_amplifier_home
 
 logger = logging.getLogger(__name__)
 
@@ -171,7 +172,7 @@ def get_cache_dir() -> Path:
     and bundle caching. This unified path ensures update checks find modules
     regardless of whether they were installed via bundles.
     """
-    return Path.home() / ".amplifier" / "cache"
+    return get_amplifier_home() / "cache"
 
 
 def _infer_module_type_from_name(module_id: str) -> str:

--- a/amplifier_app_cli/utils/settings_manager.py
+++ b/amplifier_app_cli/utils/settings_manager.py
@@ -25,18 +25,18 @@ host, and this module's only writer -- the update-check timestamp -- fires at
 
 import logging
 from datetime import datetime
-from pathlib import Path
 
 import yaml
 from filelock import BaseFileLock
 from filelock import FileLock
 from filelock import Timeout
 
+from amplifier_foundation.paths.resolution import get_amplifier_home
 from .atomic_write import atomic_write_yaml
 
 logger = logging.getLogger(__name__)
 
-SETTINGS_FILE = Path.home() / ".amplifier" / "settings.yaml"
+SETTINGS_FILE = get_amplifier_home() / "settings.yaml"
 
 # Must match lib/settings.py::AppSettings._scope_lock for the "global" scope,
 # or the two writers lock against nothing.

--- a/amplifier_app_cli/utils/update_check.py
+++ b/amplifier_app_cli/utils/update_check.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import httpx
 
+from amplifier_foundation.paths.resolution import get_amplifier_home
 from .atomic_write import atomic_write_json
 from .atomic_write import atomic_write_text
 from .source_status import UpdateReport
@@ -24,8 +25,8 @@ UPDATE_CHECK_INTERVAL = 86400
 UPDATE_CACHE_TTL = 3600
 
 # Cache file locations
-UPDATE_CHECK_FILE = Path.home() / ".amplifier" / ".last_update_check"
-UPDATE_CACHE_FILE = Path.home() / ".amplifier" / ".update_cache.json"
+UPDATE_CHECK_FILE = get_amplifier_home() / ".last_update_check"
+UPDATE_CACHE_FILE = get_amplifier_home() / ".update_cache.json"
 
 
 async def check_updates(include_all_cached: bool = False) -> UpdateReport:

--- a/tests/test_amplifier_home_isolation.py
+++ b/tests/test_amplifier_home_isolation.py
@@ -1,0 +1,195 @@
+"""`AMPLIFIER_HOME` is the only home the CLI may compose paths from.
+
+Foundation's ``get_amplifier_home()`` is the single source of truth: it honours
+``AMPLIFIER_HOME`` and falls back to ``~/.amplifier``. Code that instead writes
+``Path.home() / ".amplifier" / ...`` looks identical in the default layout and
+silently splits in two the moment ``AMPLIFIER_HOME`` points somewhere else --
+bundle discovery reading the registry from one home while the caches, settings
+and install state come from another.
+
+Two tests, deliberately different in kind:
+
+* a *behavioural* test -- discovery reads the registry from ``AMPLIFIER_HOME``
+  even when ``HOME`` holds a perfectly good decoy registry; and
+* a *structural* guard -- no module in ``amplifier_app_cli`` composes a
+  ``.amplifier`` path from ``Path.home()`` again, so the class of bug cannot
+  come back through a file this test never heard of.
+"""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+
+import pytest
+
+import amplifier_app_cli
+
+
+# ---------------------------------------------------------------------------
+# Behaviour: AMPLIFIER_HOME wins over HOME
+# ---------------------------------------------------------------------------
+
+
+def _write_registry(amplifier_dir: Path, bundle_name: str) -> None:
+    amplifier_dir.mkdir(parents=True, exist_ok=True)
+    (amplifier_dir / "registry.json").write_text(
+        json.dumps(
+            {
+                "bundles": {
+                    bundle_name: {
+                        "uri": f"git+https://example.invalid/{bundle_name}",
+                        "is_root": True,
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+@pytest.fixture
+def split_homes(tmp_path, monkeypatch) -> tuple[Path, Path]:
+    """Point ``HOME`` and ``AMPLIFIER_HOME`` at two *different* registries.
+
+    The decoy under ``HOME`` is the whole point: an assertion that only checks
+    "the isolated bundle is present" passes even when the code is still reading
+    ``~/.amplifier``. Asserting the decoy is *absent* is what actually proves
+    which home won.
+    """
+    decoy_home = tmp_path / "decoy-home"
+    _write_registry(decoy_home / ".amplifier", "decoy-bundle-from-home")
+
+    isolated = tmp_path / "isolated" / ".amplifier"
+    _write_registry(isolated, "isolated-bundle-from-amplifier-home")
+
+    monkeypatch.setenv("HOME", str(decoy_home))
+    monkeypatch.setenv("USERPROFILE", str(decoy_home))  # Path.home() on Windows
+    monkeypatch.setenv("AMPLIFIER_HOME", str(isolated))
+    return decoy_home, isolated
+
+
+def test_discovery_reads_registry_from_amplifier_home(split_homes):
+    """Discovery enumerates AMPLIFIER_HOME's registry, not HOME's."""
+    from amplifier_app_cli.lib.bundle_loader.discovery import AppBundleDiscovery
+
+    discovery = AppBundleDiscovery()
+
+    all_names = discovery._read_all_from_registry()
+    roots, _nested = discovery._get_root_and_nested_bundles()
+
+    assert "isolated-bundle-from-amplifier-home" in all_names
+    assert "isolated-bundle-from-amplifier-home" in roots
+
+    assert "decoy-bundle-from-home" not in all_names, (
+        "discovery read ~/.amplifier/registry.json instead of AMPLIFIER_HOME's"
+    )
+    assert "decoy-bundle-from-home" not in roots
+
+
+def test_cli_paths_follow_amplifier_home(split_homes):
+    """The CLI's own path policy resolves under AMPLIFIER_HOME too.
+
+    Install state and global settings living in a different home than the
+    registry is exactly the split-brain this fix exists to prevent.
+    """
+    _decoy_home, isolated = split_homes
+
+    from amplifier_app_cli.lib.settings import SettingsPaths
+    from amplifier_app_cli.paths import get_install_state_path
+
+    assert get_install_state_path() == isolated / "cache" / "install-state.json"
+    assert SettingsPaths.default().global_settings == isolated / "settings.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Guard: the composition cannot come back
+# ---------------------------------------------------------------------------
+
+_PACKAGE_ROOT = Path(amplifier_app_cli.__file__).resolve().parent
+
+
+def _is_path_home_call(node: ast.AST) -> bool:
+    """True for ``Path.home()`` / ``pathlib.Path.home()``."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "home"
+        and isinstance(node.func.value, ast.Attribute | ast.Name)
+        and (
+            node.func.value.id == "Path"
+            if isinstance(node.func.value, ast.Name)
+            else node.func.value.attr == "Path"
+        )
+    )
+
+
+def _joins_amplifier(node: ast.AST) -> bool:
+    """True for ``<something> / ".amplifier"``."""
+    return (
+        isinstance(node, ast.BinOp)
+        and isinstance(node.op, ast.Div)
+        and isinstance(node.right, ast.Constant)
+        and node.right.value == ".amplifier"
+    )
+
+
+def _home_aliases(tree: ast.AST) -> set[str]:
+    """Names ever bound to ``Path.home()`` anywhere in the module."""
+    aliases: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and _is_path_home_call(node.value):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    aliases.add(target.id)
+    return aliases
+
+
+def _violations(path: Path) -> list[str]:
+    """Report every ``.amplifier`` path composed from the OS home directory."""
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    aliases = _home_aliases(tree)
+    found: list[str] = []
+
+    for node in ast.walk(tree):
+        # Path.home() / ".amplifier" -- and the one-hop `home = Path.home()`
+        # form, which reads innocently and is exactly how routing.py hid one.
+        if _joins_amplifier(node):
+            left = node.left  # type: ignore[attr-defined]
+            if _is_path_home_call(left) or (
+                isinstance(left, ast.Name) and left.id in aliases
+            ):
+                found.append(f"{path.relative_to(_PACKAGE_ROOT)}:{node.lineno}")
+        # expanduser("~/.amplifier...")
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "expanduser"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+            and node.args[0].value.startswith("~/.amplifier")
+        ):
+            found.append(f"{path.relative_to(_PACKAGE_ROOT)}:{node.lineno}")
+
+    return found
+
+
+def test_no_module_composes_amplifier_home_from_path_home():
+    """No file in the package may rebuild ~/.amplifier by hand.
+
+    Use ``get_amplifier_home()`` from
+    ``amplifier_foundation.paths.resolution`` -- it honours AMPLIFIER_HOME and
+    falls back to ``~/.amplifier``, so both layouts keep working.
+    """
+    sources = sorted(_PACKAGE_ROOT.rglob("*.py"))
+    assert sources, "guard found no sources to scan -- it would pass vacuously"
+
+    violations = [v for src in sources for v in _violations(src)]
+
+    assert not violations, (
+        "these compose a .amplifier path from the OS home directory, ignoring "
+        "AMPLIFIER_HOME -- use get_amplifier_home() instead:\n  "
+        + "\n  ".join(violations)
+    )


### PR DESCRIPTION
## Defect

With `AMPLIFIER_HOME` set to anything other than `~/.amplifier`, the CLI read the
**bundle registry from one home and everything else from another**. `amplifier update`
and `amplifier bundle list` enumerated `~/.amplifier/registry.json` while caches,
settings and install state resolved under `AMPLIFIER_HOME` — a latent split-brain that is
invisible in the default layout (the two paths coincide) and a trap for anyone testing
with an isolated home. Noticed while building an isolated-home live proof for recipes-0yc:
`HOME` *and* `AMPLIFIER_HOME` both had to be set for the two halves to agree.

## Root cause

`amplifier_foundation.paths.resolution.get_amplifier_home()` is the single source of truth
(honours `AMPLIFIER_HOME`, falls back to `~/.amplifier`). These composed the path by hand
instead:

- `amplifier_app_cli/lib/bundle_loader/discovery.py:668` — `_get_root_and_nested_bundles()`
- `amplifier_app_cli/lib/bundle_loader/discovery.py:537` — `list_cached_root_bundles()` sub-bundle filter
- `amplifier_app_cli/lib/bundle_loader/discovery.py:428`, `:450`, `:621` — the other registry readers
- `amplifier_app_cli/paths.py:47` — `get_install_state_path()`

The hardcode had spread far past those: **35 compositions across 18 modules**.

## Change

Every `Path.home() / ".amplifier" / …` in `amplifier_app_cli` now calls
`get_amplifier_home()`. Nothing else changed — same paths in the default layout, byte for
byte.

One site was **not** a literal match and would have survived a naive grep:
`commands/routing.py:113` bound `home = Path.home()` and joined `.amplifier / "cache"` five
lines later. The new guard understands that one-hop form.

Four `from pathlib import Path` imports became unused as a result and were removed
(`key_manager.py`, `user_registry.py`, `settings_manager.py`, and a function-local one in
`commands/update.py`).

### Tests

`tests/test_amplifier_home_isolation.py`, two kinds:

1. **Behavioural** — `HOME` and `AMPLIFIER_HOME` point at two *different* registries.
   Discovery must return the `AMPLIFIER_HOME` bundle **and not** the decoy planted under
   `HOME`. Asserting the decoy's *absence* is what actually proves which home won; a test
   that only checks for the isolated bundle passes even against the broken code. A second
   test pins `get_install_state_path()` and `SettingsPaths.default().global_settings` to the
   same home, since registry-and-settings-in-different-homes is the exact split-brain here.
2. **Structural guard** — an AST walk over every `.py` in the package, flagging
   `Path.home() / ".amplifier"`, the one-hop `home = Path.home()` alias form, and
   `expanduser("~/.amplifier…")`. It asserts it found sources to scan, so it cannot pass
   vacuously.

Both were **mutation-verified**: reverting `discovery.py` to `Path.home()` makes both fail;
a probe module containing all three violation shapes is caught at all three line numbers.

## Remaining `Path.home()` / `expanduser` uses — each justified

**Zero** `.amplifier` compositions remain. What is left refers to the *OS* home on purpose:

| Site | Why it stays |
|---|---|
| `paths.py:94`, `lib/settings.py:741` | "is cwd the home directory?" scope checks — the real OS home *is* the question |
| `main.py:308` | shell rc files (`~/.bashrc`, `~/.zshrc`, `~/.config/fish/…`) |
| `utils/source_status.py:632`, `lib/sources_compat.py:325` | `~/.config/gh/hosts.yml` — GitHub CLI's config, not Amplifier's |
| `commands/bundle.py:408`, `commands/routing.py:329` | display-only abbreviation of a path to `~/…` |
| `lib/mention_loading/app_resolver.py:162` | `@~/path` mentions resolve to the OS home by definition (its `@user:` sibling now uses `get_amplifier_home()`) |
| `allowed_dirs.py:109`, `denied_dirs.py:109`, `source.py:102`, `main.py:3030`/`:3095` | `Path(user_input).expanduser()` on user-supplied paths |

Two **string** literals also mention `~/.amplifier` and are deliberately untouched:

- `runtime/config.py:918` — `"~/.amplifier/skills"` in tool-skills' default dirs. It is
  deduped by *exact string* against entries a bundle may declare in the same tilde form,
  and expanded downstream by `tool-skills`. Making it absolute would break that dedup and
  6 assertions in `tests/test_merge_utils.py`. The fix belongs in tool-skills' own
  resolution — flagging, not fixing, here.
- `commands/bundle.py:862`, `ui/scope.py:21` — human-facing scope labels.

**Out of repo (follow-ups for amplifier-foundation):** `session/finder.py:36`
(`DEFAULT_SESSIONS_ROOT`), `registry.py:453`, `configurator/_state_manager.py:756` still
hardcode `~/.amplifier`. This CLI does not depend on those defaults — it uses its own
`SessionStore` and passes explicit paths — so no new split was introduced here.

**Known limitation, stated plainly:** three module-level constants
(`settings_manager.SETTINGS_FILE`, `update_check.UPDATE_CHECK_FILE`/`UPDATE_CACHE_FILE`,
`user_registry.REGISTRY_PATH`) now resolve `AMPLIFIER_HOME` at **import** time rather than
call time. Correct for a CLI process (env is set before start); an in-process env change
after import would not be seen. Left as module constants because
`tests/test_settings_atomic_write.py` monkeypatches `SETTINGS_FILE` as the test seam.

## Gates

| Gate | Result |
|---|---|
| `uv run pytest -q` | **1880 passed**, 1 skipped, 13 deselected, 1 xfailed — 4 consecutive clean runs |
| `ruff check` (touched files) | no new findings: 7 pre-existing errors, all in `commands/session.py`, byte-identical to the `main` baseline; the diff *removed* violations, added none |
| `ruff format --diff` (touched files) | every remaining complaint is at a line range this PR did not touch |
| CI | 9-job matrix on this PR |

One flake worth naming honestly: the *first* full-suite run failed
`test_truststore_wrap_bio_shim.py::test_real_truststore_is_covered_at_cli_import` with
`truststore is not importable` — during a run where `uv` was reinstalling packages. It
passed in isolation immediately after and in 4 subsequent full runs, on this branch and on
stashed `main`. Not reproducible; unrelated to these paths.

## Live proof

Isolated home = a real copy of `~/.amplifier` (registry + settings + 403M cache) at
`/tmp/j48-iso-…/.amplifier`, its `registry.json` trimmed to 4 bundles including
**`j48-isolated-marker`** — a name that exists in no other registry on the machine.
`HOME` untouched (`/home/bkrabach`).

```
AMPLIFIER_HOME=$ISO uv run --project <worktree> amplifier bundle list --all
```

| | rows in table | `j48-isolated-marker` |
|---|---|---|
| **main** (pre-fix), same `AMPLIFIER_HOME` | 107 — i.e. `~/.amplifier`'s 106-bundle registry | **absent** |
| **this branch** | 13 — the isolated registry | **present** |

And the update enumeration itself:

```
yes | AMPLIFIER_HOME=$ISO uv run --project <worktree> amplifier update --check-only
```

lists `j48-isolated-marker  7f5ff46  7f5ff46  ✓` alongside the isolated cache's bundles —
enumerated from the isolated registry, not `~/.amplifier`'s.

`--check-only` deliberately: a bare `amplifier update`, once confirmed, reaches
`execute_self_update()` → `uv tool install --upgrade --reinstall`, which would mutate the
developer's **global** CLI install. The enumeration table under test is identical and is
printed before any execution.

Closes recipes-j48.

Generated with Amplifier

Co-Authored-By: Amplifier <240397093+microsoft-amplifier@users.noreply.github.com>
