### PR TITLE
routing show: a candidate is active only if its glob resolves against live model lists

### DIFF
--- a/amplifier_app_cli/commands/routing.py
+++ b/amplifier_app_cli/commands/routing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import fnmatch
 import logging
 import re
 from collections.abc import Mapping
@@ -447,18 +448,193 @@ def _check_compatibility(
     return covered, total
 
 
+_GLOB_CHARS = frozenset("*?[")
+
+
+def _is_glob(model: str) -> bool:
+    return any(ch in model for ch in _GLOB_CHARS)
+
+
+def _best_glob_match(pattern: str, models: list[str]) -> str | None:
+    """The model id the routing hook would pick for *pattern* from *models*.
+
+    Reuses the hook's own version-aware sort when importable so the id shown
+    here is the id that actually runs; falls back to a plain reverse sort
+    (the same matcher, minus the date-suffix awareness) when it is not.
+    """
+    lowered = pattern.lower()
+    matched = [m for m in models if fnmatch.fnmatch(m.lower(), lowered)]
+    if not matched:
+        return None
+    try:
+        from amplifier_module_hooks_routing.resolver import _version_sort_key
+
+        return sorted(matched, key=_version_sort_key, reverse=True)[0]
+    except Exception:  # pragma: no cover - import environment dependent
+        return sorted(matched, reverse=True)[0]
+
+
+# Wall-clock cap on ONE provider's live model listing, in seconds.
+#
+# Why a cap and not just "let it fail": a provider with no usable credentials
+# does not fail fast -- provider-anthropic, for one, retries list_models() up
+# to 5 times with backoff (its __init__.py: max_retries=5), which measured at
+# ~35s per provider. `show` is a display command; a user with one dead key
+# must not wait half a minute per role for it. Anything that misses the cap is
+# reported as UNVERIFIED, exactly like a provider that could not be listed at
+# all. Override with AMPLIFIER_ROUTING_LIST_TIMEOUT (seconds) when a slow but
+# healthy backend needs more.
+_LIVE_LIST_TIMEOUT_S = 6.0
+
+
+def _list_models_bounded(selector: str, settings: AppSettings) -> list[str]:
+    """`_list_models_for_provider` with a hard wall-clock cap.
+
+    Runs the listing on a worker thread and abandons it on timeout. The thread
+    is left to finish on its own (``shutdown(wait=False)``) -- for a CLI that
+    is about to exit that is the right trade, and it cannot leak into the
+    process's own event loop because the listing helper builds its own.
+    Returns ``[]`` on timeout, the same "could not list" value the helper
+    itself uses for every other failure.
+    """
+    import concurrent.futures
+    import os
+
+    try:
+        timeout = float(
+            os.environ.get("AMPLIFIER_ROUTING_LIST_TIMEOUT", _LIVE_LIST_TIMEOUT_S)
+        )
+    except ValueError:
+        timeout = _LIVE_LIST_TIMEOUT_S
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        future = pool.submit(_list_models_for_provider, selector, settings)
+        return future.result(timeout=timeout)
+    except concurrent.futures.TimeoutError:
+        logger.debug(
+            "list_models() for %r exceeded %.1fs; treating as unverified",
+            selector,
+            timeout,
+        )
+        return []
+    except Exception:
+        return []
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
+
+
+class _LiveModels:
+    """Memoized live ``list_models()`` per matrix provider name, for `show`.
+
+    WHY `show` NEEDS THIS. "Configured" is a property of the PROVIDER; a
+    candidate's model is a GLOB that must also match something that provider
+    actually lists. `show` used to mark a candidate active on provider presence
+    alone, so it claimed models the session could not serve -- measured
+    2026-09-07 in a DTU with only `gpt-5.6-terra` configured: `fast -> *
+    openai / gpt-?.?-luna <- active`, a model nothing would resolve.
+
+    One ``list_models()`` per DISTINCT matrix provider name, fetched lazily
+    (only for candidates that are actually evaluated) and memoized across
+    roles, so a typical matrix costs a handful of calls, not one per candidate.
+    Alias-aware: a `provider: openai` candidate lists models from whichever
+    openai-family backend is configured, canonical first -- the same
+    preference the resolver applies.
+
+    Honest about what it could not check: a provider whose list could not be
+    fetched (offline, no key, module not installed, empty list) is UNVERIFIED,
+    never "no match". Unverified candidates render exactly as before this
+    class existed, and `show` names them once in a footer.
+    """
+
+    def __init__(self, settings: AppSettings) -> None:
+        self._settings = settings
+        self._cache: dict[str, list[str] | None] = {}
+        self.unverified: set[str] = set()
+
+    def _configured_selector(self, provider: str) -> str | None:
+        """The configured provider (type or instance) a candidate name resolves to.
+
+        Canonical name first, then its family aliases -- mirrors the resolver.
+        Checks against the RAW configured names (module types + instance ids),
+        not the alias-expanded set `_get_configured_provider_types` returns:
+        with only `openai-chatgpt` configured that set contains "openai" too,
+        and listing models from a provider entry that does not exist would
+        silently return [] and mark every openai candidate unverified.
+        """
+        raw: set[str] = set()
+        for p in self._settings.get_provider_overrides():
+            module = str(p.get("module", ""))
+            raw.add(module.removeprefix("provider-"))
+            if p.get("id"):
+                raw.add(str(p["id"]))
+        for name in (provider, *_provider_family_aliases().get(provider, ())):
+            if name in raw:
+                return name
+        return None
+
+    def models_for(self, provider: str) -> list[str] | None:
+        if provider in self._cache:
+            return self._cache[provider]
+        selector = self._configured_selector(provider)
+        models: list[str] | None = None
+        if selector is not None:
+            listed = _list_models_bounded(selector, self._settings)
+            models = listed or None  # [] means "could not list", not "lists nothing"
+        if models is None:
+            self.unverified.add(provider)
+        self._cache[provider] = models
+        return models
+
+    def resolve(self, provider: str, model: str) -> tuple[str, str | None]:
+        """Return ``(status, resolved_id)``.
+
+        status is ``"active"`` (an exact name, or a glob with a live match),
+        ``"no-match"`` (a glob that matches nothing the provider lists), or
+        ``"unverified"`` (the list could not be fetched -- treated as active,
+        exactly as before, and named in the footer).
+        """
+        if not _is_glob(model):
+            # The resolver passes exact names straight to the API without
+            # consulting list_models(); so does this.
+            return "active", model
+        models = self.models_for(provider)
+        if models is None:
+            return "unverified", None
+        best = _best_glob_match(model, models)
+        return ("active", best) if best else ("no-match", None)
+
+    def print_footer(self) -> None:
+        if not self.unverified:
+            return
+        console.print(
+            f"\n[dim]Model lists not fetched for: {', '.join(sorted(self.unverified))} "
+            f"-- their globs are shown as configured but not verified live.[/dim]"
+        )
+
+
 def _resolve_role(
-    role_config: dict[str, Any], provider_types: set[str]
+    role_config: dict[str, Any],
+    provider_types: set[str],
+    live: _LiveModels | None = None,
 ) -> tuple[str | None, str | None]:
     """Resolve a role to its first matching candidate.
 
     Returns (model_pattern, provider_type) or (None, None) if unresolvable.
+    With *live*, a configured candidate whose glob matches no live model is
+    skipped -- the resolver would skip it too -- so the winner shown is the
+    winner the session gets. Without *live* (the compatibility counts in
+    `routing list`, which must stay offline-fast) this is provider-presence
+    only, byte-identical to before.
     """
     candidates = role_config.get("candidates", [])
     for candidate in candidates:
         provider = candidate.get("provider", "")
-        if provider in provider_types:
-            return candidate.get("model", "?"), provider
+        if provider not in provider_types:
+            continue
+        model = candidate.get("model", "?")
+        if live is not None and live.resolve(provider, model)[0] == "no-match":
+            continue
+        return model, provider
     return None, None
 
 
@@ -724,14 +900,42 @@ def _show_matrix_resolution(
     table.add_column("Model", style="green")
     table.add_column("Provider")
 
-    for role_name, role_config in roles.items():
-        model, provider_type = _resolve_role(role_config, provider_types)
-        if model and provider_type:
-            table.add_row(role_name, model, provider_type)
-        else:
-            table.add_row(role_name, "[yellow]⚠ (no provider)[/yellow]", "[dim]-[/dim]")
+    live = _LiveModels(settings)
+    rows: list[tuple[str, str, str]] = []
+    with console.status(
+        "[dim]Checking globs against live model lists...[/dim]", spinner="dots"
+    ):
+        for role_name, role_config in roles.items():
+            model, provider_type = _resolve_role(role_config, provider_types, live)
+            if model and provider_type:
+                status, resolved = live.resolve(provider_type, model)
+                shown = (
+                    f"{model} → {resolved}"
+                    if status == "active" and resolved and resolved != model
+                    else model
+                )
+                rows.append((role_name, shown, provider_type))
+            elif any(
+                c.get("provider", "") in provider_types
+                for c in role_config.get("candidates", [])
+            ):
+                # A provider IS configured; no candidate glob matches what it lists.
+                rows.append(
+                    (
+                        role_name,
+                        "[yellow]⚠ (no matching model)[/yellow]",
+                        "[dim]-[/dim]",
+                    )
+                )
+            else:
+                rows.append(
+                    (role_name, "[yellow]⚠ (no provider)[/yellow]", "[dim]-[/dim]")
+                )
+    for row in rows:
+        table.add_row(*row)
 
     console.print(table)
+    live.print_footer()
 
     # Show provider summary
     if provider_types:
@@ -776,6 +980,7 @@ def _show_matrix_details(
 
     provider_types = _get_configured_provider_types(settings)
     roles = matrix_data.get("roles", {})
+    live = _LiveModels(settings)
 
     for role_name, role_config in roles.items():
         role_desc = role_config.get("description", "")
@@ -786,6 +991,7 @@ def _show_matrix_details(
 
         candidates = role_config.get("candidates", [])
         winner_found = False
+        any_configured = False
 
         for candidate in candidates:
             provider = candidate.get("provider", "")
@@ -800,12 +1006,30 @@ def _show_matrix_details(
                 config_str = f"  [dim]\\[{pairs}][/dim]"
 
             is_configured = provider in provider_types
+            any_configured = any_configured or is_configured
+            status, resolved = (
+                live.resolve(provider, model)
+                if is_configured
+                else ("unconfigured", None)
+            )
 
-            if is_configured and not winner_found:
+            if status == "no-match":
+                # The provider is here; nothing it lists matches this glob. The
+                # resolver would fall through, and so does this display.
+                line = (
+                    f"    [dim]✗ {provider} / {model}[/dim]"
+                    f"{config_str}  [yellow]no model matches this glob[/yellow]"
+                )
+            elif is_configured and not winner_found:
                 winner_found = True
+                tail = (
+                    f" ({resolved})"
+                    if status == "active" and resolved and resolved != model
+                    else ""
+                )
                 line = (
                     f"    [green]★ {provider} / {model}[/green]"
-                    f"{config_str}  [green]← active[/green]"
+                    f"{config_str}  [green]← active{tail}[/green]"
                 )
             elif is_configured:
                 line = f"    [dim]✓ {provider} / {model}[/dim]{config_str}"
@@ -818,9 +1042,17 @@ def _show_matrix_details(
             console.print(line)
 
         if not winner_found:
-            console.print(
-                "    [yellow]⚠ No configured provider can serve this role[/yellow]"
-            )
+            if any_configured:
+                console.print(
+                    "    [yellow]⚠ A provider is configured but none of its models "
+                    "matches any candidate glob[/yellow]"
+                )
+            else:
+                console.print(
+                    "    [yellow]⚠ No configured provider can serve this role[/yellow]"
+                )
+
+    live.print_footer()
 
 
 # ============================================================
@@ -1246,7 +1478,15 @@ def _list_models_for_provider(
             )
         )
         models = get_provider_models(provider_id, collected_config=collected_config)
-        return [str(getattr(m, "name", m)) for m in models]
+        # ModelInfo's identifier is `.id`, not `.name`. This helper had no
+        # caller until `_LiveModels` arrived, so the old `getattr(m, "name",
+        # m)` -- which fell through to str(m) and returned the whole dataclass
+        # repr (`"id='gpt-5.6-terra' display_name=..."`) -- went unnoticed: a
+        # list of reprs matches no glob, and every live-verified candidate
+        # showed "no model matches". Measured on this host, 2026-09-07.
+        return [
+            str(getattr(m, "id", None) or getattr(m, "name", None) or m) for m in models
+        ]
     except Exception:
         return []
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ from amplifier_app_cli.main import CommandProcessor  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
-def no_live_model_listing(monkeypatch):
+def no_live_model_listing():
     """`routing show` verifies candidate globs against live ``list_models()``.
 
     Unit tests must never do that: a fixture provider with no credentials
@@ -46,11 +46,21 @@ def no_live_model_listing(monkeypatch):
 
     Patched at the bounded wrapper, not at ``_list_models_for_provider``, so
     the tests that exercise THAT helper directly still see the real thing.
+
+    Uses a PRIVATE MonkeyPatch, deliberately not the shared ``monkeypatch``
+    fixture. Requesting the shared one from an autouse fixture makes it set
+    up before -- and therefore torn down after -- every test's own fixtures.
+    Tests that ``monkeypatch.chdir()`` into a ``TemporaryDirectory`` then had
+    that directory deleted while it was still the process cwd: fine on
+    Linux/macOS, PermissionError on Windows, deterministically, in
+    tests/lib/mention_loading/test_resolver.py. Measured on CI for #323.
     """
-    monkeypatch.setattr(
-        "amplifier_app_cli.commands.routing._list_models_bounded",
-        lambda _selector, _settings: [],
-    )
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(
+            "amplifier_app_cli.commands.routing._list_models_bounded",
+            lambda _selector, _settings: [],
+        )
+        yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,27 @@ from amplifier_app_cli.main import CommandProcessor  # noqa: E402
 
 
 @pytest.fixture(autouse=True)
+def no_live_model_listing(monkeypatch):
+    """`routing show` verifies candidate globs against live ``list_models()``.
+
+    Unit tests must never do that: a fixture provider with no credentials
+    retries for ~35s before failing (measured: the routing test files went
+    from 3s to 578s), and the result would depend on the network anyway. The
+    default here is "could not list" -- every glob renders as unverified,
+    which is byte-identical to the pre-verification output. Tests that
+    exercise verification itself patch ``_list_models_bounded`` with an
+    explicit table on top of this (tests/test_routing_show_verifies_globs.py).
+
+    Patched at the bounded wrapper, not at ``_list_models_for_provider``, so
+    the tests that exercise THAT helper directly still see the real thing.
+    """
+    monkeypatch.setattr(
+        "amplifier_app_cli.commands.routing._list_models_bounded",
+        lambda _selector, _settings: [],
+    )
+
+
+@pytest.fixture(autouse=True)
 def reset_skill_shortcuts():
     """Clear SKILL_SHORTCUTS before and after every test in this suite."""
     CommandProcessor.SKILL_SHORTCUTS.clear()

--- a/tests/test_routing_show_verifies_globs.py
+++ b/tests/test_routing_show_verifies_globs.py
@@ -1,0 +1,282 @@
+"""`routing show` must not call a candidate "active" unless its glob resolves.
+
+"Configured" is a property of the PROVIDER; a candidate's model is a GLOB that
+must ALSO match something that provider actually lists. `show` used to mark a
+candidate active on provider presence alone, so it claimed models the session
+could not serve. Measured 2026-09-07 in a DTU with only `gpt-5.6-terra`
+configured on the openai provider:
+
+    fast -> * openai / gpt-?.?-luna  <- active      # nothing would resolve this
+
+The `_LiveModels` helper closes that: one memoized `list_models()` per matrix
+provider name, alias-aware, and honest about what it could not fetch -- an
+unlistable provider is UNVERIFIED (rendered exactly as before, named once in a
+footer), never "no match".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import yaml
+
+from amplifier_app_cli.commands import routing as r
+from amplifier_app_cli.lib.settings import AppSettings, SettingsPaths
+
+
+def _settings(tmp_path: Path, providers: list[dict]) -> AppSettings:
+    paths = SettingsPaths(
+        global_settings=tmp_path / "g" / "settings.yaml",
+        project_settings=tmp_path / "p" / "settings.yaml",
+        local_settings=tmp_path / "l" / "settings.local.yaml",
+    )
+    paths.global_settings.parent.mkdir(parents=True, exist_ok=True)
+    paths.global_settings.write_text(
+        yaml.safe_dump({"config": {"providers": providers}}), encoding="utf-8"
+    )
+    return AppSettings(paths=paths)
+
+
+OPENAI_ONLY = [{"module": "provider-openai", "source": "git+x"}]
+CHATGPT_ONLY = [{"module": "provider-openai-chatgpt", "source": "git+x"}]
+ALIASES = {"openai": ("openai-chatgpt",)}
+
+
+def _listing(table: dict[str, list[str]]):
+    """Patch the live model listing with a fixed provider-selector -> models table.
+
+    Patched at ``_list_models_bounded`` -- the seam ``_LiveModels`` calls and
+    the one the conftest autouse guard stubs -- so these tests override that
+    guard rather than being defeated by it.
+    """
+    return patch.object(
+        r, "_list_models_bounded", side_effect=lambda sel, _s: table.get(sel, [])
+    )
+
+
+# ---------------------------------------------------------------------------
+# _LiveModels.resolve
+# ---------------------------------------------------------------------------
+
+
+class TestResolve:
+    def test_glob_with_a_live_match_is_active_and_names_the_id(self, tmp_path):
+        s = _settings(tmp_path, OPENAI_ONLY)
+        with _listing({"openai": ["gpt-5.6-terra", "gpt-5.5"]}):
+            assert r._LiveModels(s).resolve("openai", "gpt-?.?-terra") == (
+                "active",
+                "gpt-5.6-terra",
+            )
+
+    def test_glob_matching_nothing_listed_is_no_match(self, tmp_path):
+        """The DTU case: provider present, luna not among its models."""
+        s = _settings(tmp_path, OPENAI_ONLY)
+        with _listing({"openai": ["gpt-5.6-terra"]}):
+            assert r._LiveModels(s).resolve("openai", "gpt-?.?-luna") == (
+                "no-match",
+                None,
+            )
+
+    def test_exact_name_is_active_without_a_lookup(self, tmp_path):
+        """The resolver sends exact names straight to the API; so does this."""
+        s = _settings(tmp_path, OPENAI_ONLY)
+        with _listing({}) as listing:
+            assert r._LiveModels(s).resolve("openai", "gpt-5.6-terra") == (
+                "active",
+                "gpt-5.6-terra",
+            )
+            listing.assert_not_called()
+
+    def test_unlistable_provider_is_unverified_never_no_match(self, tmp_path):
+        """Offline / no key / module absent -> [] -> UNVERIFIED, and named."""
+        s = _settings(tmp_path, OPENAI_ONLY)
+        with _listing({"openai": []}):
+            live = r._LiveModels(s)
+            assert live.resolve("openai", "gpt-?.?-luna") == ("unverified", None)
+            assert live.unverified == {"openai"}
+
+    def test_unconfigured_provider_is_unverified_and_not_listed(self, tmp_path):
+        s = _settings(tmp_path, OPENAI_ONLY)
+        with _listing({}) as listing:
+            live = r._LiveModels(s)
+            assert live.resolve("gemini", "gemini-[3-9]*-flash")[0] == "unverified"
+            listing.assert_not_called()
+
+    def test_picks_the_same_id_the_hook_would(self, tmp_path):
+        """Newest version wins; a `-fast` sibling must NOT beat the clean id for a
+        suffix-free glob -- the exact trap the shipped globs were shaped around."""
+        s = _settings(tmp_path, OPENAI_ONLY)
+        with _listing({"openai": ["gpt-5.5", "gpt-5.6-terra", "gpt-5.6-terra-fast"]}):
+            assert (
+                r._LiveModels(s).resolve("openai", "gpt-?.?-terra")[1]
+                == "gpt-5.6-terra"
+            )
+
+
+# ---------------------------------------------------------------------------
+# memoization and aliasing
+# ---------------------------------------------------------------------------
+
+
+class TestListingBehaviour:
+    def test_one_list_models_call_per_provider_across_roles(self, tmp_path):
+        s = _settings(tmp_path, OPENAI_ONLY)
+        with _listing({"openai": ["gpt-5.6-terra", "gpt-5.6-luna"]}) as listing:
+            live = r._LiveModels(s)
+            for glob in (
+                "gpt-?.?-terra",
+                "gpt-?.?-luna",
+                "gpt-?.?-terra",
+                "gpt-?.?-sol",
+            ):
+                live.resolve("openai", glob)
+            assert listing.call_count == 1
+
+    def test_alias_lists_models_from_the_configured_backend(self, tmp_path):
+        """`provider: openai` with ONLY openai-chatgpt configured lists chatgpt's
+        models -- the same preference the resolver applies."""
+        s = _settings(tmp_path, CHATGPT_ONLY)
+        with (
+            patch.object(r, "_provider_family_aliases", return_value=ALIASES),
+            _listing(
+                {"openai-chatgpt": ["gpt-5.6-terra", "gpt-5.6-terra-fast"]}
+            ) as listing,
+        ):
+            assert r._LiveModels(s).resolve("openai", "gpt-?.?-terra") == (
+                "active",
+                "gpt-5.6-terra",
+            )
+            assert listing.call_args.args[0] == "openai-chatgpt"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_role with live verification
+# ---------------------------------------------------------------------------
+
+
+ROLE = {
+    "candidates": [
+        {"provider": "openai", "model": "gpt-?.?-luna"},
+        {"provider": "anthropic", "model": "claude-haiku-*"},
+    ]
+}
+
+
+class TestResolveRole:
+    def test_falls_through_a_no_match_candidate_like_the_resolver(self, tmp_path):
+        s = _settings(
+            tmp_path,
+            OPENAI_ONLY + [{"module": "provider-anthropic", "source": "git+x"}],
+        )
+        with _listing({"openai": ["gpt-5.6-terra"], "anthropic": ["claude-haiku-4-5"]}):
+            assert r._resolve_role(ROLE, {"openai", "anthropic"}, r._LiveModels(s)) == (
+                "claude-haiku-*",
+                "anthropic",
+            )
+
+    def test_without_live_is_provider_presence_only_as_before(self):
+        """`routing list`'s compatibility counts stay offline-fast and unchanged."""
+        assert r._resolve_role(ROLE, {"openai", "anthropic"}) == (
+            "gpt-?.?-luna",
+            "openai",
+        )
+
+    def test_all_configured_candidates_no_match_yields_none(self, tmp_path):
+        s = _settings(tmp_path, OPENAI_ONLY)
+        with _listing({"openai": ["gpt-5.6-terra"]}):
+            assert r._resolve_role(ROLE, {"openai"}, r._LiveModels(s)) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# rendering
+# ---------------------------------------------------------------------------
+
+
+MATRIX = {
+    "name": "t",
+    "roles": {
+        "fast": {
+            "description": "quick",
+            "candidates": [
+                {"provider": "openai", "model": "gpt-?.?-luna"},
+                {"provider": "openai", "model": "gpt-?.?-terra"},
+            ],
+        }
+    },
+}
+
+
+class TestRendering:
+    def _capture(self):
+        return patch.object(r.console, "print")
+
+    def test_details_marks_no_match_and_promotes_the_next_candidate(self, tmp_path):
+        s = _settings(tmp_path, OPENAI_ONLY)
+        with _listing({"openai": ["gpt-5.6-terra"]}), self._capture() as out:
+            r._show_matrix_details(MATRIX, s, "t")
+        text = "\n".join(str(c.args[0]) for c in out.call_args_list if c.args)
+        assert "gpt-?.?-luna" in text and "no model matches this glob" in text
+        assert "gpt-?.?-terra" in text and "\u2190 active (gpt-5.6-terra)" in text
+        assert "Model lists not fetched" not in text
+
+    def test_details_unverified_renders_as_before_plus_footer(self, tmp_path):
+        s = _settings(tmp_path, OPENAI_ONLY)
+        with _listing({"openai": []}), self._capture() as out:
+            r._show_matrix_details(MATRIX, s, "t")
+        text = "\n".join(str(c.args[0]) for c in out.call_args_list if c.args)
+        assert "\u2605 openai / gpt-?.?-luna" in text and "\u2190 active" in text
+        assert "no model matches" not in text
+        assert "Model lists not fetched for: openai" in text
+
+    def test_resolution_table_shows_the_resolved_id(self, tmp_path):
+        s = _settings(tmp_path, OPENAI_ONLY)
+        with _listing({"openai": ["gpt-5.6-terra"]}), self._capture() as out:
+            r._show_matrix_resolution(MATRIX, s, "t")
+        tables = [
+            c.args[0]
+            for c in out.call_args_list
+            if c.args and hasattr(c.args[0], "columns")
+        ]
+        assert tables, "no Rich table printed"
+        cells = [str(cell) for col in tables[0].columns for cell in col._cells]
+        assert any("gpt-?.?-terra \u2192 gpt-5.6-terra" in c for c in cells), cells
+
+
+# ---------------------------------------------------------------------------
+# the helper that feeds all of this
+# ---------------------------------------------------------------------------
+
+
+def test_list_models_for_provider_returns_model_ids_not_reprs(tmp_path):
+    """ModelInfo carries `.id`; the old `getattr(m, "name", m)` fell through to
+    the dataclass repr, so every live-verified candidate read "no model
+    matches". Dead code until `_LiveModels` called it -- now load-bearing."""
+    from amplifier_core import ModelInfo
+
+    s = _settings(tmp_path, OPENAI_ONLY)
+    infos = [
+        ModelInfo(
+            id="gpt-5.6-terra",
+            display_name="GPT 5.6 Terra",
+            context_window=272000,
+            max_output_tokens=128000,
+        ),
+        ModelInfo(
+            id="gpt-5.6-luna",
+            display_name="GPT 5.6 Luna",
+            context_window=272000,
+            max_output_tokens=128000,
+        ),
+    ]
+    with (
+        patch(
+            "amplifier_app_cli.provider_loader.get_provider_models", return_value=infos
+        ),
+        patch.object(r, "_resolve_provider_module", return_value="provider-openai"),
+        patch.object(r, "_get_provider_config", return_value={}),
+    ):
+        assert r._list_models_for_provider("openai", s) == [
+            "gpt-5.6-terra",
+            "gpt-5.6-luna",
+        ]


### PR DESCRIPTION
Follow-up to #322 — the last "UX lies" case the DTU surfaced.

## The bug

"Configured" is a property of the **provider**; a candidate's model is a **glob** that must *also* match something that provider actually lists. `show` marked a candidate active on provider presence alone. Measured in a DTU with only `gpt-5.6-terra` on openai:

```
fast → ★ openai / gpt-?.?-luna  ← active      # nothing would resolve this
```

## The fix

`_LiveModels` — one memoized `list_models()` per **distinct** matrix provider name, fetched lazily (only for candidates actually evaluated) and shared across roles. Alias-aware: `provider: openai` lists from whichever openai-family backend is configured, canonical first. The resolved id is shown so you see what will actually run:

```
fast → ★ openai / gpt-?.?-luna  [reasoning_effort: medium]  ← active (gpt-5.6-luna)
```

chosen with the hook's own version-aware sort when importable, so display and runtime agree.

**Honest about what it can't check.** A provider whose list can't be fetched (offline, no key, module absent, empty) is **unverified** — never "no match" — renders exactly as before, and is named once in a footer. A glob that matches nothing a *listed* provider returns is `✗ … no model matches this glob` and the display falls through to the next candidate, as the resolver would. `routing list`'s compatibility counts don't pass `live` and stay offline-fast, byte-identical.

## Two things found making it real on this host

**1. Wall-clock cap.** A provider with no usable credentials doesn't fail fast — `provider-anthropic` retries `list_models()` 5× with backoff, measured ~35s. `_list_models_bounded` runs each listing on a worker thread with a **6s cap** (`AMPLIFIER_ROUTING_LIST_TIMEOUT` overrides); a miss is unverified. Without this the routing test files went from 3s → 578s, and a user with one dead key would wait half a minute per role.

**2. `_list_models_for_provider` returned reprs, not ids.** `ModelInfo` carries `.id`; the helper read `getattr(m, "name", m)`, fell through to `str(m)`, and returned `"id='gpt-5.6-terra' display_name=…"` — a list that matches no glob. It had **no caller** until now, so it went unnoticed; the first live run said "no model matches" for every openai/anthropic/gemini candidate on a host where all three resolve. Fixed to read `.id`.

`tests/conftest.py` gains an autouse guard stubbing `_list_models_bounded` to "could not list" — unit tests must never list live, and the stub makes every glob unverified = the pre-change output. Verification tests patch the same seam with an explicit table.

## Verified live on this host (15 provider instances)

Every openai glob resolves to its terra/luna id, gemini resolves, whole detailed view **2.7s**.

## Tests

`tests/test_routing_show_verifies_globs.py` (15): live match is active with the id · nothing-listed is no-match · exact names skip the lookup · unlistable is unverified and named · unconfigured never lists · picks the same id the hook would (suffix-free glob doesn't fall for `-fast`) · one call per provider across roles · alias lists from the configured backend · `_resolve_role` falls through a no-match like the resolver / unchanged without `live` / None when nothing matches · details marks no-match and promotes the next · unverified renders as before + footer · table shows the resolved id · helper returns ids not reprs.

Full suite **1932 passed in 19s**; ruff clean on touched files.