### PR TITLE
routing show: honour provider family aliases; warn when the hook isn't mounted in the active bundle

### DIFF
--- a/amplifier_app_cli/commands/routing.py
+++ b/amplifier_app_cli/commands/routing.py
@@ -372,6 +372,23 @@ def _print_origin_paths(origin: Any) -> None:
         )
 
 
+def _provider_family_aliases() -> dict[str, tuple[str, ...]]:
+    """The routing hook's family-alias table, or ``{}`` if the hook isn't importable.
+
+    Read from the hook module itself so this display can never disagree with
+    what the resolver actually does at routing time -- the table has exactly
+    one home. The hook is editable-installed from the bundle cache, so the
+    import succeeds on any host that has ever loaded the routing-matrix
+    bundle; on a clean install before that first fetch it degrades to "no
+    aliases", which is the pre-alias behaviour, not an error.
+    """
+    try:
+        from amplifier_module_hooks_routing.resolver import PROVIDER_FAMILY_ALIASES
+    except Exception:  # pragma: no cover - import environment dependent
+        return {}
+    return dict(PROVIDER_FAMILY_ALIASES)
+
+
 def _get_configured_provider_types(settings: AppSettings) -> set[str]:
     """Get the set of configured provider identifiers a matrix candidate may reference.
 
@@ -382,6 +399,13 @@ def _get_configured_provider_types(settings: AppSettings) -> set[str]:
     provider-chat-completions entries named "qwen-3.6" and "ornith") -- and
     both forms must be recognized as "configured" here to match how
     find_provider_by_type() resolves candidates at actual routing time.
+
+    ALSO includes every family name a configured module SATISFIES via the
+    hook's ``PROVIDER_FAMILY_ALIASES``. ``openai-chatgpt`` (the ChatGPT-
+    subscription backend) satisfies ``provider: openai`` at routing time, so a
+    ChatGPT-only user must see the openai candidates as configured here too --
+    before this, `routing show` told exactly that user "not configured" for
+    every openai role while the session routed them fine.
 
     E.g., {'anthropic', 'openai', 'github-copilot', 'ornith', 'qwen-3.6'}
     """
@@ -396,6 +420,11 @@ def _get_configured_provider_types(settings: AppSettings) -> set[str]:
         provider_id = p.get("id")
         if provider_id:
             types.add(provider_id)
+
+    # A configured alias module satisfies its canonical family name.
+    for canonical, aliases in _provider_family_aliases().items():
+        if any(alias in types for alias in aliases):
+            types.add(canonical)
     return types
 
 
@@ -628,6 +657,7 @@ def routing_show(matrix_name: str | None, compact: bool, detailed: bool, fmt: st
         return
 
     _print_shadowing_note(origin)
+    _print_not_mounted_warning(settings)
     declared = _disagreeing_name(matrix_data, matrix_name)
     if declared is not None:
         _print_name_stem_note([(matrix_name, declared)])
@@ -639,6 +669,88 @@ def routing_show(matrix_name: str | None, compact: bool, detailed: bool, fmt: st
         _show_matrix_details(matrix_data, settings, matrix_name)
     else:
         _show_matrix_resolution(matrix_data, settings, matrix_name)
+
+
+ROUTING_BEHAVIOR_URI = (
+    "git+https://github.com/microsoft/amplifier-bundle-routing-matrix@main"
+    "#subdirectory=behaviors/routing.yaml"
+)
+
+
+def _routing_hook_is_composed(settings: AppSettings) -> bool | None:
+    """Is ``hooks-routing`` actually in the session this cwd would start?
+
+    `routing show` reads matrix files straight from the bundle cache, so it
+    can render a matrix as "active" on a host whose ACTIVE BUNDLE never mounts
+    the routing hook -- in which case nothing applies the matrix and every
+    sub-agent silently inherits the parent's provider. Measured 2026-09-07 on
+    a project pinned to `anchors-amp-dev` (a lean base that does not include
+    routing-matrix): `routing show` said "balanced ... active" for every role
+    while `delegate:agent_spawned` carried `provider_preferences: null`.
+
+    Composes the same way a session does -- active bundle + every app bundle,
+    in that order -- but stops at ``to_mount_plan()``: no ``prepare()``, so no
+    module installs and no network beyond what is already cached (~0.1s).
+
+    Returns ``True`` / ``False``, or ``None`` when it cannot tell (the caller
+    prints nothing in that case; a diagnostic must never break the command).
+
+    Only runs when an active bundle is EXPLICITLY set. With none set the CLI
+    starts its built-in default, `foundation`, which includes routing-matrix --
+    so there is nothing to warn about, and skipping the composition keeps this
+    out of every code path (and test fixture) that never chose a bundle.
+    """
+    active = settings.get_active_bundle()
+    if not active:
+        return None
+    try:
+        import asyncio
+
+        from amplifier_foundation import load_bundle
+
+        from ..lib.bundle_loader import AppBundleDiscovery
+
+        discovery = AppBundleDiscovery()
+        base_uri = discovery.find(active)
+        if not base_uri:
+            return None
+
+        async def _compose() -> list[str]:
+            base = await load_bundle(base_uri, registry=discovery.registry)
+            overlays = [
+                await load_bundle(uri, registry=discovery.registry)
+                for uri in settings.get_app_bundles()
+            ]
+            composed = base.compose(*overlays) if overlays else base
+            return [
+                h.get("module", "")
+                for h in composed.to_mount_plan().get("hooks", [])
+                if isinstance(h, dict)
+            ]
+
+        return "hooks-routing" in asyncio.run(_compose())
+    except Exception as exc:  # pragma: no cover - environment dependent
+        logger.debug("Could not determine whether hooks-routing is composed: %s", exc)
+        return None
+
+
+def _print_not_mounted_warning(settings: AppSettings) -> None:
+    """Warn when this matrix is displayed but nothing in the session applies it."""
+    if _routing_hook_is_composed(settings) is not False:
+        return
+    active = settings.get_active_bundle()
+    console.print(
+        f"\n[yellow]\u26a0 Not applied in your sessions.[/yellow] The active bundle "
+        f"[bold]{active}[/bold] (and your app bundles) never mount the "
+        f"[bold]hooks-routing[/bold] hook, so this matrix is only displayed here -- "
+        f"sub-agents will inherit the parent session's provider instead.\n"
+        f"  To apply it in every session regardless of active bundle:"
+    )
+    # soft_wrap: the command must survive copy-paste, so Rich must not fold it.
+    console.print(
+        f"    [cyan]amplifier bundle add {ROUTING_BEHAVIOR_URI} --app[/cyan]",
+        soft_wrap=True,
+    )
 
 
 def _print_shadowing_note(origin: Any) -> None:

--- a/tests/test_routing_family_alias_and_mount_warning.py
+++ b/tests/test_routing_family_alias_and_mount_warning.py
@@ -1,0 +1,209 @@
+"""`routing show` must tell the truth to two users it used to mislead.
+
+1. THE ALIAS-BLIND USER. A ChatGPT-subscription-only user (`openai-chatgpt`
+   module, no `openai` module) is routed fine at runtime -- the hook's
+   ``PROVIDER_FAMILY_ALIASES`` maps ``provider: openai`` onto that mount -- but
+   `routing show` computed "is this candidate configured?" with a bare
+   set-membership test that never consulted the alias table, and told exactly
+   that user "✗ not configured" for every openai role. Measured in a DTU,
+   2026-09-07.
+
+2. THE HOOK-LESS USER. `routing show` reads matrix files straight from the
+   bundle cache, so it renders a matrix as "★ active" on a host whose ACTIVE
+   BUNDLE never mounts `hooks-routing` -- and then nothing applies the matrix,
+   and every sub-agent silently inherits the parent's provider. Measured on a
+   project pinned to `anchors-amp-dev` (a lean base without routing-matrix):
+   `routing show` said "balanced ... active" for every role while
+   `delegate:agent_spawned` carried `provider_preferences: null`.
+
+Both fixes live in `commands/routing.py`; this file pins them.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from amplifier_app_cli.commands import routing as routing_cmd
+from amplifier_app_cli.lib.settings import AppSettings, SettingsPaths
+
+
+def _settings_with_providers(tmp_path: Path, providers: list[dict]) -> AppSettings:
+    paths = SettingsPaths(
+        global_settings=tmp_path / "global" / "settings.yaml",
+        project_settings=tmp_path / "project" / "settings.yaml",
+        local_settings=tmp_path / "local" / "settings.local.yaml",
+    )
+    paths.global_settings.parent.mkdir(parents=True, exist_ok=True)
+    paths.global_settings.write_text(
+        yaml.safe_dump({"config": {"providers": providers}}), encoding="utf-8"
+    )
+    return AppSettings(paths=paths)
+
+
+# ---------------------------------------------------------------------------
+# 1. Family aliases in "is this provider configured?"
+# ---------------------------------------------------------------------------
+
+
+class TestConfiguredProviderTypesHonourFamilyAliases:
+    ALIASES = {"openai": ("openai-chatgpt",)}
+
+    def test_chatgpt_alone_makes_openai_configured(self, tmp_path: Path) -> None:
+        """The user this was built for: subscription backend only."""
+        settings = _settings_with_providers(
+            tmp_path,
+            [{"module": "provider-openai-chatgpt", "source": "git+x", "id": "chatgpt"}],
+        )
+        with patch.object(
+            routing_cmd, "_provider_family_aliases", return_value=self.ALIASES
+        ):
+            types = routing_cmd._get_configured_provider_types(settings)
+        assert "openai-chatgpt" in types  # the module type, as before
+        assert "chatgpt" in types  # the instance id, as before
+        assert "openai" in types, (
+            "openai-chatgpt satisfies `provider: openai` at routing time, so the "
+            "display must count openai as configured too"
+        )
+
+    def test_alias_is_directional(self, tmp_path: Path) -> None:
+        """A plain `openai` mount does NOT make `openai-chatgpt` look configured.
+
+        Mirrors the resolver: naming the subscription backend explicitly means
+        it, and the display must not claim a backend the user doesn't have.
+        """
+        settings = _settings_with_providers(
+            tmp_path, [{"module": "provider-openai", "source": "git+x"}]
+        )
+        with patch.object(
+            routing_cmd, "_provider_family_aliases", return_value=self.ALIASES
+        ):
+            types = routing_cmd._get_configured_provider_types(settings)
+        assert "openai" in types
+        assert "openai-chatgpt" not in types
+
+    def test_no_aliases_is_byte_identical_to_before(self, tmp_path: Path) -> None:
+        """With an empty table (hook not importable) the set is exactly the old one."""
+        settings = _settings_with_providers(
+            tmp_path,
+            [
+                {"module": "provider-anthropic", "source": "git+x", "id": "opus"},
+                {"module": "provider-openai-chatgpt", "source": "git+x"},
+            ],
+        )
+        with patch.object(routing_cmd, "_provider_family_aliases", return_value={}):
+            types = routing_cmd._get_configured_provider_types(settings)
+        assert types == {"anthropic", "opus", "openai-chatgpt"}
+
+    def test_alias_table_comes_from_the_hook_not_a_copy(self) -> None:
+        """Single source of truth: the CLI reads the resolver's table verbatim.
+
+        If the hook is importable in this environment the two must be equal;
+        if it is not, the CLI must degrade to `{}` rather than raise. Either
+        way there is no second copy of the table in this repo to drift.
+        """
+        try:
+            from amplifier_module_hooks_routing.resolver import PROVIDER_FAMILY_ALIASES
+        except Exception:
+            assert routing_cmd._provider_family_aliases() == {}
+        else:
+            assert routing_cmd._provider_family_aliases() == dict(
+                PROVIDER_FAMILY_ALIASES
+            )
+
+
+# ---------------------------------------------------------------------------
+# 2. "Displayed but not mounted" warning
+# ---------------------------------------------------------------------------
+
+
+class TestNotMountedWarning:
+    def _settings(self, tmp_path: Path, active: str) -> AppSettings:
+        paths = SettingsPaths(
+            global_settings=tmp_path / "global" / "settings.yaml",
+            project_settings=tmp_path / "project" / "settings.yaml",
+            local_settings=tmp_path / "local" / "settings.local.yaml",
+        )
+        paths.global_settings.parent.mkdir(parents=True, exist_ok=True)
+        paths.global_settings.write_text(
+            yaml.safe_dump({"bundle": {"active": active}}), encoding="utf-8"
+        )
+        return AppSettings(paths=paths)
+
+    def test_warns_when_hook_is_not_composed(self, tmp_path: Path, capsys) -> None:
+        settings = self._settings(tmp_path, "anchors-amp-dev")
+        with (
+            patch.object(routing_cmd, "_routing_hook_is_composed", return_value=False),
+            patch.object(routing_cmd.console, "print") as out,
+        ):
+            routing_cmd._print_not_mounted_warning(settings)
+        text = " ".join(str(c.args[0]) for c in out.call_args_list)
+        assert "Not applied in your sessions" in text
+        assert "anchors-amp-dev" in text, (
+            "must name the bundle that is missing the hook"
+        )
+        assert "hooks-routing" in text
+        assert routing_cmd.ROUTING_BEHAVIOR_URI in text, (
+            "must hand the user the exact `bundle add` command, not a description of one"
+        )
+        assert "--app" in text
+
+    def test_silent_when_hook_is_composed(self, tmp_path: Path) -> None:
+        settings = self._settings(tmp_path, "foundation")
+        with (
+            patch.object(routing_cmd, "_routing_hook_is_composed", return_value=True),
+            patch.object(routing_cmd.console, "print") as out,
+        ):
+            routing_cmd._print_not_mounted_warning(settings)
+        out.assert_not_called()
+
+    def test_silent_when_it_cannot_tell(self, tmp_path: Path) -> None:
+        """A diagnostic that cannot run must never turn into a false alarm."""
+        settings = self._settings(tmp_path, "whatever")
+        with (
+            patch.object(routing_cmd, "_routing_hook_is_composed", return_value=None),
+            patch.object(routing_cmd.console, "print") as out,
+        ):
+            routing_cmd._print_not_mounted_warning(settings)
+        out.assert_not_called()
+
+    def test_detection_failure_degrades_to_none_not_an_exception(
+        self, tmp_path: Path
+    ) -> None:
+        """`routing show` must keep working on a host where composition blows up."""
+        settings = self._settings(tmp_path, "anchors-amp-dev")
+        with patch(
+            "amplifier_app_cli.lib.bundle_loader.AppBundleDiscovery",
+            side_effect=RuntimeError("no registry here"),
+        ):
+            assert routing_cmd._routing_hook_is_composed(settings) is None
+
+    def test_behavior_uri_is_the_one_the_bundle_ships(self) -> None:
+        """The remediation must point at the real behaviors file, on main."""
+        uri = routing_cmd.ROUTING_BEHAVIOR_URI
+        assert uri.startswith(
+            "git+https://github.com/microsoft/amplifier-bundle-routing-matrix@main"
+        )
+        assert uri.endswith("#subdirectory=behaviors/routing.yaml")
+
+    def test_no_active_bundle_means_no_composition_and_no_warning(
+        self, tmp_path: Path
+    ) -> None:
+        """No explicit active bundle -> the CLI's built-in default (foundation,
+        which includes routing-matrix). Nothing to warn about, and the
+        composition must not even run -- that is what keeps this diagnostic out
+        of every fixture that never chose a bundle."""
+        paths = SettingsPaths(
+            global_settings=tmp_path / "g.yaml",
+            project_settings=tmp_path / "p.yaml",
+            local_settings=tmp_path / "l.yaml",
+        )
+        settings = AppSettings(paths=paths)
+        assert settings.get_active_bundle() is None
+        with patch(
+            "amplifier_app_cli.lib.bundle_loader.AppBundleDiscovery",
+            side_effect=AssertionError("composition must not run"),
+        ):
+            assert routing_cmd._routing_hook_is_composed(settings) is None


### PR DESCRIPTION
`amplifier routing show` misled two kinds of user. Both found 2026-09-07 while shipping [routing-matrix#71](https://github.com/microsoft/amplifier-bundle-routing-matrix/pull/71); both fixed in `commands/routing.py`.

## 1. The alias-blind user

A ChatGPT-subscription-only user (`openai-chatgpt` module, no `openai` module) is routed fine at runtime — the hook's `PROVIDER_FAMILY_ALIASES` maps `provider: openai` onto that mount. But `_get_configured_provider_types` fed a bare set-membership test that never consulted the alias table, so the display told **exactly that user** "✗ not configured" for every openai role. Measured in a DTU.

**Fix:** `_get_configured_provider_types` also adds every canonical family a configured module *satisfies*, reading the table from `amplifier_module_hooks_routing.resolver.PROVIDER_FAMILY_ALIASES` itself — one home, so the display cannot disagree with the resolver. All four downstream `in provider_types` sites become alias-aware with no change. Guarded import: on a clean install before the bundle is first fetched it degrades to "no aliases" (pre-alias behaviour), never an error. Directional, as in the resolver.

## 2. The hook-less user — the one that actually bit

`routing show` reads matrix files straight from the bundle cache (it even lazy-fetches the bundle), so it renders a matrix as "★ active" on a host whose **active bundle never mounts `hooks-routing`**. Nothing then applies the matrix; every sub-agent silently inherits the parent's provider.

Measured on a project pinned to `anchors-amp-dev` — a lean base that does not include routing-matrix:

```
$ amplifier routing show
  general — …
    ★ openai / gpt-?.?-terra  [reasoning_effort: medium]  ← active   ← says this
```
```
delegate:agent_spawned … "provider_preferences": null              ← does this
llm:request … "model": "claude-opus-5", "provider": "anthropic"     ← explorer ran on the parent's model
```

**Fix:** `_routing_hook_is_composed` composes the session the way `runtime/config.py` does — active bundle + every app bundle, in order — but stops at `to_mount_plan()`: no `prepare()`, no module installs, no network beyond what's cached (~0.1s warm). If `hooks-routing` is absent, `show` prints:

```
⚠ Not applied in your sessions. The active bundle anchors-amp-dev (and your app
bundles) never mount the hooks-routing hook, so this matrix is only displayed
here -- sub-agents will inherit the parent session's provider instead.
  To apply it in every session regardless of active bundle:
    amplifier bundle add git+https://github.com/microsoft/amplifier-bundle-routing-matrix@main#subdirectory=behaviors/routing.yaml --app
```

(command printed with `soft_wrap=True` so Rich can't fold it mid-URI).

**Scope guard:** only runs when an active bundle is *explicitly* set. With none set the CLI starts its built-in default `foundation`, which includes routing-matrix — nothing to warn about, and skipping the composition keeps this out of every code path and test fixture that never chose a bundle. (An earlier draft composed the real `foundation` bundle inside the shadowing tests: 12s per invocation, and its side effects made two runs of `show` disagree. That's why the guard exists.) Any failure inside the check → `None` → prints nothing. A diagnostic must never break the command.

## Verified live on the host that surfaced it

| cwd | active bundle | `routing show` |
|---|---|---|
| the anchors-amp-dev project | `anchors-amp-dev` | **warns**, with the copy-pasteable command |
| `/tmp` | default (`foundation`) | no warning |

## Tests

`tests/test_routing_family_alias_and_mount_warning.py` (10): chatgpt alone makes openai configured · alias is directional · empty table is byte-identical to before · table is read from the hook, never copied · warning names bundle + hook + exact command · silent when composed · silent when it can't tell · detection failure degrades to `None` · no active bundle means no composition · remediation URI is the bundle's real behaviors file.

Full suite **1917 passed**; ruff clean on touched files (the 9 pre-existing findings elsewhere are untouched).