### PR TITLE
fix: refuse to run when the Python environment belongs to another AMPLIFIER_HOME

### DIFF
--- a/amplifier_app_cli/lib/venv_home_guard.py
+++ b/amplifier_app_cli/lib/venv_home_guard.py
@@ -1,0 +1,341 @@
+"""Guard against one Python environment being shared by two ``AMPLIFIER_HOME``s.
+
+``AMPLIFIER_HOME`` isolates config, cache, registry and sessions. It does **not**
+isolate the Python environment Amplifier is installed into. Modules and bundles
+are installed *editable* (``uv pip install -e <cache path> --python
+sys.executable``), so every editable ``.pth`` file in that environment points
+into ``<AMPLIFIER_HOME>/cache/...``. Point ``AMPLIFIER_HOME`` somewhere else and
+run again, and those pointers are silently rewritten to the new home's cache --
+leaving the first home's install importing code from a directory it does not own.
+
+That is not hypothetical. On 2026-09-07 a batch of automated lanes ran
+``AMPLIFIER_HOME=/tmp/hd-*-scratch-* amplifier ...`` on a host that already had a
+real install. 61 of 63 ``_editable_impl_*.pth`` files in the owner's uv tool venv
+were repointed at ``/tmp/hd-android-scratch-before-bfKCxP/...`` and
+``/tmp/hd-stock-fbf8ce6/...``. Nothing warned. The install had to be repaired by
+hand from a backup.
+
+This module detects that collision *before* anything is installed, from the one
+piece of evidence that cannot lie: the ``.pth`` files already on disk.
+
+Everything here is pure functions over paths plus one enforcement entry point;
+the CLI layer only prints and exits.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sysconfig
+from dataclasses import dataclass
+from pathlib import Path
+
+# Environment variable that lets a caller proceed anyway. Named in every
+# refusal message -- a guard with no documented way past it gets worked around
+# with something worse.
+OVERRIDE_ENV = "AMPLIFIER_ALLOW_SHARED_VENV"
+
+# Subcommands that must keep working even while the guard is tripped: they are
+# how a user diagnoses or repairs the collision. Blocking `reset` in particular
+# would make the recommended repair unreachable.
+EXEMPT_COMMANDS = frozenset({"version", "reset"})
+
+# Flags that never start a session and never install anything.
+EXEMPT_FLAGS = frozenset({"--help", "-h", "--version"})
+
+# Foundation's cache lays modules out as `<home>/cache/<repo-name>-<16 hex>`.
+# The hash suffix is what distinguishes an Amplifier cache entry from an
+# arbitrary directory that merely happens to sit under something called
+# "cache", so a dev checkout installed editable is never mistaken for one.
+_CACHE_ENTRY_SUFFIX = re.compile(r"-[0-9a-f]{16}$")
+
+_CACHE_DIR_NAME = "cache"
+
+
+@dataclass(frozen=True)
+class EditableEntry:
+    """One editable ``.pth`` file in the environment, and the home that owns it."""
+
+    pth: Path
+    target: Path
+    home: Path
+
+
+@dataclass(frozen=True)
+class HomeConflict:
+    """The environment's editable installs are owned by a different home."""
+
+    site_packages: Path
+    current_home: Path
+    foreign: tuple[EditableEntry, ...]
+    owned: tuple[EditableEntry, ...]
+
+    @property
+    def foreign_homes(self) -> tuple[Path, ...]:
+        """Distinct foreign homes, most-claimed first."""
+        counts: dict[Path, int] = {}
+        for entry in self.foreign:
+            counts[entry.home] = counts.get(entry.home, 0) + 1
+        return tuple(sorted(counts, key=lambda h: (-counts[h], str(h))))
+
+    @property
+    def total(self) -> int:
+        return len(self.foreign) + len(self.owned)
+
+
+class SharedVenvHomeError(RuntimeError):
+    """Raised when running would repoint another home's editable installs."""
+
+    def __init__(self, conflict: HomeConflict):
+        self.conflict = conflict
+        super().__init__(format_conflict(conflict))
+
+
+def site_packages_dir() -> Path:
+    """The ``site-packages`` directory of the interpreter running Amplifier.
+
+    This is the directory ``uv pip install -e --python sys.executable`` writes
+    ``.pth`` files into -- the shared resource ``AMPLIFIER_HOME`` fails to
+    isolate.
+    """
+    return Path(sysconfig.get_paths()["purelib"])
+
+
+def home_for_target(target: Path) -> Path | None:
+    """Return the Amplifier home owning ``target``, or None if it owns none.
+
+    ``<home>/cache/<repo>-<16 hex>[/subpath]`` -> ``<home>``. Anything else --
+    a dev checkout, a site-packages copy, a path with no cache segment -- is
+    not claimed by any home and returns None.
+    """
+    parts = target.parts
+    for index, part in enumerate(parts[:-1]):
+        # index 0 would make the home an empty path; a real home always has at
+        # least a root component before `cache/`.
+        if index == 0 or part != _CACHE_DIR_NAME:
+            continue
+        if _CACHE_ENTRY_SUFFIX.search(parts[index + 1]):
+            return Path(*parts[:index])
+    return None
+
+
+def _targets_in_pth(pth: Path) -> list[Path]:
+    """Absolute directory targets declared by a ``.pth`` file.
+
+    Only path lines are read. A line beginning with ``import`` is executable
+    setuptools finder glue whose mapping lives in a separate module; it is
+    skipped rather than half-parsed. uv -- which writes every ``.pth`` involved
+    in the incident this module exists to prevent -- uses the path form.
+    """
+    try:
+        text = pth.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+
+    targets: list[Path] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or line.startswith("import "):
+            continue
+        candidate = Path(line)
+        if candidate.is_absolute():
+            targets.append(candidate)
+    return targets
+
+
+def read_editable_entries(site_packages: Path) -> list[EditableEntry]:
+    """Every ``.pth`` entry in ``site_packages`` that an Amplifier home owns."""
+    try:
+        pth_files = sorted(site_packages.glob("*.pth"))
+    except OSError:
+        return []
+
+    entries: list[EditableEntry] = []
+    for pth in pth_files:
+        for target in _targets_in_pth(pth):
+            home = home_for_target(target)
+            if home is not None:
+                entries.append(EditableEntry(pth=pth, target=target, home=home))
+    return entries
+
+
+def _normalize(path: Path) -> Path:
+    """Resolve without requiring existence -- a foreign home is often deleted."""
+    try:
+        return path.resolve()
+    except OSError:  # pragma: no cover - defensive; resolve() is non-strict
+        return path
+
+
+def detect_home_conflict(
+    current_home: Path | None = None,
+    site_packages: Path | None = None,
+) -> HomeConflict | None:
+    """Detect that this environment's editable installs belong to another home.
+
+    Args:
+        current_home: The home in effect. Defaults to the resolved
+            ``AMPLIFIER_HOME``.
+        site_packages: Environment to inspect. Defaults to the running
+            interpreter's.
+
+    Returns:
+        A ``HomeConflict`` when at least one editable install is owned by a
+        different home, else None. A fresh environment (no Amplifier-owned
+        editable installs at all) is never a conflict.
+    """
+    if current_home is None:
+        from amplifier_foundation.paths.resolution import get_amplifier_home
+
+        current_home = get_amplifier_home()
+    if site_packages is None:
+        site_packages = site_packages_dir()
+
+    current = _normalize(current_home)
+    owned: list[EditableEntry] = []
+    foreign: list[EditableEntry] = []
+    for entry in read_editable_entries(site_packages):
+        if _normalize(entry.home) == current:
+            owned.append(entry)
+        else:
+            foreign.append(entry)
+
+    if not foreign:
+        return None
+
+    return HomeConflict(
+        site_packages=site_packages,
+        current_home=current,
+        foreign=tuple(foreign),
+        owned=tuple(owned),
+    )
+
+
+def format_conflict(conflict: HomeConflict, *, override_active: bool = False) -> str:
+    """Render a conflict as a message that names the cause and the remedy."""
+    homes = conflict.foreign_homes
+    claimed_by = "\n".join(
+        f"      {home}"
+        f"  ({sum(1 for e in conflict.foreign if e.home == home)} editable install(s)"
+        f"{'' if home.exists() else ', directory no longer exists'})"
+        for home in homes
+    )
+    samples = "\n".join(
+        f"      {entry.pth.name} -> {entry.target}" for entry in conflict.foreign[:5]
+    )
+    more = len(conflict.foreign) - 5
+    if more > 0:
+        samples += f"\n      ... and {more} more"
+
+    headline = (
+        "AMPLIFIER_HOME changed, but the Python environment did not."
+        if override_active
+        else "Refusing to run: this Python environment belongs to a different AMPLIFIER_HOME."
+    )
+
+    return f"""{headline}
+
+  AMPLIFIER_HOME now:  {conflict.current_home}
+  claimed by:
+{claimed_by}
+  environment:         {conflict.site_packages}
+  editable installs:   {len(conflict.foreign)} foreign of {conflict.total} total
+
+{samples}
+
+AMPLIFIER_HOME isolates config, cache, registry and sessions. It does NOT isolate
+this Python environment. Modules are installed editable into it, so continuing
+here silently rewrites the pointers above to {conflict.current_home}'s cache and
+leaves the other home importing code it does not own. That is how 61 of 63
+_editable_impl_*.pth files in a real install were repointed at
+/tmp/hd-android-scratch-before-bfKCxP and /tmp/hd-stock-fbf8ce6 on 2026-09-07.
+
+Pick one:
+
+  1. Give this home its own environment (do this for scratch, CI and eval homes):
+       UV_TOOL_DIR={conflict.current_home}/uv-tools \\
+       UV_TOOL_BIN_DIR={conflict.current_home}/bin \\
+       uv tool install git+https://github.com/microsoft/amplifier
+       AMPLIFIER_HOME={conflict.current_home} {conflict.current_home}/bin/amplifier ...
+
+  2. Go back to the home this environment already belongs to:
+       AMPLIFIER_HOME={homes[0]} amplifier ...
+
+  3. Hand this environment over to {conflict.current_home} on purpose
+     (this rewrites the pointers above -- the other home stops working):
+       {OVERRIDE_ENV}=1 amplifier ...
+     To repoint everything cleanly instead of module by module:
+       {OVERRIDE_ENV}=1 amplifier reset --remove cache -y
+"""
+
+
+def is_exempt(argv: list[str] | None) -> bool:
+    """True when the invocation is a diagnostic or repair path.
+
+    ``amplifier version``, ``amplifier reset``, ``--help`` and ``--version``
+    install nothing and are how a tripped guard gets diagnosed and cleared.
+    """
+    if not argv:
+        return False
+    for arg in argv:
+        if arg in EXEMPT_FLAGS:
+            return True
+    for arg in argv:
+        if arg.startswith("-"):
+            continue
+        return arg in EXEMPT_COMMANDS
+    return False
+
+
+def enforce_home_ownership(
+    argv: list[str] | None = None,
+    *,
+    current_home: Path | None = None,
+    site_packages: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> HomeConflict | None:
+    """Refuse to continue when this environment belongs to another home.
+
+    Args:
+        argv: Arguments after the program name. Exempt invocations skip the check.
+        current_home: Override the home in effect (tests).
+        site_packages: Override the environment inspected (tests).
+        env: Override the environment variables consulted (tests).
+
+    Returns:
+        None when there is nothing to report, or the ``HomeConflict`` when the
+        override is set (caller should warn and continue).
+
+    Raises:
+        SharedVenvHomeError: A conflict exists and the override is not set.
+    """
+    if is_exempt(argv):
+        return None
+
+    environ = os.environ if env is None else env
+    conflict = detect_home_conflict(
+        current_home=current_home, site_packages=site_packages
+    )
+    if conflict is None:
+        return None
+
+    if environ.get(OVERRIDE_ENV, "").strip().lower() in {"1", "true", "yes", "on"}:
+        return conflict
+
+    raise SharedVenvHomeError(conflict)
+
+
+__all__ = [
+    "EXEMPT_COMMANDS",
+    "OVERRIDE_ENV",
+    "EditableEntry",
+    "HomeConflict",
+    "SharedVenvHomeError",
+    "detect_home_conflict",
+    "enforce_home_ownership",
+    "format_conflict",
+    "home_for_target",
+    "is_exempt",
+    "read_editable_entries",
+    "site_packages_dir",
+]

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -4541,7 +4541,11 @@ def _guard_shared_venv_home() -> None:
     try:
         conflict = enforce_home_ownership(sys.argv[1:])
     except SharedVenvHomeError as e:
-        console.print(f"[red]{escape_markup(str(e))}[/red]")
+        # soft_wrap: the message is nothing but paths and commands the user has
+        # to copy. Rich's default wrapping breaks a long path across lines and
+        # makes it uncopyable -- which is how a guard that names the fix stops
+        # naming the fix.
+        console.print(f"[red]{escape_markup(str(e))}[/red]", soft_wrap=True)
         sys.exit(1)
     except Exception as e:  # pragma: no cover - the guard must never be fatal
         logger.debug(f"venv home guard skipped: {e}")
@@ -4549,7 +4553,8 @@ def _guard_shared_venv_home() -> None:
 
     if conflict is not None:
         console.print(
-            f"[yellow]{escape_markup(format_conflict(conflict, override_active=True))}[/yellow]"
+            f"[yellow]{escape_markup(format_conflict(conflict, override_active=True))}[/yellow]",
+            soft_wrap=True,
         )
 
 

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -4526,10 +4526,38 @@ register_session_commands(
 )
 
 
+def _guard_shared_venv_home() -> None:
+    """Refuse to run when this environment belongs to a different AMPLIFIER_HOME.
+
+    Thin CLI wrapper: all of the behavior lives in ``lib.venv_home_guard``.
+    It runs here, before ``cli()``, because it must fire ahead of *every*
+    editable install -- this package's own provider installs AND foundation's
+    ModuleActivator -- not just the ones this repo owns.
+    """
+    from .lib.venv_home_guard import SharedVenvHomeError
+    from .lib.venv_home_guard import enforce_home_ownership
+    from .lib.venv_home_guard import format_conflict
+
+    try:
+        conflict = enforce_home_ownership(sys.argv[1:])
+    except SharedVenvHomeError as e:
+        console.print(f"[red]{escape_markup(str(e))}[/red]")
+        sys.exit(1)
+    except Exception as e:  # pragma: no cover - the guard must never be fatal
+        logger.debug(f"venv home guard skipped: {e}")
+        return
+
+    if conflict is not None:
+        console.print(
+            f"[yellow]{escape_markup(format_conflict(conflict, override_active=True))}[/yellow]"
+        )
+
+
 def main():
     """Main entry point."""
     _ensure_utf8_output()
     _attach_llm_error_filter()
+    _guard_shared_venv_home()
     cli()
 
 

--- a/docs/lanes/q99f-amplifier-home-pth-bug/FINDINGS.md
+++ b/docs/lanes/q99f-amplifier-home-pth-bug/FINDINGS.md
@@ -1,0 +1,184 @@
+# q99f — `AMPLIFIER_HOME` does not isolate the Python environment
+
+Work item: `model_performance-q99f`. Spend authority: **$0**. No paid API
+measurement was taken; the one DTU is infrastructure and was registered and torn
+down per the lane's infra-ledger rules.
+
+---
+
+## 1. The incident this lane exists for (verbatim from the item)
+
+> **INCIDENT 2026-09-07:** `hd-*` head-census lanes ran `amplifier` with
+> `AMPLIFIER_HOME=/tmp/hd-*-scratch-*` on the HOST to render a tool/skill surface
+> for a before/after byte count. Amplifier's first-run editable-install logic
+> writes into the SHARED uv tool venv
+> (`~/.local/share/uv/tools/amplifier/lib/python3.13/site-packages/*.pth`)
+> regardless of `AMPLIFIER_HOME` — the env var does NOT isolate the venv, only
+> the config/cache/session directories. Result: **61 of 63 `_editable_impl_*.pth`
+> files in the owner's real install were silently rewritten** to point at
+> `/tmp/hd-android-scratch-before-bfKCxP/...` and `/tmp/hd-stock-fbf8ce6/...`.
+> The owner's CLI then printed something to the effect of *"the two disagree
+> about whose code runs"* — a real, user-visible symptom of a completely
+> different root cause (the shared venv, not a version mismatch). Repaired by
+> hand from a backup at `~/dev/_backups/pth-backup-20260907-1512`.
+
+---
+
+## 2. Mechanism, in one paragraph
+
+`AMPLIFIER_HOME` selects the **cache root** (`<home>/cache/<repo>-<16 hex>/…`).
+Modules and bundles are installed **editable** into the interpreter running
+Amplifier — `uv pip install -e <cache path> --python sys.executable`
+(`amplifier_app_cli/provider_sources.py:425` for providers; foundation's
+`ModuleActivator` for everything else). `sys.executable` is the **uv tool venv**,
+which is one per machine and completely outside `AMPLIFIER_HOME`'s reach. So every
+`.pth` file in that venv encodes *one* home's cache root, and the next run under a
+different home overwrites them.
+
+---
+
+## 3. Reproduction (DTU `q99f-pth-repro`, ubuntu 24.04, amplifier 2026.09.07-10af274 / core 1.6.1)
+
+Scripts: [`repro.sh`](repro.sh) (runs A/B), [`repro-flip.sh`](repro-flip.sh) (forces the rewrite), [`verify-fix.sh`](verify-fix.sh), [`verify-remedy1.sh`](verify-remedy1.sh), [`patch_installed.py`](patch_installed.py). Profile:
+[`q99f-pth-repro.dtu.yaml`](q99f-pth-repro.dtu.yaml). No API key —
+each run reaches the provider and fails auth *after* module activation, which is
+the part under test.
+
+### 3.1 Two homes, one venv — measured
+
+| step | `.pth` total | → `home-a/cache` | → `home-b/cache` |
+|---|---:|---:|---:|
+| fresh install | 1 | 0 | 0 |
+| after run A (`AMPLIFIER_HOME=/root/home-a`) | 37 | 36 | 0 |
+| after run B (`AMPLIFIER_HOME=/root/home-b`) | 37 | 36 | 0 |
+| after run B again | 37 | 36 | 0 |
+| after `rm -rf /root/home-a/cache`, then run B | 37 | **27** | **9** |
+
+**Two distinct failures, both silent, both present in one environment:**
+
+1. **The disagreement.** Run B populated `/root/home-b/cache` and imported
+   modules from it, while the venv's `.pth` files still pointed at
+   `/root/home-a/cache`. The only signal the user got was one module's own
+   self-check, verbatim from `/tmp/run-b.log`:
+
+   > `tool-recipes engine: editable install
+   > /root/.local/share/uv/tools/amplifier/lib/python3.12/site-packages/_editable_impl_amplifier_module_tool_recipes.pth
+   > points at /root/home-a/cache/amplifier-bundle-recipes-2b1e350432fea9ba/modules/tool-recipes,
+   > but this engine was imported from /root/home-b/cache/…
+   > — the two disagree about whose code runs.`
+
+   That is the incident's reported symptom, reproduced.
+
+2. **The rewrite.** Once home-a's cache was gone — exactly what happens when a
+   scratch home under `/tmp` is cleaned — the modules stopped being importable,
+   the install path ran, and **9 `_editable_impl_*.pth` files flipped from
+   `/root/home-a/cache/…` to `/root/home-b/cache/…` with no warning of any
+   kind.** All nine are provider modules, i.e. installed by *this repo's*
+   `install_known_providers()`:
+
+   ```
+   _editable_impl_amplifier_module_provider_anthropic.pth
+   _editable_impl_amplifier_module_provider_azure_openai.pth
+   _editable_impl_amplifier_module_provider_chat_completions.pth
+   _editable_impl_amplifier_module_provider_gemini.pth
+   _editable_impl_amplifier_module_provider_github_copilot.pth
+   _editable_impl_amplifier_module_provider_ollama.pth
+   _editable_impl_amplifier_module_provider_openai.pth
+   _editable_impl_amplifier_module_provider_openai_chatgpt.pth
+   _editable_impl_amplifier_module_provider_vllm.pth
+   ```
+
+**Honest scope note.** The flip needed a second condition (the first home's cache
+gone) that the host incident supplied naturally and a same-session A/B does not.
+The *shared, unisolated venv* is the defect; whether a given run rewrites or
+merely disagrees depends on whether the already-installed module still imports.
+Both outcomes are corruption of a resource `AMPLIFIER_HOME` is widely assumed to
+isolate, and the guard below fires before either.
+
+---
+
+## 4. The fix: (b), refuse before installing
+
+`amplifier_app_cli/lib/venv_home_guard.py` (library) +
+`amplifier_app_cli/main.py::_guard_shared_venv_home` (thin CLI wrapper, called in
+`main()` before `cli()`).
+
+Before click dispatches anything, the guard reads the `.pth` files already in
+`sysconfig.get_paths()["purelib"]`, maps each `<home>/cache/<repo>-<16 hex>/…`
+target back to the home that owns it, and compares against the resolved
+`AMPLIFIER_HOME`. Any foreign owner ⇒ refuse, exit 1, with a message that names
+both homes, the environment, the count, five example pointers, and three ranked
+remedies.
+
+### Why (b) and not (a) or (c)
+
+| option | verdict |
+|---|---|
+| **(a) per-home venv** | Correct, and **deferred** — filed as a follow-up. The venv is created by `uv tool install`, outside Amplifier's control; owning it means Amplifier provisioning and re-execing into a per-home environment. Not a $0 change, and shipping it half-done is worse than the guard. |
+| **(b) refuse loudly** | **Shipped.** It is the only option that stops the corruption *before* it happens, it lives entirely in this repo, and one check at the entrypoint covers **every** editable install in the process — this repo's provider installs *and* foundation's `ModuleActivator`. |
+| **(c) name the fix in the existing warning** | **Not editable from this repo.** The "the two disagree about whose code runs" string belongs to `tool-recipes`, in `amplifier-bundle-recipes` — see the verbatim quote in §3.1. Its intent is satisfied anyway: the guard's own message names `amplifier reset --remove cache -y` and the isolation command. |
+
+### Deliberate design choices
+
+- **Refuse, not warn.** The incident happened inside automated lanes with nobody
+  reading stdout. A warning would have been missed exactly as the silence was.
+- **`AMPLIFIER_ALLOW_SHARED_VENV=1` escape hatch,** named in the refusal. A guard
+  with no documented way past it gets routed around with something worse. Under
+  the override the same message prints as a warning and the run continues.
+- **`version` and `reset` stay reachable** while tripped. Blocking `reset` would
+  make the recommended repair unreachable.
+- **Never fatal by accident.** Any unexpected exception inside the guard is
+  logged at debug and the CLI proceeds.
+- **Dev checkouts are not claimed.** Only `<home>/cache/<name>-<16 hex>` counts,
+  so `uv pip install -e ~/dev/my-module` never trips it.
+- **`import`-form `.pth` files are skipped, not half-parsed.** uv — which wrote
+  every `.pth` in the incident — uses the plain-path form.
+
+---
+
+## 5. After-fix verification, same DTU, same scenario
+
+The patched `main.py` + new module were applied to the DTU's installed CLI
+(`patch_installed.py`), then `verify-fix.sh` re-ran the two-homes scenario:
+
+| check | result |
+|---|---|
+| run A claims the venv | 36 `.pth` → `home-a` |
+| run B (`AMPLIFIER_HOME=/root/home-b`) | **exit 1, "Refusing to run…"** |
+| `.pth` files changed by the refused run | **0** |
+| `amplifier version` while tripped | exit 0 |
+| `amplifier reset --help` while tripped | exit 0 |
+| `AMPLIFIER_ALLOW_SHARED_VENV=1` | warns ("AMPLIFIER_HOME changed…"), continues, reaches the LLM |
+| remedy #1 verbatim on a fresh `home-c` | install exit 0 · 0 refusals · reached the LLM · isolated venv gets **36 of 37** `.pth` pointing at `home-c/cache` · **shared venv 0 changes** |
+
+Remedy #1 as printed is therefore **measured to work**, not asserted.
+
+**DTU artifact, not a product issue:** `uv` hardlinks package files from its
+cache into each venv, so patching the installed `main.py` in place also reached
+uv's cache and thus the fresh `home-c` install. The verification script copies
+the new module alongside it. This affected only the patch method used to test a
+pre-release CLI inside the DTU.
+
+---
+
+## 6. Fail-before / pass-after
+
+- `tests/test_venv_home_guard.py` — **25 tests**. With
+  `amplifier_app_cli/lib/venv_home_guard.py` removed (i.e. shipped behavior) the
+  module fails to import and the file errors at collection; with the fix, 25
+  pass. Its fixture is the nine flipped filenames and cache hashes captured in
+  §3.1, not invented paths.
+- Behavioral fail-before is the DTU itself: the shipped CLI ran the scratch home
+  to completion and rewrote nine pointers; the patched CLI exits 1 and changes
+  nothing.
+- Full suite: **1473 passed, 1 skipped, 13 deselected, 1 xfailed.**
+
+---
+
+## 7. Follow-ups filed
+
+- **(a) per-home venv** — `model_performance-xq95`.
+- Adjacent, noticed while reading and **not** fixed here (out of scope, no
+  evidence gathered): `amplifier_app_cli/paths.py:48` (`get_install_state_path`)
+  and `amplifier_app_cli/commands/reset.py:68` (`_get_amplifier_dir`) both
+  hardcode `Path.home() / ".amplifier"` and ignore `AMPLIFIER_HOME`.

--- a/docs/lanes/q99f-amplifier-home-pth-bug/patch_installed.py
+++ b/docs/lanes/q99f-amplifier-home-pth-bug/patch_installed.py
@@ -1,0 +1,40 @@
+"""Apply the q99f guard to an ALREADY-INSTALLED amplifier_app_cli in a DTU."""
+import glob, sys
+from pathlib import Path
+
+sp = glob.glob("/root/.local/share/uv/tools/amplifier/lib/*/site-packages")[0]
+main_py = Path(sp) / "amplifier_app_cli" / "main.py"
+src = main_py.read_text()
+if "_guard_shared_venv_home" in src:
+    print("already patched"); sys.exit(0)
+
+anchor = "    _attach_llm_error_filter()\n    cli()"
+assert anchor in src, "anchor not found in installed main.py"
+
+guard_fn = '''def _guard_shared_venv_home() -> None:
+    """Refuse to run when this environment belongs to a different AMPLIFIER_HOME."""
+    from .lib.venv_home_guard import SharedVenvHomeError
+    from .lib.venv_home_guard import enforce_home_ownership
+    from .lib.venv_home_guard import format_conflict
+
+    try:
+        conflict = enforce_home_ownership(sys.argv[1:])
+    except SharedVenvHomeError as e:
+        console.print(f"[red]{escape_markup(str(e))}[/red]")
+        sys.exit(1)
+    except Exception as e:  # pragma: no cover
+        logger.debug(f"venv home guard skipped: {e}")
+        return
+
+    if conflict is not None:
+        console.print(
+            f"[yellow]{escape_markup(format_conflict(conflict, override_active=True))}[/yellow]"
+        )
+
+
+'''
+
+src = src.replace(anchor, "    _attach_llm_error_filter()\n    _guard_shared_venv_home()\n    cli()")
+src = src.replace("def main():\n    \"\"\"Main entry point.\"\"\"", guard_fn + "def main():\n    \"\"\"Main entry point.\"\"\"", 1)
+main_py.write_text(src)
+print("patched", main_py)

--- a/docs/lanes/q99f-amplifier-home-pth-bug/q99f-pth-repro.dtu.yaml
+++ b/docs/lanes/q99f-amplifier-home-pth-bug/q99f-pth-repro.dtu.yaml
@@ -1,0 +1,24 @@
+# Reproduction environment for model_performance-q99f.
+#
+# One shared uv tool venv, two AMPLIFIER_HOME directories. Shows that
+# AMPLIFIER_HOME does NOT isolate the venv: the editable .pth pointers in the
+# shared venv are silently rewritten to whichever home ran last.
+name: q99f-pth-repro
+description: >
+  Isolated Amplifier install used to reproduce the AMPLIFIER_HOME / shared-venv
+  .pth rewrite (model_performance-q99f). No LLM traffic required.
+base:
+  image: ubuntu:24.04
+  config:
+    limits.memory: "4GiB"
+    limits.cpu: "2"
+
+passthrough:
+  allow_external: true
+
+provision:
+  setup_cmds:
+    - apt-get update && apt-get install -y git curl
+    - curl -LsSf https://astral.sh/uv/install.sh | sh
+    - uv tool install -vv git+https://github.com/microsoft/amplifier
+    - amplifier --version

--- a/docs/lanes/q99f-amplifier-home-pth-bug/repro-flip.sh
+++ b/docs/lanes/q99f-amplifier-home-pth-bug/repro-flip.sh
@@ -1,0 +1,19 @@
+set -uo pipefail
+SP="$(ls -d /root/.local/share/uv/tools/amplifier/lib/*/site-packages)"
+snap() { for f in "$SP"/*.pth; do [ -e "$f" ] || continue; printf '%s\t%s\n' "$(basename "$f")" "$(head -1 "$f")"; done | sort; }
+
+echo "### E3: run home-b a SECOND time"
+AMPLIFIER_HOME=/root/home-b amplifier run "hi" >/tmp/run-b2.log 2>&1
+snap > /tmp/pth-b2.txt
+echo "  -> home-a targets: $(grep -c '/root/home-a/cache' /tmp/pth-b2.txt)  home-b targets: $(grep -c '/root/home-b/cache' /tmp/pth-b2.txt)"
+
+echo "### E4: delete home-a's cache (simulates the /tmp scratch dir being cleaned), then run home-b"
+rm -rf /root/home-a/cache
+AMPLIFIER_HOME=/root/home-b amplifier run "hi" >/tmp/run-b3.log 2>&1
+snap > /tmp/pth-b3.txt
+echo "  -> home-a targets: $(grep -c '/root/home-a/cache' /tmp/pth-b3.txt)  home-b targets: $(grep -c '/root/home-b/cache' /tmp/pth-b3.txt)"
+echo "### FLIPPED between E3 and E4:"
+diff /tmp/pth-b2.txt /tmp/pth-b3.txt | grep '^>' | head -50
+echo "flip count: $(diff /tmp/pth-b2.txt /tmp/pth-b3.txt | grep -c '^>')"
+echo "### warnings in run-b3?"
+grep -icE 'AMPLIFIER_HOME|disagree|rewrote|overwrit' /tmp/run-b3.log

--- a/docs/lanes/q99f-amplifier-home-pth-bug/repro.sh
+++ b/docs/lanes/q99f-amplifier-home-pth-bug/repro.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Reproduction for model_performance-q99f: AMPLIFIER_HOME does NOT isolate the
+# uv tool venv. Two AMPLIFIER_HOME directories, ONE shared venv -- the venv's
+# editable .pth pointers are silently rewritten to whichever home ran last.
+#
+# Run INSIDE a DTU. Never on a host with a real Amplifier install.
+set -uo pipefail
+
+SP="$(ls -d /root/.local/share/uv/tools/amplifier/lib/*/site-packages)"
+echo "shared venv site-packages: $SP"
+
+snap() {
+  for f in "$SP"/*.pth; do
+    [ -e "$f" ] || continue
+    printf '%s\t%s\n' "$(basename "$f")" "$(head -1 "$f")"
+  done | sort
+}
+
+setup_home() {
+  local H="$1"
+  mkdir -p "$H"
+  cat > "$H/settings.yaml" <<EOF
+config:
+  providers:
+    - module: provider-anthropic
+      source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
+      config:
+        api_key: sk-ant-dummy-key-no-llm-traffic-is-expected
+EOF
+}
+
+setup_home /root/home-a
+setup_home /root/home-b
+
+echo "=== BEFORE: $(snap | wc -l) .pth entries ==="
+snap > /tmp/pth-before.txt
+
+echo "=== RUN 1: AMPLIFIER_HOME=/root/home-a ==="
+AMPLIFIER_HOME=/root/home-a amplifier run "hi" >/tmp/run-a.log 2>&1
+echo "exit=$? (an LLM auth failure here is expected and irrelevant)"
+snap > /tmp/pth-after-a.txt
+echo "after run A: $(wc -l < /tmp/pth-after-a.txt) .pth entries"
+echo "  pointing into /root/home-a/cache: $(grep -c '/root/home-a/cache' /tmp/pth-after-a.txt)"
+echo "  pointing into /root/home-b/cache: $(grep -c '/root/home-b/cache' /tmp/pth-after-a.txt)"
+
+echo
+echo "=== RUN 2: AMPLIFIER_HOME=/root/home-b (no warning is printed) ==="
+AMPLIFIER_HOME=/root/home-b amplifier run "hi" >/tmp/run-b.log 2>&1
+echo "exit=$?"
+snap > /tmp/pth-after-b.txt
+echo "after run B: $(wc -l < /tmp/pth-after-b.txt) .pth entries"
+echo "  pointing into /root/home-a/cache: $(grep -c '/root/home-a/cache' /tmp/pth-after-b.txt)"
+echo "  pointing into /root/home-b/cache: $(grep -c '/root/home-b/cache' /tmp/pth-after-b.txt)"
+
+echo
+echo "=== THE FLIP: .pth files whose target changed between run A and run B ==="
+diff /tmp/pth-after-a.txt /tmp/pth-after-b.txt | head -40
+echo
+echo "flipped-file count: $(diff /tmp/pth-after-a.txt /tmp/pth-after-b.txt | grep -c '^<')"
+echo
+echo "=== Did run B warn the user about any of this? ==="
+grep -iE 'AMPLIFIER_HOME|venv|\.pth|shared|different cache' /tmp/run-b.log || echo "NO WARNING FOUND in run B output."

--- a/docs/lanes/q99f-amplifier-home-pth-bug/verify-fix.sh
+++ b/docs/lanes/q99f-amplifier-home-pth-bug/verify-fix.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# After-fix verification for model_performance-q99f, run INSIDE the same DTU
+# that produced the reproduction. Same two-homes scenario, patched CLI.
+set -uo pipefail
+
+SP="$(ls -d /root/.local/share/uv/tools/amplifier/lib/*/site-packages)"
+snap() { for f in "$SP"/*.pth; do [ -e "$f" ] || continue; printf '%s\t%s\n' "$(basename "$f")" "$(head -1 "$f")"; done | sort; }
+
+setup_home() {
+  local H="$1"
+  mkdir -p "$H"
+  cat > "$H/settings.yaml" <<EOF
+config:
+  providers:
+    - module: provider-anthropic
+      source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
+      config:
+        api_key: sk-ant-dummy-key-no-llm-traffic-is-expected
+EOF
+}
+
+rm -rf /root/home-a /root/home-b
+setup_home /root/home-a
+setup_home /root/home-b
+
+echo "=== RUN 1: AMPLIFIER_HOME=/root/home-a (claims the venv) ==="
+AMPLIFIER_HOME=/root/home-a amplifier run "hi" >/tmp/fix-a.log 2>&1
+echo "exit=$?"
+snap > /tmp/fix-pth-a.txt
+echo "  home-a targets: $(grep -c '/root/home-a/cache' /tmp/fix-pth-a.txt)  home-b targets: $(grep -c '/root/home-b/cache' /tmp/fix-pth-a.txt)"
+
+echo
+echo "=== RUN 2: AMPLIFIER_HOME=/root/home-b (must REFUSE) ==="
+AMPLIFIER_HOME=/root/home-b amplifier run "hi" >/tmp/fix-b.log 2>&1
+echo "exit=$?  (expected 1)"
+sed -n '1,45p' /tmp/fix-b.log
+snap > /tmp/fix-pth-b.txt
+echo "  home-a targets: $(grep -c '/root/home-a/cache' /tmp/fix-pth-b.txt)  home-b targets: $(grep -c '/root/home-b/cache' /tmp/fix-pth-b.txt)"
+echo "  .pth files changed by the refused run: $(diff /tmp/fix-pth-a.txt /tmp/fix-pth-b.txt | grep -c '^>')  (expected 0)"
+
+echo
+echo "=== Diagnostic/repair paths must stay reachable while tripped ==="
+AMPLIFIER_HOME=/root/home-b amplifier version; echo "  version exit=$?"
+AMPLIFIER_HOME=/root/home-b amplifier reset --help >/dev/null 2>&1; echo "  reset --help exit=$?"
+
+echo
+echo "=== Override must warn and continue ==="
+AMPLIFIER_HOME=/root/home-b AMPLIFIER_ALLOW_SHARED_VENV=1 amplifier run "hi" >/tmp/fix-b-override.log 2>&1
+echo "exit=$? (LLM auth failure expected)"
+grep -c "AMPLIFIER_HOME changed" /tmp/fix-b-override.log
+
+echo
+echo "=== Remedy #1 from the message: does a per-home environment actually work? ==="
+UV_TOOL_DIR=/root/home-b/uv-tools UV_TOOL_BIN_DIR=/root/home-b/bin \
+  uv tool install -q git+https://github.com/microsoft/amplifier >/tmp/fix-isolated-install.log 2>&1
+echo "install exit=$?"
+AMPLIFIER_HOME=/root/home-b /root/home-b/bin/amplifier run "hi" >/tmp/fix-isolated.log 2>&1
+echo "isolated run exit=$? (LLM auth failure expected, NOT a refusal)"
+grep -c "Refusing to run" /tmp/fix-isolated.log
+echo "  shared venv untouched? changed .pth since run 1: $(snap > /tmp/fix-pth-final.txt; diff /tmp/fix-pth-a.txt /tmp/fix-pth-final.txt | grep -c '^>')  (expected 0)"
+echo "  isolated venv .pth owned by home-b: $(ls /root/home-b/uv-tools/amplifier/lib/*/site-packages/*.pth 2>/dev/null | wc -l) file(s)"
+grep -l '/root/home-b/cache' /root/home-b/uv-tools/amplifier/lib/*/site-packages/*.pth 2>/dev/null | wc -l

--- a/docs/lanes/q99f-amplifier-home-pth-bug/verify-remedy1.sh
+++ b/docs/lanes/q99f-amplifier-home-pth-bug/verify-remedy1.sh
@@ -1,0 +1,33 @@
+set -uo pipefail
+rm -rf /root/home-c
+mkdir -p /root/home-c
+cat > /root/home-c/settings.yaml <<EOF
+config:
+  providers:
+    - module: provider-anthropic
+      source: git+https://github.com/microsoft/amplifier-module-provider-anthropic@main
+      config:
+        api_key: sk-ant-dummy-key-no-llm-traffic-is-expected
+EOF
+SHARED="$(ls -d /root/.local/share/uv/tools/amplifier/lib/*/site-packages)"
+snap() { for f in "$SHARED"/*.pth; do [ -e "$f" ] || continue; printf '%s\t%s\n' "$(basename "$f")" "$(head -1 "$f")"; done | sort; }
+snap > /tmp/shared-before-c.txt
+
+UV_TOOL_DIR=/root/home-c/uv-tools UV_TOOL_BIN_DIR=/root/home-c/bin \
+  uv tool install -q git+https://github.com/microsoft/amplifier >/tmp/c-install.log 2>&1
+echo "install exit=$?"
+# NOTE: uv HARDLINKS package files from its cache, so the in-place patch applied
+# to the shared venv already reached this fresh install's main.py. Ship the new
+# module alongside it so the isolated install is complete.
+ISO="$(ls -d /root/home-c/uv-tools/amplifier/lib/*/site-packages)"
+cp /tmp/venv_home_guard.py "$ISO/amplifier_app_cli/lib/venv_home_guard.py"
+
+AMPLIFIER_HOME=/root/home-c /root/home-c/bin/amplifier run "hi" >/tmp/c-run.log 2>&1
+echo "run exit=$?"
+echo "  refusals:                            $(grep -c 'Refusing to run' /tmp/c-run.log)  (expected 0)"
+echo "  reached the LLM (auth failure):      $(grep -c 'AuthenticationError' /tmp/c-run.log)  (expected 1)"
+echo "  isolated venv .pth total:            $(ls "$ISO"/*.pth 2>/dev/null | wc -l)"
+echo "  isolated venv .pth -> home-c cache:  $(grep -l '/root/home-c/cache' "$ISO"/*.pth 2>/dev/null | wc -l)"
+echo "  home-c cache dirs:                   $(ls /root/home-c/cache 2>/dev/null | wc -l)"
+snap > /tmp/shared-after-c.txt
+echo "  SHARED venv .pth changed by this:    $(diff /tmp/shared-before-c.txt /tmp/shared-after-c.txt | grep -c '^>')  (expected 0)"

--- a/tests/test_venv_home_guard.py
+++ b/tests/test_venv_home_guard.py
@@ -1,0 +1,296 @@
+"""AMPLIFIER_HOME must not silently repoint another home's editable installs.
+
+FAIL-BEFORE: every test here fails against the shipped (unfixed) CLI, because
+nothing in it ever looked at the environment's ``.pth`` files before installing.
+
+The fixture below is not invented. It is the state captured in a Digital Twin
+Universe on 2026-09-07 (``docs/lanes/q99f-amplifier-home-pth-bug/``): one shared
+uv tool venv, ``AMPLIFIER_HOME=/root/home-a`` run first, then
+``AMPLIFIER_HOME=/root/home-b`` -- after which nine ``_editable_impl_*.pth``
+files that had pointed into ``/root/home-a/cache`` pointed into
+``/root/home-b/cache`` instead, with no warning of any kind.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from amplifier_app_cli.lib.venv_home_guard import OVERRIDE_ENV
+from amplifier_app_cli.lib.venv_home_guard import SharedVenvHomeError
+from amplifier_app_cli.lib.venv_home_guard import detect_home_conflict
+from amplifier_app_cli.lib.venv_home_guard import enforce_home_ownership
+from amplifier_app_cli.lib.venv_home_guard import format_conflict
+from amplifier_app_cli.lib.venv_home_guard import home_for_target
+from amplifier_app_cli.lib.venv_home_guard import is_exempt
+from amplifier_app_cli.lib.venv_home_guard import read_editable_entries
+
+# The nine provider modules whose .pth files flipped in the DTU reproduction,
+# with the cache-entry hashes exactly as captured.
+FLIPPED_IN_DTU = {
+    "_editable_impl_amplifier_module_provider_anthropic.pth": "cache/amplifier-module-provider-anthropic-5181591dcf06d076",
+    "_editable_impl_amplifier_module_provider_azure_openai.pth": "cache/amplifier-module-provider-azure-openai-922834ab260b519e",
+    "_editable_impl_amplifier_module_provider_chat_completions.pth": "cache/amplifier-module-provider-chat-completions-5872434b7d7c24df",
+    "_editable_impl_amplifier_module_provider_gemini.pth": "cache/amplifier-module-provider-gemini-06d1437d03d6b064",
+    "_editable_impl_amplifier_module_provider_github_copilot.pth": "cache/amplifier-module-provider-github-copilot-ed66ecbd21ea6054",
+    "_editable_impl_amplifier_module_provider_ollama.pth": "cache/amplifier-module-provider-ollama-014c2047033c455b",
+    "_editable_impl_amplifier_module_provider_openai.pth": "cache/amplifier-module-provider-openai-e2c4b8c10222ed8c",
+    "_editable_impl_amplifier_module_provider_openai_chatgpt.pth": "cache/amplifier-module-provider-openai-chatgpt-36f6cbc7a2650e2e",
+    "_editable_impl_amplifier_module_provider_vllm.pth": "cache/amplifier-module-provider-vllm-ac98bf87e319447e",
+}
+
+# A bundle module lives one level deeper, under `modules/<name>` -- the shape
+# that produced the "the two disagree about whose code runs" line in run B.
+NESTED_IN_DTU = {
+    "_editable_impl_amplifier_module_tool_recipes.pth": "cache/amplifier-bundle-recipes-2b1e350432fea9ba/modules/tool-recipes",
+}
+
+
+def _write_site_packages(
+    site_packages: Path, home: Path, entries: dict[str, str]
+) -> None:
+    site_packages.mkdir(parents=True, exist_ok=True)
+    for name, relative in entries.items():
+        (site_packages / name).write_text(f"{home / relative}\n", encoding="utf-8")
+
+
+@pytest.fixture
+def two_homes(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """home_a (owns the venv), home_b (the scratch home), shared site-packages."""
+    home_a = tmp_path / "home-a"
+    home_b = tmp_path / "home-b"
+    site_packages = tmp_path / "uv-tools" / "amplifier" / "site-packages"
+    home_a.mkdir()
+    home_b.mkdir()
+    _write_site_packages(
+        site_packages, home_a, {**FLIPPED_IN_DTU, **NESTED_IN_DTU}
+    )
+    return home_a, home_b, site_packages
+
+
+# ---------------------------------------------------------------------------
+# The defect itself
+# ---------------------------------------------------------------------------
+
+
+def test_second_home_is_refused_before_anything_is_installed(two_homes):
+    """The scratch-home run must stop, not silently repoint home-a's installs."""
+    home_a, home_b, site_packages = two_homes
+
+    with pytest.raises(SharedVenvHomeError) as excinfo:
+        enforce_home_ownership(
+            ["run", "hi"],
+            current_home=home_b,
+            site_packages=site_packages,
+            env={},
+        )
+
+    conflict = excinfo.value.conflict
+    assert len(conflict.foreign) == len(FLIPPED_IN_DTU) + len(NESTED_IN_DTU)
+    assert conflict.foreign_homes == (home_a.resolve(),)
+
+
+def test_the_home_that_owns_the_venv_runs_normally(two_homes):
+    """No conflict, no refusal, for the home the editable installs belong to."""
+    home_a, _home_b, site_packages = two_homes
+
+    assert (
+        enforce_home_ownership(
+            ["run", "hi"], current_home=home_a, site_packages=site_packages, env={}
+        )
+        is None
+    )
+    assert detect_home_conflict(current_home=home_a, site_packages=site_packages) is None
+
+
+def test_fresh_environment_is_not_a_conflict(tmp_path: Path):
+    """A venv with no Amplifier-owned editable installs must never trip."""
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    (site_packages / "unrelated.pth").write_text("/opt/other/lib\n", encoding="utf-8")
+
+    assert (
+        detect_home_conflict(
+            current_home=tmp_path / "home", site_packages=site_packages
+        )
+        is None
+    )
+
+
+def test_dev_checkout_editables_are_not_claimed_by_any_home(tmp_path: Path):
+    """`uv pip install -e ~/dev/my-module` must not be read as a home's cache."""
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    (site_packages / "_editable_impl_mine.pth").write_text(
+        f"{tmp_path / 'dev' / 'amplifier-module-mine'}\n", encoding="utf-8"
+    )
+
+    assert read_editable_entries(site_packages) == []
+    assert (
+        detect_home_conflict(
+            current_home=tmp_path / "home", site_packages=site_packages
+        )
+        is None
+    )
+
+
+# ---------------------------------------------------------------------------
+# home_for_target: which paths a home actually owns
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "target,expected",
+    [
+        ("/root/home-a/cache/amplifier-module-provider-openai-e2c4b8c10222ed8c", "/root/home-a"),
+        (
+            "/root/home-a/cache/amplifier-bundle-recipes-2b1e350432fea9ba/modules/tool-recipes",
+            "/root/home-a",
+        ),
+        ("/home/u/.amplifier/cache/amplifier-foundation-c909465861f9d6ce", "/home/u/.amplifier"),
+        # No 16-hex suffix -> not a foundation cache entry.
+        ("/home/u/.amplifier/cache/something-else", None),
+        # No cache segment at all.
+        ("/home/u/dev/amplifier-module-provider-openai", None),
+        ("/opt/site-packages/whatever", None),
+    ],
+)
+def test_home_for_target(target: str, expected: str | None):
+    result = home_for_target(Path(target))
+    assert result == (Path(expected) if expected else None)
+
+
+def test_pth_import_lines_are_skipped(tmp_path: Path):
+    """setuptools finder glue is executable, not a path -- do not half-parse it."""
+    site_packages = tmp_path / "site-packages"
+    site_packages.mkdir()
+    (site_packages / "__editable__.thing-0.1.0.pth").write_text(
+        "import __editable___thing_finder; __editable___thing_finder.install()\n",
+        encoding="utf-8",
+    )
+
+    assert read_editable_entries(site_packages) == []
+
+
+# ---------------------------------------------------------------------------
+# Escape hatches: the guard must be passable, and must not block the repair
+# ---------------------------------------------------------------------------
+
+
+def test_override_downgrades_refusal_to_a_returned_conflict(two_homes):
+    """With the override set, the caller continues -- and still gets told."""
+    _home_a, home_b, site_packages = two_homes
+
+    conflict = enforce_home_ownership(
+        ["run", "hi"],
+        current_home=home_b,
+        site_packages=site_packages,
+        env={OVERRIDE_ENV: "1"},
+    )
+
+    assert conflict is not None
+    assert len(conflict.foreign) == len(FLIPPED_IN_DTU) + len(NESTED_IN_DTU)
+
+
+@pytest.mark.parametrize("argv", [["version"], ["reset", "--remove", "cache", "-y"], ["--help"], ["--version"], ["run", "-h"]])
+def test_diagnostic_and_repair_paths_stay_reachable(two_homes, argv):
+    """Blocking `reset` would make the recommended repair unreachable."""
+    _home_a, home_b, site_packages = two_homes
+
+    assert is_exempt(argv) is True
+    assert (
+        enforce_home_ownership(
+            argv, current_home=home_b, site_packages=site_packages, env={}
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("argv", [["run", "hi"], [], ["--verbose", "run", "hi"], ["bundle", "add", "x"]])
+def test_session_paths_are_guarded(argv):
+    assert is_exempt(argv) is False
+
+
+# ---------------------------------------------------------------------------
+# The message has to be actionable, not just loud
+# ---------------------------------------------------------------------------
+
+
+def test_message_names_both_homes_the_env_and_the_remedies(two_homes):
+    home_a, home_b, site_packages = two_homes
+    conflict = detect_home_conflict(
+        current_home=home_b, site_packages=site_packages
+    )
+    assert conflict is not None
+
+    message = format_conflict(conflict)
+
+    assert str(home_a.resolve()) in message
+    assert str(home_b.resolve()) in message
+    assert str(site_packages) in message
+    # Names the fix, rather than leaving the user to diagnose a .pth collision.
+    assert OVERRIDE_ENV in message
+    assert "UV_TOOL_DIR" in message
+    assert "amplifier reset --remove cache" in message
+    # Quotes the incident that motivated the guard.
+    assert "61 of 63" in message
+
+
+def test_message_flags_a_foreign_home_that_no_longer_exists(two_homes):
+    """The repair case: the scratch home under /tmp has already been cleaned."""
+    home_a, home_b, site_packages = two_homes
+    home_a.rmdir()
+
+    conflict = detect_home_conflict(
+        current_home=home_b, site_packages=site_packages
+    )
+    assert conflict is not None
+    assert "no longer exists" in format_conflict(conflict)
+
+
+# ---------------------------------------------------------------------------
+# CLI wiring: the refusal has to reach the user before click dispatches
+# ---------------------------------------------------------------------------
+
+
+def test_cli_entrypoint_refuses_and_exits_nonzero(two_homes, monkeypatch, capsys):
+    """`amplifier run` must exit 1, not install into someone else's venv."""
+    import sys
+
+    from amplifier_app_cli.lib import venv_home_guard
+    from amplifier_app_cli.main import _guard_shared_venv_home
+
+    home_a, home_b, site_packages = two_homes
+    monkeypatch.setattr(venv_home_guard, "site_packages_dir", lambda: site_packages)
+    monkeypatch.setenv("AMPLIFIER_HOME", str(home_b))
+    monkeypatch.delenv(OVERRIDE_ENV, raising=False)
+    monkeypatch.setattr(sys, "argv", ["amplifier", "run", "hi"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        _guard_shared_venv_home()
+
+    assert excinfo.value.code == 1
+    output = capsys.readouterr().out
+    assert "Refusing to run" in output
+    assert str(home_a.resolve()) in output
+
+
+def test_cli_entrypoint_warns_and_continues_under_override(
+    two_homes, monkeypatch, capsys
+):
+    import sys
+
+    from amplifier_app_cli.lib import venv_home_guard
+    from amplifier_app_cli.main import _guard_shared_venv_home
+
+    _home_a, home_b, site_packages = two_homes
+    monkeypatch.setattr(venv_home_guard, "site_packages_dir", lambda: site_packages)
+    monkeypatch.setenv("AMPLIFIER_HOME", str(home_b))
+    monkeypatch.setenv(OVERRIDE_ENV, "1")
+    monkeypatch.setattr(sys, "argv", ["amplifier", "run", "hi"])
+
+    _guard_shared_venv_home()
+
+    output = capsys.readouterr().out
+    assert "AMPLIFIER_HOME changed" in output

--- a/tests/test_venv_home_guard.py
+++ b/tests/test_venv_home_guard.py
@@ -271,9 +271,12 @@ def test_cli_entrypoint_refuses_and_exits_nonzero(two_homes, monkeypatch, capsys
         _guard_shared_venv_home()
 
     assert excinfo.value.code == 1
+    # Rich may still break lines depending on the runner's console width, and a
+    # tmp_path on macOS is long enough to hit it -- compare with line breaks
+    # removed so the assertion is about content, not terminal geometry.
     output = capsys.readouterr().out
     assert "Refusing to run" in output
-    assert str(home_a.resolve()) in output
+    assert str(home_a.resolve()) in output.replace("\n", "")
 
 
 def test_cli_entrypoint_warns_and_continues_under_override(


### PR DESCRIPTION
## The incident this fixes

> **INCIDENT 2026-09-07:** `hd-*` head-census lanes ran `amplifier` with
> `AMPLIFIER_HOME=/tmp/hd-*-scratch-*` on the HOST to render a tool/skill surface for a
> before/after byte count. Amplifier's first-run editable-install logic writes into the SHARED
> uv tool venv (`~/.local/share/uv/tools/amplifier/lib/python3.13/site-packages/*.pth`)
> regardless of `AMPLIFIER_HOME` — the env var does NOT isolate the venv, only the
> config/cache/session directories. Result: **61 of 63 `_editable_impl_*.pth` files in the
> owner's real install were silently rewritten** to point at
> `/tmp/hd-android-scratch-before-bfKCxP/...` and `/tmp/hd-stock-fbf8ce6/...`. The owner's CLI
> then printed something to the effect of *"the two disagree about whose code runs"* — a real,
> user-visible symptom of a completely different root cause (the shared venv, not a version
> mismatch). Repaired by hand: all 61 `.pth` files backed up and rewritten back to
> `~/.amplifier/cache/<hash>/...`, verified 0 `/tmp` pointers remain, imports resolve to the
> real cache, `amplifier --version` clean. Backup preserved at
> `~/dev/_backups/pth-backup-20260907-1512`.

Work item: `model_performance-q99f`. Lane artifacts and full evidence:
[`docs/lanes/q99f-amplifier-home-pth-bug/FINDINGS.md`](docs/lanes/q99f-amplifier-home-pth-bug/FINDINGS.md).

## Mechanism

`AMPLIFIER_HOME` selects the **cache root** (`<home>/cache/<repo>-<16 hex>/…`). Modules and
bundles are installed **editable** into the interpreter running Amplifier —
`uv pip install -e <cache path> --python sys.executable`
(`amplifier_app_cli/provider_sources.py:425` for providers; foundation's `ModuleActivator` for
everything else). `sys.executable` is the uv tool venv: one per machine, entirely outside
`AMPLIFIER_HOME`'s reach. So every `.pth` file there encodes *one* home's cache root, and the
next run under a different home overwrites them.

## Reproduced in a DTU (before the fix)

Profile + scripts are in the lane directory. Ubuntu 24.04, `amplifier 2026.09.07-10af274`
(core 1.6.1), no API key — each run reaches the provider and fails auth *after* module
activation, which is the part under test.

| step | `.pth` total | → `home-a/cache` | → `home-b/cache` |
|---|---:|---:|---:|
| fresh install | 1 | 0 | 0 |
| after run A (`AMPLIFIER_HOME=/root/home-a`) | 37 | 36 | 0 |
| after run B (`AMPLIFIER_HOME=/root/home-b`) | 37 | 36 | 0 |
| after deleting home-a's cache, then run B | 37 | **27** | **9** |

Two silent failures, both present:

1. **The disagreement.** Run B imported modules from `/root/home-b/cache` while the venv's
   `.pth` still pointed at `/root/home-a/cache`. The only signal was one module's own
   self-check, verbatim from the captured log:

   > `tool-recipes engine: editable install …/_editable_impl_amplifier_module_tool_recipes.pth
   > points at /root/home-a/cache/amplifier-bundle-recipes-2b1e350432fea9ba/modules/tool-recipes,
   > but this engine was imported from /root/home-b/cache/… — the two disagree about whose code runs.`

2. **The rewrite.** With home-a's cache gone — exactly what happens when a `/tmp` scratch home
   is cleaned — **nine `_editable_impl_*.pth` files flipped from `/root/home-a/cache/…` to
   `/root/home-b/cache/…` with no warning of any kind.** All nine are provider modules, i.e.
   written by this repo's own `install_known_providers()`.

**Honest scope note:** the flip needs a second condition (the first home's cache gone) that the
host incident supplied naturally. The *shared, unisolated venv* is the defect; whether a given
run rewrites or merely disagrees depends on whether the already-installed module still imports.
The guard fires before either.

## The change

New library `amplifier_app_cli/lib/venv_home_guard.py` + a thin wrapper
`main.py::_guard_shared_venv_home` called from `main()` before `cli()` — early enough to cover
**every** editable install in the process, this repo's provider installs *and* foundation's
`ModuleActivator`.

It reads the `.pth` files already in `sysconfig.get_paths()["purelib"]`, maps each
`<home>/cache/<repo>-<16 hex>/…` target back to the home that owns it, and compares against the
resolved `AMPLIFIER_HOME`. Any foreign owner ⇒ refuse, exit 1:

```
Refusing to run: this Python environment belongs to a different AMPLIFIER_HOME.

  AMPLIFIER_HOME now:  /root/home-b
  claimed by:
      /root/home-a  (36 editable install(s))
  environment:         /root/.local/share/uv/tools/amplifier/lib/python3.12/site-packages
  editable installs:   36 foreign of 36 total
  … five example pointers …

Pick one:
  1. Give this home its own environment (do this for scratch, CI and eval homes):
       UV_TOOL_DIR=<home>/uv-tools UV_TOOL_BIN_DIR=<home>/bin uv tool install git+…/amplifier
  2. Go back to the home this environment already belongs to.
  3. Hand this environment over on purpose:  AMPLIFIER_ALLOW_SHARED_VENV=1 amplifier …
     To repoint everything cleanly:  AMPLIFIER_ALLOW_SHARED_VENV=1 amplifier reset --remove cache -y
```

### Why (b) and not (a) or (c)

| option | verdict |
|---|---|
| **(a) per-home venv** | Correct root fix, **deferred** — filed as `model_performance-xq95`. The venv is created by `uv tool install`, outside Amplifier's control; owning it means provisioning and re-execing into a per-home environment, across this repo and foundation. Not a $0 change. |
| **(b) refuse loudly** | **Shipped.** The only option that stops the corruption *before* it happens, it lives entirely in this repo, and one entrypoint check covers every editable install in the process. |
| **(c) name the fix in the existing warning** | **Not editable from here** — the "disagree about whose code runs" string belongs to `tool-recipes`, in `amplifier-bundle-recipes`. Its intent is satisfied anyway: the guard's message names both the isolation command and `amplifier reset --remove cache -y`. |

### Deliberate choices

- **Refuse, not warn** — the incident happened inside automated lanes with nobody reading stdout.
- **`AMPLIFIER_ALLOW_SHARED_VENV=1`** is named in the refusal; a guard with no documented way
  past it gets routed around with something worse.
- **`version` and `reset` stay reachable** while tripped — blocking `reset` would make the
  recommended repair unreachable.
- **Never fatal by accident** — any unexpected exception inside the guard is logged at debug and
  the CLI proceeds.
- **Dev checkouts are not claimed** — only `<home>/cache/<name>-<16 hex>` counts, so
  `uv pip install -e ~/dev/my-module` never trips it. Normal users (whose only home *is*
  `~/.amplifier`) never see this.

## Verification, same DTU, same scenario

| check | result |
|---|---|
| run A claims the venv | 36 `.pth` → home-a |
| run B under home-b | **exit 1, "Refusing to run…"** |
| `.pth` changed by the refused run | **0** |
| `amplifier version` / `amplifier reset --help` while tripped | exit 0 / exit 0 |
| `AMPLIFIER_ALLOW_SHARED_VENV=1` | warns, continues, reaches the LLM |
| printed remedy #1, verbatim, on a fresh home | install exit 0 · 0 refusals · isolated venv gets **36 of 37** `.pth` → its own cache · **shared venv 0 changes** |

Remedy #1 is measured, not asserted.

## Tests

`tests/test_venv_home_guard.py`, 25 tests. Its fixture is the nine flipped filenames and cache
hashes captured in the DTU, not invented paths.

- **Fail-before:** with `lib/venv_home_guard.py` removed (i.e. shipped behavior) the module
  fails to import and the file errors at collection. Behavioral fail-before is the DTU itself —
  the shipped CLI ran the scratch home to completion and rewrote nine pointers; the patched CLI
  exits 1 and changes nothing.
- **Pass-after:** 25 pass. Full suite **1473 passed, 1 skipped, 13 deselected, 1 xfailed**.

## Follow-ups

- **`model_performance-xq95`** — per-`AMPLIFIER_HOME` Python environment (fix (a)).
- Noticed while reading, **not** fixed here and no evidence gathered:
  `amplifier_app_cli/paths.py:48` (`get_install_state_path`) and
  `amplifier_app_cli/commands/reset.py:68` (`_get_amplifier_dir`) both hardcode
  `Path.home() / ".amplifier"` and ignore `AMPLIFIER_HOME`.

## Reviewer note

`docs/` is force-included into the wheel, so the lane artifacts (~30 KB of markdown and shell)
ship with it. The lane's goal mandated `docs/lanes/<lane>/`; say the word and they move.
