### PR TITLE
feat: a Python environment per AMPLIFIER_HOME for editable module installs (xq95)

### DIFF
--- a/amplifier_app_cli/lib/home_env.py
+++ b/amplifier_app_cli/lib/home_env.py
@@ -1,0 +1,289 @@
+"""A Python environment per ``AMPLIFIER_HOME``, so editable installs stop colliding.
+
+``AMPLIFIER_HOME`` isolates config, cache, registry and sessions. It does **not**
+isolate the Python environment. Modules are installed editable into the
+interpreter running Amplifier (``uv pip install -e <cache path> --python
+sys.executable``), which under ``uv tool install`` is one venv per machine. Two
+homes therefore write the same ``.pth`` filenames into the same directory, and
+the second run silently repoints the first home's installs at its own cache.
+``lib.venv_home_guard`` refuses to run when that has already happened; this
+module removes the shared resource so there is nothing to refuse.
+
+**The mechanism is an overlay, not a second Amplifier install.** Each home gets
+``<AMPLIFIER_HOME>/env/py<major>.<minor>`` -- a bare venv holding *only* the
+packages Amplifier installs at runtime. Amplifier itself, and every dependency
+it shipped with, keep living in the base environment; the overlay carries a
+single ``.pth`` pointing back at the base ``site-packages`` so its own
+interpreter can still import them. At startup the running process calls
+``site.addsitedir()`` on the overlay, which is how modules installed there become
+importable *in this process* -- no re-exec, no second copy of the stack.
+
+Measured on the host that filed this (uv 0.12.6, CPython 3.13.11, all offline):
+``uv venv`` 0.374 s; an editable install of a module whose dependency is already
+in the base environment 0.794 s wall / "Installed 5 packages in 6 ms"; base
+environment ``.pth`` count 75 before and 75 after -- zero cross-contamination.
+
+Two consequences worth knowing before reading the code:
+
+* **Dependencies already present in the base environment are re-resolved into
+  the overlay.** ``uv`` reads a venv's own ``dist-info``; it does not follow the
+  base ``.pth``. Measured: ``uv pip list`` on a fresh overlay reports 0 packages
+  while the base has 156 ``dist-info`` directories. The copies come from uv's
+  cache as hardlinks, so the cost is milliseconds and near-zero disk -- but they
+  are real entries.
+* **The base environment wins at import time**, because ``site.addsitedir()``
+  appends. A dependency resolved to a *different* version in the overlay would
+  therefore be installed and then silently ignored. To make that impossible,
+  every install is passed a constraints file pinning each base distribution to
+  its installed version, so an incompatible requirement fails loudly at install
+  time instead of quietly at import time.
+
+While the foundation half of this change is unshipped (foundation's
+``ModuleActivator`` performs most editable installs and still targets
+``sys.executable``), the behavior here is **opt-in**: with
+``AMPLIFIER_HOME_ENV`` unset, every entry point below is a no-op and installs
+target ``sys.executable`` exactly as before.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import site
+import subprocess
+import sys
+import sysconfig
+from pathlib import Path
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+# Opt-in switch. Off by default: app-cli owns only the provider installs, so
+# isolating them alone does not make a home isolated -- it makes it *partly*
+# isolated, which is harder to reason about than today's honest collision plus
+# the guard. Flip the default when foundation's ModuleActivator also targets
+# ``install_python()``.
+ENABLE_ENV = "AMPLIFIER_HOME_ENV"
+
+# Directory layout under the home. Version-keyed so upgrading the base
+# interpreter starts a fresh overlay rather than importing 3.13 builds into 3.14.
+ENV_DIR_NAME = "env"
+
+# Points the overlay's own interpreter back at the base environment, so
+# ``<overlay>/bin/python`` can import Amplifier and everything it shipped with.
+BASE_PTH_NAME = "_amplifier_base.pth"
+
+# Pins every base distribution during an overlay install (see module docstring).
+CONSTRAINTS_NAME = "base-constraints.txt"
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+Runner = Callable[..., "subprocess.CompletedProcess[str]"]
+
+
+def is_enabled(env: dict[str, str] | None = None) -> bool:
+    """True when per-home environments are switched on."""
+    environ = os.environ if env is None else env
+    return environ.get(ENABLE_ENV, "").strip().lower() in _TRUTHY
+
+
+def _resolved_home(home: Path | None) -> Path:
+    if home is not None:
+        return home
+    from amplifier_foundation.paths.resolution import get_amplifier_home
+
+    return get_amplifier_home()
+
+
+def home_env_root(home: Path | None = None) -> Path:
+    """``<AMPLIFIER_HOME>/env/py<major>.<minor>`` -- this home's overlay.
+
+    Version-keyed on the *running* interpreter: an overlay built for 3.13 is
+    never handed to 3.14, and neither has to be torn down for the other.
+    """
+    tag = f"py{sys.version_info.major}.{sys.version_info.minor}"
+    return _resolved_home(home) / ENV_DIR_NAME / tag
+
+
+def env_python(root: Path) -> Path:
+    """The overlay interpreter, whether or not it exists yet."""
+    if os.name == "nt":
+        return root / "Scripts" / "python.exe"
+    return root / "bin" / "python"
+
+
+def env_site_packages(root: Path) -> Path | None:
+    """The overlay's ``site-packages``, or None when the overlay is absent."""
+    if os.name == "nt":
+        candidate = root / "Lib" / "site-packages"
+        return candidate if candidate.is_dir() else None
+    try:
+        return next(iter(sorted(root.glob("lib/python*/site-packages"))), None)
+    except OSError:
+        return None
+
+
+def base_site_packages() -> Path:
+    """The base environment's ``site-packages`` -- the resource being unshared."""
+    return Path(sysconfig.get_paths()["purelib"])
+
+
+def base_constraints() -> list[str]:
+    """``name==version`` for every distribution importable in the base environment.
+
+    Pinning these during an overlay install is what turns a silently-ignored
+    version skew (the overlay resolves a newer dependency, the base copy wins at
+    import) into a loud install-time resolution failure naming both versions.
+    """
+    import importlib.metadata
+
+    pins: dict[str, str] = {}
+    for dist in importlib.metadata.distributions():
+        name = dist.metadata["Name"] if dist.metadata else None
+        version = dist.version
+        if not name or not version:
+            continue
+        pins.setdefault(name, version)
+    return [f"{name}=={version}" for name, version in sorted(pins.items())]
+
+
+def write_constraints(root: Path) -> Path:
+    """Write the base pins into the overlay and return the file path.
+
+    Rewritten on every ensure: the base environment changes under
+    ``amplifier update``, and a stale pin file would pin to a version that is no
+    longer there.
+    """
+    path = root / CONSTRAINTS_NAME
+    path.write_text("\n".join(base_constraints()) + "\n", encoding="utf-8")
+    return path
+
+
+def ensure_home_env(
+    home: Path | None = None,
+    *,
+    runner: Runner | None = None,
+) -> Path | None:
+    """Create this home's overlay if needed and return its interpreter.
+
+    Returns None when per-home environments are off, when ``uv`` is missing, or
+    when creation fails. Every one of those is a *fallback*, not an error: the
+    caller keeps using ``sys.executable``, which is exactly today's behavior,
+    and ``lib.venv_home_guard`` still converts the resulting cross-home
+    collision into a refusal on the next run. Failing loudly here would make a
+    missing ``uv`` fatal for a CLI that is otherwise perfectly able to run.
+
+    Args:
+        home: Override the home (tests). Defaults to the resolved AMPLIFIER_HOME.
+        runner: Override the subprocess runner (tests).
+
+    Returns:
+        Path to the overlay interpreter, or None to fall back.
+    """
+    if not is_enabled():
+        return None
+
+    root = home_env_root(home)
+    python = env_python(root)
+    run = subprocess.run if runner is None else runner
+
+    if not python.exists():
+        try:
+            root.parent.mkdir(parents=True, exist_ok=True)
+            result = run(
+                ["uv", "venv", "--python", sys.executable, str(root)],
+                capture_output=True,
+                text=True,
+            )
+        except FileNotFoundError:
+            logger.debug("per-home environment skipped: uv is not installed")
+            return None
+        except OSError as e:
+            logger.debug(f"per-home environment skipped: {e}")
+            return None
+        if result.returncode != 0:
+            logger.debug(
+                f"per-home environment skipped: uv venv exited "
+                f"{result.returncode}: {(result.stderr or '').strip()}"
+            )
+            return None
+        if not python.exists():
+            logger.debug(f"per-home environment skipped: {python} was not created")
+            return None
+
+    site_packages = env_site_packages(root)
+    if site_packages is None:
+        logger.debug(f"per-home environment skipped: no site-packages under {root}")
+        return None
+
+    try:
+        (site_packages / BASE_PTH_NAME).write_text(
+            f"{base_site_packages()}\n", encoding="utf-8"
+        )
+        write_constraints(root)
+    except OSError as e:
+        logger.debug(f"per-home environment skipped: {e}")
+        return None
+
+    return python
+
+
+def uv_target_args(
+    home: Path | None = None,
+    *,
+    runner: Runner | None = None,
+) -> list[str]:
+    """The ``uv pip install`` arguments that select where an install lands.
+
+    ``["--python", <overlay>, "--constraint", <pins>]`` when this home has its
+    own environment, and ``["--python", sys.executable]`` -- today's behavior --
+    whenever it does not. Call sites splice this in and need to know nothing
+    else.
+    """
+    python = ensure_home_env(home, runner=runner)
+    if python is None:
+        return ["--python", sys.executable]
+    return [
+        "--python",
+        str(python),
+        "--constraint",
+        str(home_env_root(home) / CONSTRAINTS_NAME),
+    ]
+
+
+def activate_home_env(home: Path | None = None) -> Path | None:
+    """Put this home's overlay on ``sys.path`` and return the directory added.
+
+    ``site.addsitedir`` *appends*, and that ordering is deliberate: the base
+    environment keeps winning for any package present in both, so the one copy
+    of a shared dependency that actually gets imported is the one Amplifier
+    shipped with. Modules only ever exist in the overlay, so nothing they need
+    is shadowed.
+
+    Returns None when there is nothing to activate (off, or not created yet).
+    """
+    if not is_enabled():
+        return None
+    site_packages = env_site_packages(home_env_root(home))
+    if site_packages is None:
+        return None
+    site.addsitedir(str(site_packages))
+    return site_packages
+
+
+__all__ = [
+    "BASE_PTH_NAME",
+    "CONSTRAINTS_NAME",
+    "ENABLE_ENV",
+    "ENV_DIR_NAME",
+    "activate_home_env",
+    "base_constraints",
+    "base_site_packages",
+    "ensure_home_env",
+    "env_python",
+    "env_site_packages",
+    "home_env_root",
+    "is_enabled",
+    "uv_target_args",
+    "write_constraints",
+]

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -4654,12 +4654,34 @@ def _guard_shared_venv_home() -> None:
         )
 
 
+def _activate_home_env() -> None:
+    """Put this AMPLIFIER_HOME's own Python environment on ``sys.path``.
+
+    Thin CLI wrapper: the behavior lives in ``lib.home_env``. It runs after the
+    guard because the guard describes the state this is meant to make
+    impossible, and before ``cli()`` because modules installed into the overlay
+    must be importable by everything the command then does.
+
+    A no-op unless ``AMPLIFIER_HOME_ENV`` is set -- see ``lib.home_env``.
+    """
+    from .lib.home_env import activate_home_env
+
+    try:
+        added = activate_home_env()
+    except Exception as e:  # pragma: no cover - must never be fatal
+        logger.debug(f"per-home environment activation skipped: {e}")
+        return
+    if added is not None:
+        logger.debug(f"per-home environment on sys.path: {added}")
+
+
 def main():
     """Main entry point."""
     _ensure_utf8_output()
     _configure_console_logging()
     _attach_llm_error_filter()
     _guard_shared_venv_home()
+    _activate_home_env()
     cli()
 
 

--- a/amplifier_app_cli/provider_manager.py
+++ b/amplifier_app_cli/provider_manager.py
@@ -6,6 +6,7 @@ import sys
 from dataclasses import dataclass
 from typing import Any
 
+from .lib.home_env import uv_target_args
 from .lib.settings import AppSettings
 from .lib.settings import ScopeType
 from .provider_loader import get_provider_info
@@ -402,8 +403,7 @@ class ProviderManager:
                                 "install",
                                 "-e",
                                 str(module_path),
-                                "--python",
-                                sys.executable,
+                                *uv_target_args(),
                             ],
                             capture_output=True,
                             text=True,

--- a/amplifier_app_cli/provider_sources.py
+++ b/amplifier_app_cli/provider_sources.py
@@ -6,11 +6,12 @@ import importlib.util
 import logging
 import site
 import subprocess
-import sys
 from typing import TYPE_CHECKING
 
 from rich.console import Console
 
+from .lib.home_env import activate_home_env
+from .lib.home_env import uv_target_args
 from .utils.error_format import escape_markup
 
 if TYPE_CHECKING:
@@ -314,8 +315,7 @@ def ensure_provider_installed(
                 "install",
                 "-e",
                 str(module_path),
-                "--python",
-                sys.executable,
+                *uv_target_args(),
                 "--refresh",  # Force fresh fetch from git sources
             ],
             capture_output=True,
@@ -329,6 +329,9 @@ def ensure_provider_installed(
         importlib.invalidate_caches()
         for site_dir in site.getsitepackages():
             site.addsitedir(site_dir)
+        # And this home's own environment, which is where the install landed
+        # when per-home environments are on (no-op when they are off).
+        activate_home_env()
         if hasattr(importlib.metadata, "distributions"):
             list(importlib.metadata.distributions())
 
@@ -399,6 +402,10 @@ def install_known_providers(
     # (e.g., provider-openai before provider-azure-openai)
     ordered_providers = _get_ordered_providers(sources)
 
+    # Resolve the install target once, not once per provider: it creates this
+    # home's environment on first use and rewrites its constraints file.
+    target_args = uv_target_args()
+
     for module_id, source_uri in ordered_providers:
         # Leave already-installed providers alone. Overwriting them would
         # discard the build the user actually has in place.
@@ -430,8 +437,7 @@ def install_known_providers(
                     "install",
                     "-e",
                     str(module_path),
-                    "--python",
-                    sys.executable,
+                    *target_args,
                 ],
                 capture_output=True,
                 text=True,
@@ -475,6 +481,7 @@ def install_known_providers(
         # Re-add site directories to ensure newly installed packages are found
         for site_dir in site.getsitepackages():
             site.addsitedir(site_dir)
+        activate_home_env()
 
         # Force refresh of importlib.metadata distributions cache
         if hasattr(importlib.metadata, "distributions"):

--- a/docs/designs/per-home-python-environment.md
+++ b/docs/designs/per-home-python-environment.md
@@ -311,7 +311,7 @@ provider modules isolated and everything else still colliding.
 
 ## 8. Open, and deliberately not done here
 
-1. **The foundation half** (§6) — filed as a linked follow-up item. Without it
+1. **The foundation half** (§6) — filed as `model_performance-zv3p`. Without it
    this is nine modules, not isolation.
 2. **The two-homes DTU verification** (§7) — blocked on 1.
 3. **Flip the default.** `AMPLIFIER_HOME_ENV` is opt-in in this PR. Partial

--- a/docs/designs/per-home-python-environment.md
+++ b/docs/designs/per-home-python-environment.md
@@ -1,0 +1,326 @@
+# A Python environment per `AMPLIFIER_HOME`
+
+**Status:** design + proof-of-concept, shipped opt-in. The default path is
+unchanged until the foundation half lands.
+**Work item:** `model_performance-xq95`, deferred from `model_performance-q99f`.
+**Spend:** $0. Every number below was measured on the host at no API cost; no
+DTU was needed, for the reason given in §7.
+
+---
+
+## 1. The defect, and why the guard is not the end of it
+
+`AMPLIFIER_HOME` isolates config, cache, registry and sessions. It does **not**
+isolate the Python environment. Modules are installed *editable* into the
+interpreter running Amplifier —
+
+```
+uv pip install -e <AMPLIFIER_HOME>/cache/<repo>-<16 hex>/... --python sys.executable
+```
+
+— and under `uv tool install` that interpreter is one venv per machine. Every
+`_editable_impl_<name>.pth` file in it encodes exactly one home's cache root, and
+the next run under a different home overwrites it.
+
+That is measured, not theorised. From
+[`docs/lanes/q99f-amplifier-home-pth-bug/FINDINGS.md`](../lanes/q99f-amplifier-home-pth-bug/FINDINGS.md),
+DTU `q99f-pth-repro`:
+
+| step | `.pth` total | → `home-a/cache` | → `home-b/cache` |
+|---|---:|---:|---:|
+| fresh install | 1 | 0 | 0 |
+| after run A (`AMPLIFIER_HOME=/root/home-a`) | 37 | 36 | 0 |
+| after run B (`AMPLIFIER_HOME=/root/home-b`) | 37 | 36 | 0 |
+| after `rm -rf /root/home-a/cache`, then run B | 37 | **27** | **9** |
+
+and, on the host that filed it, *"61 of 63 `_editable_impl_*.pth` files in the
+owner's real install were silently rewritten"*, repaired by hand from a backup.
+Run B's only visible symptom before that was one module's own self-check:
+
+> `_editable_impl_amplifier_module_tool_recipes.pth points at
+> /root/home-a/cache/…, but this engine was imported from /root/home-b/cache/…
+> — the two disagree about whose code runs.`
+
+`model_performance-q99f` shipped fix **(b)**: `lib/venv_home_guard.py` refuses to
+run when the environment's `.pth` files are owned by a foreign home. It stops the
+corruption. It does not remove the shared resource, so a user with two homes
+still cannot run both — they get a refusal instead of a silent rewrite. This
+document is fix **(a)**: give each home its own environment, so there is nothing
+left to refuse.
+
+---
+
+## 2. The shape: an overlay, not a second Amplifier
+
+The obvious reading of "per-home venv" is the one q99f measured as a manual
+remedy — `UV_TOOL_DIR=<home>/uv-tools uv tool install git+…` — a complete second
+Amplifier per home. Automating *that* means Amplifier provisioning an install of
+itself and re-exec'ing into it: minutes, network, and a duplicate of the whole
+stack per home.
+
+It is not necessary. The shared resource is not "Amplifier"; it is the one
+`site-packages` that runtime editable installs write into. So:
+
+> **Each home gets `<AMPLIFIER_HOME>/env/py<major>.<minor>` — a bare venv holding
+> only the packages Amplifier installs at runtime. Amplifier itself, and
+> everything it shipped with, stay in the base environment.**
+
+Two wires connect it:
+
+1. **Write side.** Every `uv pip install -e` targets the overlay's interpreter
+   instead of `sys.executable`.
+2. **Read side.** The running process calls `site.addsitedir(<overlay>)` at
+   startup and after each install, which is how modules installed there become
+   importable *in this process*.
+
+The overlay carries one `.pth` naming the base `site-packages`, so the overlay's
+own interpreter can still import Amplifier and its dependencies — needed for
+`uv`'s build step and for any subprocess that runs the overlay python directly.
+
+**No re-exec.** Re-exec costs a process restart on every invocation, needs the
+whole stack installed per home, and is fragile under `uv tool run`, `python -m`,
+editable dev checkouts, pytest, and Windows. The overlay reaches the same
+property — no shared writable resource — for a `site.addsitedir` call.
+
+### Measured, on this host (uv 0.12.6, CPython 3.13.11, `UV_OFFLINE=1`)
+
+| what | measurement |
+|---|---|
+| `uv venv --python <base>` | **0.374 s** wall, offline |
+| editable install of a module whose dep is already in the base env | **0.794 s** wall; uv reports *"Installed 5 packages in 6 ms"* |
+| base env `.pth` count, before / after that install | **75 / 75** |
+| overlay disk for one module + 4 deps | 7.2 MB apparent, hardlinked from uv's cache |
+
+And end-to-end, the q99f shape run through the library
+([`probe-overlay-isolation.sh`](../lanes/xq95-per-home-venv/probe-overlay-isolation.sh),
+output in `evidence/`), against the very uv tool venv that collided:
+
+```
+== base environment
+  /home/bkrabach/.local/share/uv/tools/amplifier/lib/python3.13/site-packages
+  .pth files before: 75
+== claims
+  PASS  base .pth count unchanged                            75
+  PASS  home-a .pth points into home-a                       yes
+  PASS  home-b .pth points into home-b                       yes
+  PASS  home-a survived home-b's install                     yes
+  PASS  base environment has no probe .pth                   0
+```
+
+The same probe with the feature off, against a throwaway base
+([`probe-fail-before.sh`](../lanes/xq95-per-home-venv/probe-fail-before.sh)):
+
+```
+  FAIL  base .pth count unchanged                            got 2, want 1
+  FAIL  home-a survived home-b's install                     got no (missing), want yes
+the shared .pth the two homes fought over, and who won:
+  _editable_impl_amplifier_module_probe.pth -> …/home-b/cache/amplifier-module-probe-…/src
+```
+
+That last line is q99f's flip, reproduced and then removed.
+
+---
+
+## 3. Mechanics
+
+### 3.1 Where, and keyed on what
+
+`<AMPLIFIER_HOME>/env/py<major>.<minor>`.
+
+Under the home, so it is destroyed with the home and shares its lifetime.
+Version-keyed on the *running* interpreter, so upgrading the base Python starts a
+fresh overlay instead of importing 3.13 builds into 3.14. The stale one is inert
+and can be deleted whenever.
+
+### 3.2 When created
+
+**Lazily, on the first install for that home** — not at startup.
+`ensure_home_env()` is called from `uv_target_args()`, which only the install
+call sites use. Startup pays only `activate_home_env()`, which is a directory
+check plus one `site.addsitedir` when the overlay exists, and returns
+immediately when it does not.
+
+### 3.3 Dependency resolution, and the one hazard it creates
+
+`uv` reads a venv's own `dist-info`; it does not follow the base `.pth`. Measured:
+`uv pip list` on a fresh overlay reports **0** packages while the base has **156**
+`dist-info` directories. So a module's dependencies that already exist in the base
+environment are *re-resolved into the overlay*. They come from uv's cache as
+hardlinks — the 6 ms above — so the cost is real but small.
+
+The hazard is not the duplication, it is the **version skew**. `site.addsitedir`
+appends, so for any package present in both, the **base copy wins at import**. A
+dependency resolved to a newer version in the overlay would be installed and then
+silently ignored — precisely the class of silent disagreement this whole item
+exists to end.
+
+**So every overlay install is passed a constraints file pinning each base
+distribution to its installed version.** An incompatible requirement then fails
+loudly at install time, naming both versions, instead of quietly at import time.
+Measured:
+
+```
+  rich>15.0.0
+and rich==15.0.0, we can conclude that amplifier-module-fake2==0.1.0
+cannot be used.
+```
+
+(exit 1, against a base pinned at `rich==15.0.0`.)
+
+The constraints file is rewritten on every `ensure`, because `amplifier update`
+changes the base environment and a stale pin would pin to a version that is gone.
+
+### 3.4 Ordering
+
+Base first, overlay appended. Deliberate: it is what makes "one copy of a shared
+dependency is the one Amplifier shipped with" true. Modules themselves exist only
+in the overlay, so nothing they provide is shadowed. A pre-existing base `.pth`
+for a module *would* shadow the overlay's copy — but only for the home that
+already owns it, pointing at the same cache path (§4), and for a foreign home the
+guard fires first.
+
+### 3.5 Fallback, and why it is a fallback
+
+`ensure_home_env()` returns `None` — and the caller silently keeps using
+`sys.executable` — when the feature is off, `uv` is missing, `uv venv` fails, or
+the overlay cannot be written. That is deliberate: making a missing `uv` fatal
+would break a CLI that is otherwise perfectly able to run, and the fallback is
+*recoverable* precisely because the q99f guard turns the resulting cross-home
+collision into a refusal on the next run. This is the strongest single argument
+for §5's conclusion.
+
+---
+
+## 4. Migration: an existing single-venv install
+
+**It is a no-op by construction, and nothing is stranded.**
+
+Today's base environment holds N editable `.pth` files owned by the default home
+(`~/.amplifier`). After this change, that home's *new* installs go to
+`~/.amplifier/env/pyX.Y`. The old `.pth` files keep working untouched: they point
+at `~/.amplifier/cache/...`, which still exists, and the base `site-packages` is
+still the running interpreter's own — first on `sys.path`, `.pth` files processed
+by normal `site` initialisation. No move, no rewrite, no reinstall.
+
+Three consequences worth stating rather than discovering:
+
+1. **The base environment stays mixed for a while.** A module installed before
+   the change resolves from the base; one installed after resolves from the
+   overlay. Both work. The mix drains naturally as modules are reinstalled or
+   updated, and can be drained deliberately with `amplifier reset --remove cache`
+   (which already forces a reinstall).
+2. **A foreign home's leftovers are still a conflict**, and still handled by the
+   q99f guard plus `amplifier reset`. This change prevents new ones; it does not
+   retroactively clean up an install that was already corrupted.
+3. **`amplifier reset` should learn about `<home>/env`.** It currently removes
+   `<home>/cache`; leaving the overlay behind after a cache wipe leaves editable
+   pointers into directories that no longer exist. Small, mechanical, and listed
+   in §8 rather than smuggled into this change.
+
+Explicitly **not** proposed: automatically moving existing base `.pth` files into
+the overlay. It buys nothing (they already work), and a partial move during an
+in-flight install is a new failure mode for no gain.
+
+---
+
+## 5. Does the q99f guard become unreachable? — argued both ways
+
+**The case that it does.** Once no editable install targets the base environment,
+no base `.pth` can name a `<home>/cache/<repo>-<16 hex>` path, so
+`detect_home_conflict()` returns `None` forever. On a green-field install the
+guard is dead code, and dead code that prints a scary message is a liability: it
+will one day fire on something that is not this defect (a dev checkout laid out
+like a cache entry, a vendored path) and cost someone an afternoon. The honest
+end state of a fix is that its tripwire is removed.
+
+**The case that it does not — and this is the recommendation: RETAIN.** Three
+reasons, in decreasing strength:
+
+1. **The fallback in §3.5 is a real, reachable code path.** No `uv`, an
+   unwritable home, a read-only filesystem, a locked-down CI image — any of them
+   sends installs straight back to `sys.executable`. The guard is what turns that
+   from a silent cross-home rewrite into a refusal naming both homes. Removing
+   the guard would mean the fallback has to become fatal instead, which trades a
+   rare loud failure for a common one.
+2. **The two halves ship on different release trains.** foundation's
+   `ModuleActivator` performs most editable installs (app-cli owns only the nine
+   provider modules). Between the two releases, a home is *partly* isolated —
+   exactly the window in which a tripwire earns its keep.
+3. **It costs approximately nothing.** It is a glob over `*.pth` and a path-prefix
+   comparison, on paths already in the page cache, before click dispatches. It
+   has no side effects and an escape hatch.
+
+There is also a fourth, softer reason: the guard is the only thing that will ever
+explain to a user with a *pre-existing* corrupted install what happened to them.
+That population does not shrink to zero on the day this ships.
+
+**Decision:** retain, unchanged in behaviour. One line should be added to its
+message once per-home environments are the default — *"this environment predates
+per-home environments; `amplifier reset --remove cache` will move these into
+`<home>/env`"* — so the message names the new remedy rather than only the old
+manual one.
+
+---
+
+## 6. The cross-repo split
+
+The isolation property needs both repos. app-cli alone cannot deliver it.
+
+| repo | change | risk |
+|---|---|---|
+| **amplifier-app-cli** | `lib/home_env.py` (the library); `main()` activation; the three `uv pip install -e` call sites (`provider_sources.py` ×2, `provider_manager.py` ×1) | low — this PR |
+| **amplifier-foundation** | `ModuleActivator._install_dependencies` takes the target interpreter from an injected policy rather than `sys.executable` | low, and *additive* |
+
+**Suggested seam, and ship order.** Give `ModuleActivator` an optional
+`install_python: str | None = None` (and an optional `install_constraints: Path |
+None`), defaulting to `sys.executable`. Foundation shipping that on its own
+changes **no** behaviour. app-cli then passes `home_env.uv_target_args()`'s
+values when it constructs the activator, and the property arrives with the
+second release. Foundation first, app-cli second; the reverse order leaves a
+release in which app-cli isolates providers while foundation does not, which is
+the confusing half-state §5.2 describes.
+
+Do **not** put `home_env` in foundation. The policy "where does this home install
+to" is a host decision, exactly like the rest of `amplifier_app_cli/paths.py`;
+foundation should receive the answer, not compute it.
+
+---
+
+## 7. Why no DTU was needed here
+
+q99f needed one because it reproduced a *behavioural* failure: run the real CLI
+under two homes and watch a real install get rewritten. That is unsafe on a host
+by definition — it is the incident.
+
+This lane's claims are about where an install *lands*, which can be established
+without invoking `amplifier` at all: the probe drives `uv` directly through the
+library, installs only into its own temp directories, and merely **reads** the
+base environment's `.pth` count before and after. The fail-before half builds its
+own throwaway base venv rather than borrowing a real one, because with the
+feature off the installs do land in the base — and pointing that at a real
+install is the corruption itself.
+
+**What a DTU is still needed for, and what it should assert** (the acceptance
+criteria this lane does not close — see §8): the real CLI, two homes, in
+sequence, asserting each home's `<home>/env/pyX.Y` holds its own ~36 `.pth` and
+the base environment's count does not move. That is the direct analogue of q99f's
+table and it needs the foundation half to exist first, or it will measure nine
+provider modules isolated and everything else still colliding.
+
+---
+
+## 8. Open, and deliberately not done here
+
+1. **The foundation half** (§6) — filed as a linked follow-up item. Without it
+   this is nine modules, not isolation.
+2. **The two-homes DTU verification** (§7) — blocked on 1.
+3. **Flip the default.** `AMPLIFIER_HOME_ENV` is opt-in in this PR. Partial
+   isolation by default is harder to reason about than today's honest collision
+   plus a guard.
+4. **`amplifier reset` should remove `<home>/env`** (§4.3).
+5. **Unmeasured: total overlay cost on a real home.** One module cost 7.2 MB
+   apparent / 6 ms. A real home activates dozens. The prediction is "hardlinks,
+   so near-zero incremental disk and under a second", and it is a prediction, not
+   a measurement.
+6. **Unmeasured: Windows.** The path branches (`Scripts/`, `Lib/site-packages`)
+   are written and unit-tested against a synthetic layout; no Windows run exists.

--- a/docs/lanes/xq95-per-home-venv/DONE-NOTE.md
+++ b/docs/lanes/xq95-per-home-venv/DONE-NOTE.md
@@ -4,6 +4,9 @@ Work item: `model_performance-xq95` (deferred fix **(a)** from
 `model_performance-q99f`). Spend authority: **$0**; **$0 spent** — no paid API
 measurement, and **no DTU was created**, for the reason argued in §5.
 
+Draft PR: [microsoft/amplifier-app-cli#326](https://github.com/microsoft/amplifier-app-cli/pull/326).
+Foundation follow-up filed: `model_performance-zv3p`.
+
 **Outcome branch: B — resolved at the cap.** The item flags itself as *"larger
 than a $0 lane"* and asks, if both cannot be funded, for the **design plus a
 proof-of-concept demonstrating the mechanism in one repo**. That is what shipped:
@@ -124,8 +127,8 @@ issue in this worktree, not a product regression. Delta from this branch: **0**.
 
 ## 8. Open / filed
 
-1. **The foundation half** — `ModuleActivator` install target. Filed as a linked
-   follow-up. Without it this is nine modules, not isolation.
+1. **The foundation half** — `ModuleActivator` install target. Filed as
+   `model_performance-zv3p` (discovered-from this item). Without it this is nine modules, not isolation.
 2. **The two-homes DTU verification** — blocked on 1 (§5).
 3. **Flip `AMPLIFIER_HOME_ENV` to default-on** — after 1 and 2.
 4. **`amplifier reset` should remove `<home>/env`** — it removes `<home>/cache`

--- a/docs/lanes/xq95-per-home-venv/DONE-NOTE.md
+++ b/docs/lanes/xq95-per-home-venv/DONE-NOTE.md
@@ -1,0 +1,148 @@
+# xq95 — a Python environment per `AMPLIFIER_HOME`
+
+Work item: `model_performance-xq95` (deferred fix **(a)** from
+`model_performance-q99f`). Spend authority: **$0**; **$0 spent** — no paid API
+measurement, and **no DTU was created**, for the reason argued in §5.
+
+**Outcome branch: B — resolved at the cap.** The item flags itself as *"larger
+than a $0 lane"* and asks, if both cannot be funded, for the **design plus a
+proof-of-concept demonstrating the mechanism in one repo**. That is what shipped:
+a design covering every question the acceptance criteria ask, and a working,
+measured, **opt-in** implementation of the app-cli half. The default path is
+byte-identical to today. The foundation half and the two-homes DTU verification
+are filed, not attempted.
+
+---
+
+## 1. What shipped
+
+| deliverable | state |
+|---|---|
+| Design for per-home Python environments | **DONE** — [`docs/designs/per-home-python-environment.md`](../../designs/per-home-python-environment.md) |
+| — creation: how and when | DONE — §3.1–3.2 |
+| — detection / routing (re-exec or otherwise) | DONE — §2, §3.4; re-exec **rejected**, with the reason |
+| — migration for an existing single-venv install | DONE — §4; no-op by construction, nothing stranded |
+| — is the q99f guard unreachable, or retained? | DONE — §5, argued both ways, **retain** |
+| Proof-of-concept, one repo | **DONE** — `amplifier_app_cli/lib/home_env.py`, opt-in behind `AMPLIFIER_HOME_ENV`, 40 tests |
+| Two-homes reproduction in a DTU (before/after) | **NOT-POSSIBLE at $0 *as specified*** — see §5. A host-safe equivalent of the *mechanism* claim was measured instead, fail-before and pass-after. |
+| Design quotes the q99f DTU findings as motivation | DONE — design §1 reproduces q99f's table and the verbatim symptom |
+
+## 2. The design, in five lines
+
+A home does **not** get a second Amplifier. It gets
+`<AMPLIFIER_HOME>/env/py<major>.<minor>` — a bare venv holding only what Amplifier
+installs at runtime — plus one `.pth` pointing back at the base environment.
+Installs target the overlay's interpreter; the running process reaches them with
+`site.addsitedir`. No re-exec, no duplicated stack, no shared writable resource.
+Every overlay install carries a constraints file pinning each base distribution,
+because the base wins at import and a silently-ignored version skew is the same
+class of bug all over again.
+
+## 3. Measured, on this host (uv 0.12.6, CPython 3.13.11, `UV_OFFLINE=1`, $0)
+
+| claim | measurement |
+|---|---|
+| overlay creation is cheap | `uv venv` **0.374 s**, offline |
+| an install into the overlay is cheap | **0.794 s** wall; uv: *"Installed 5 packages in 6 ms"* |
+| **the base environment does not move** | `.pth` count **75 → 75** against the real uv tool venv |
+| uv cannot see the base env from the overlay (the cost driver) | `uv pip list` on a fresh overlay: **0** packages, vs **156** `dist-info` in the base |
+| version skew fails loudly rather than silently | constrained install exits **1**, naming `rich>15.0.0` vs `rich==15.0.0` |
+
+## 4. Fail-before / pass-after
+
+`evidence/probe-overlay-isolation.txt` — the q99f shape (one module name, two
+home cache roots) routed through the library, against the real uv tool venv:
+
+```
+  PASS  base .pth count unchanged                            75
+  PASS  home-a .pth points into home-a                       yes
+  PASS  home-b .pth points into home-b                       yes
+  PASS  home-a survived home-b's install                     yes
+  PASS  base environment has no probe .pth                   0
+```
+
+`evidence/probe-fail-before.txt` — same probe, feature off, against a throwaway
+base venv:
+
+```
+  FAIL  base .pth count unchanged                            got 2, want 1
+  FAIL  home-a survived home-b's install                     got no (missing), want yes
+the shared .pth the two homes fought over, and who won:
+  _editable_impl_amplifier_module_probe.pth -> …/home-b/cache/amplifier-module-probe-…/src
+```
+
+That last line is q99f's measured flip, reproduced at $0 and then removed.
+
+Unit level: `tests/test_home_env.py`, **40 tests**, all fail against the shipped
+CLI (the module does not exist and the call sites hardcode `sys.executable`).
+
+## 5. Why no DTU — and what the DTU still owes
+
+The item and the lane rules require any *reproduction* to happen in a DTU. That
+requirement is about running the real CLI under a scratch `AMPLIFIER_HOME`, which
+is the incident itself. **No such run happened here, on the host or anywhere.**
+
+The claims this lane makes are narrower — *where does an editable install land* —
+and they are establishable without invoking `amplifier` at all. The probes drive
+`uv` directly through the library, write only into their own temp directories,
+and merely **read** the base environment's `.pth` count. The fail-before half
+builds its own throwaway base venv rather than borrowing a real one, precisely
+because with the feature off the installs do land in the base.
+
+**What the DTU still owes, and cannot be given yet:** the real CLI, two homes, in
+sequence, asserting each home's overlay holds its own ~36 `.pth` while the base
+count does not move. Running it *today* would measure nine provider modules
+isolated and every foundation-installed module still colliding — a misleading
+result. It is blocked on the foundation half, and filed with it.
+
+## 6. Cross-repo — the half this lane may not touch
+
+`ModuleActivator` in **amplifier-foundation** performs most editable installs;
+app-cli owns only the nine provider modules. **This lane was given
+amplifier-app-cli only and edited nothing else.**
+
+Proposed seam (design §6): `ModuleActivator` gains an optional
+`install_python: str | None = None` (plus `install_constraints: Path | None`)
+defaulting to `sys.executable`, so foundation can ship it with **zero** behaviour
+change; app-cli then passes `home_env.uv_target_args()`'s values. **Foundation
+first, app-cli second** — the reverse order creates a release where providers are
+isolated and nothing else is.
+
+Filed as a linked follow-up item (see §8).
+
+## 7. Test suite
+
+`1990 passed, 2 skipped, 13 deselected, 1 xfailed, 7 failed`.
+
+**The 7 failures are pre-existing on `origin/main` and unrelated.** Verified by
+`git stash`: the same 7 fail at `2e2d6a0` with this branch's changes removed.
+They are `tests/lib/bundle_loader/test_root_instruction_survives_behaviors.py`
+(5), `tests/test_fail_loud_bundle_activation.py` (1) and
+`tests/test_transitive_include_updates.py` (1); each fails cloning a fixture repo
+(`fatal: Remote branch <sha> not found in upstream origin`), i.e. an environment
+issue in this worktree, not a product regression. Delta from this branch: **0**.
+
+## 8. Open / filed
+
+1. **The foundation half** — `ModuleActivator` install target. Filed as a linked
+   follow-up. Without it this is nine modules, not isolation.
+2. **The two-homes DTU verification** — blocked on 1 (§5).
+3. **Flip `AMPLIFIER_HOME_ENV` to default-on** — after 1 and 2.
+4. **`amplifier reset` should remove `<home>/env`** — it removes `<home>/cache`
+   today, which would leave overlay pointers into deleted directories.
+5. **Unmeasured:** total overlay cost on a real home (dozens of modules, not
+   one), and Windows (the `Scripts/` / `Lib/site-packages` branches are
+   unit-tested against a synthetic layout, never run).
+
+## 9. Reproduce
+
+```bash
+# pass-after, against the environment that actually collided
+PROBE_PYTHON=~/.local/share/uv/tools/amplifier/bin/python \
+  bash docs/lanes/xq95-per-home-venv/probe-overlay-isolation.sh
+
+# fail-before, against a throwaway base it builds itself
+bash docs/lanes/xq95-per-home-venv/probe-fail-before.sh
+
+python -m pytest tests/test_home_env.py -q
+```

--- a/docs/lanes/xq95-per-home-venv/evidence/probe-fail-before.txt
+++ b/docs/lanes/xq95-per-home-venv/evidence/probe-fail-before.txt
@@ -1,0 +1,23 @@
+throwaway base: /tmp/xq95-failbefore.wlW4sc/base
+
+== base environment
+  /tmp/xq95-failbefore.wlW4sc/base/lib/python3.12/site-packages
+  .pth files before: 1
+
+== install the same module name from both homes
+  home-a -> /tmp/xq95-failbefore.wlW4sc/base/bin/python
+  home-b -> /tmp/xq95-failbefore.wlW4sc/base/bin/python
+
+== claims
+  FAIL  base .pth count unchanged                            got 2, want 1
+  FAIL  home-a has its own editable .pth                     got missing, want present
+  FAIL  home-b has its own editable .pth                     got missing, want present
+  FAIL  home-a survived home-b's install                     got no (missing), want yes
+  FAIL  base environment has no probe .pth                   got 1, want 0
+
+artifacts: /tmp/xq95-overlay.VQCVAG
+
+the shared .pth the two homes fought over, and who won:
+  _editable_impl_amplifier_module_probe.pth -> /tmp/xq95-overlay.VQCVAG/home-b/cache/amplifier-module-probe-0123456789abcdef/src
+
+exit 1  (non-zero is the expected fail-before result)

--- a/docs/lanes/xq95-per-home-venv/evidence/probe-overlay-isolation.txt
+++ b/docs/lanes/xq95-per-home-venv/evidence/probe-overlay-isolation.txt
@@ -1,0 +1,18 @@
+########## PASS-AFTER (real uv tool venv as base) ##########
+
+== base environment
+  /home/bkrabach/.local/share/uv/tools/amplifier/lib/python3.13/site-packages
+  .pth files before: 75
+
+== install the same module name from both homes
+  home-a -> /tmp/xq95-overlay.Jv52zd/home-a/env/py3.13/bin/python
+  home-b -> /tmp/xq95-overlay.Jv52zd/home-b/env/py3.13/bin/python
+
+== claims
+  PASS  base .pth count unchanged                            75
+  PASS  home-a .pth points into home-a                       yes
+  PASS  home-b .pth points into home-b                       yes
+  PASS  home-a survived home-b's install                     yes
+  PASS  base environment has no probe .pth                   0
+
+artifacts: /tmp/xq95-overlay.Jv52zd

--- a/docs/lanes/xq95-per-home-venv/probe-fail-before.sh
+++ b/docs/lanes/xq95-per-home-venv/probe-fail-before.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# The same two-homes probe with per-home environments OFF -- i.e. the shipped
+# behaviour -- run against a THROWAWAY base environment.
+#
+# The throwaway is not politeness. With the feature off, installs target the
+# base environment, so pointing this at a real install is precisely the
+# corruption q99f had to repair from a backup.
+#
+# Expect: FAILURES. That is the point -- it is the fail-before half of
+# probe-overlay-isolation.sh's pass-after.
+
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+D="$(mktemp -d "${TMPDIR:-/tmp}/xq95-failbefore.XXXXXX")"
+
+uv venv --python "$(command -v python3)" "$D/base" >/dev/null 2>&1 \
+  || { echo "could not create a throwaway base environment"; exit 2; }
+
+echo "throwaway base: $D/base"
+AMPLIFIER_HOME_ENV=0 PROBE_PYTHON="$D/base/bin/python" \
+  bash "$HERE/probe-overlay-isolation.sh"
+rc=$?
+echo
+echo "the shared .pth the two homes fought over, and who won:"
+for f in "$D"/base/lib/python*/site-packages/_editable_impl_amplifier_module_probe.pth; do
+  [ -f "$f" ] && printf '  %s -> %s\n' "$(basename "$f")" "$(head -1 "$f")"
+done
+echo
+echo "exit $rc  (non-zero is the expected fail-before result)"
+exit 0

--- a/docs/lanes/xq95-per-home-venv/probe-overlay-isolation.sh
+++ b/docs/lanes/xq95-per-home-venv/probe-overlay-isolation.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Two homes, one base environment: does the overlay actually isolate them?
+#
+# This is the q99f shape -- the SAME module name installed editable from two
+# different AMPLIFIER_HOME cache roots, which is what produces two writes to one
+# `_editable_impl_<name>.pth` filename -- run through
+# `amplifier_app_cli.lib.home_env.uv_target_args()` instead of `sys.executable`.
+#
+# SAFETY: this never invokes `amplifier`, never sets AMPLIFIER_HOME for a CLI
+# run, and writes nothing outside its own temp directory. It only READS the base
+# environment's `.pth` count, before and after, to prove it did not move. That
+# is why it is safe on a host, unlike the q99f behavioural reproduction, which
+# needed a DTU.
+#
+# Usage:  bash probe-overlay-isolation.sh
+#         PROBE_PYTHON=<interpreter> bash probe-overlay-isolation.sh
+#
+# PROBE_PYTHON selects the BASE environment under test. Point it at the uv tool
+# venv (`~/.local/share/uv/tools/amplifier/bin/python`) to run the claims
+# against the environment that actually collided.
+#
+# FAIL-BEFORE: set AMPLIFIER_HOME_ENV=0 to get the shipped behaviour (installs
+# target the base environment) and watch the same claims fail. Do that ONLY
+# against a throwaway base -- see probe-fail-before.sh, which builds one.
+#
+# Exit:   0 = isolated, 1 = a claim failed (each failure prints what it saw)
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+D="$(mktemp -d "${TMPDIR:-/tmp}/xq95-overlay.XXXXXX")"
+export REPO
+export AMPLIFIER_HOME_ENV="${AMPLIFIER_HOME_ENV:-1}"
+export UV_OFFLINE="${UV_OFFLINE:-1}"
+PY_BIN="${PROBE_PYTHON:-python3}"
+fail=0
+
+say() { printf '\n== %s\n' "$*"; }
+claim() { # claim <description> <actual> <expected>
+  if [ "$2" = "$3" ]; then printf '  PASS  %-52s %s\n' "$1" "$2"
+  else printf '  FAIL  %-52s got %s, want %s\n' "$1" "$2" "$3"; fail=1; fi
+}
+
+# The module is loaded by file path, not by importing the `amplifier_app_cli`
+# package: the package's __init__ pulls in click and the whole CLI, which a
+# throwaway base environment does not have. Same file either way.
+LOADER='
+import importlib.util, os, sys
+from pathlib import Path
+_spec = importlib.util.spec_from_file_location(
+    "xq95_home_env",
+    Path(os.environ["REPO"]) / "amplifier_app_cli" / "lib" / "home_env.py",
+)
+home_env = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(home_env)
+'
+
+BASE_SP="$("$PY_BIN" -c 'import sysconfig;print(sysconfig.get_paths()["purelib"])')"
+pth_count() { ls "$BASE_SP"/*.pth 2>/dev/null | wc -l | tr -d ' '; }
+
+say "base environment"
+echo "  $BASE_SP"
+BEFORE="$(pth_count)"
+echo "  .pth files before: $BEFORE"
+
+# One module source per home, under a cache path shaped exactly like
+# foundation's: <home>/cache/<repo>-<16 hex>.
+for home in home-a home-b; do
+  SRC="$D/$home/cache/amplifier-module-probe-0123456789abcdef"
+  mkdir -p "$SRC/src/amplifier_module_probe"
+  cat > "$SRC/pyproject.toml" <<EOF
+[project]
+name = "amplifier-module-probe"
+version = "0.1.0"
+requires-python = ">=3.11"
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+[tool.hatch.build.targets.wheel]
+packages = ["src/amplifier_module_probe"]
+EOF
+  printf 'HOME_NAME = "%s"\n' "$home" > "$SRC/src/amplifier_module_probe/__init__.py"
+done
+
+say "install the same module name from both homes"
+for home in home-a home-b; do
+  SRC="$D/$home/cache/amplifier-module-probe-0123456789abcdef"
+  mapfile -t UVARGS < <("$PY_BIN" -c "$LOADER"'
+print("\n".join(home_env.uv_target_args(Path(sys.argv[1]))))
+' "$D/$home")
+  printf '  %s -> %s\n' "$home" "${UVARGS[1]:-<none>}"
+  uv pip install -e "$SRC" "${UVARGS[@]}" >"$D/$home-install.log" 2>&1 \
+    || { echo "  install failed; see $D/$home-install.log"; fail=1; }
+done
+
+say "claims"
+claim "base .pth count unchanged" "$(pth_count)" "$BEFORE"
+
+overlay_pth() { # overlay_pth <home-dir>
+  "$PY_BIN" -c "$LOADER"'
+sp = home_env.env_site_packages(home_env.home_env_root(Path(sys.argv[1])))
+if sp is None:
+    print("")
+else:
+    p = sp / "_editable_impl_amplifier_module_probe.pth"
+    print(p.read_text().strip() if p.exists() else "")
+' "$1"
+}
+
+for home in home-a home-b; do
+  TARGET="$(overlay_pth "$D/$home")"
+  case "$TARGET" in
+    *"/$home/cache/"*) claim "$home .pth points into $home" yes yes ;;
+    "") claim "$home has its own editable .pth" missing present ;;
+    *) claim "$home .pth points into $home" "no ($TARGET)" yes ;;
+  esac
+done
+
+# The failure q99f measured: one filename, two homes, second write wins.
+A="$(overlay_pth "$D/home-a")"
+case "$A" in
+  *"/home-a/cache/"*) claim "home-a survived home-b's install" yes yes ;;
+  *) claim "home-a survived home-b's install" "no (${A:-missing})" yes ;;
+esac
+
+claim "base environment has no probe .pth" \
+  "$(ls "$BASE_SP"/_editable_impl_amplifier_module_probe.pth 2>/dev/null | wc -l | tr -d ' ')" 0
+
+printf '\nartifacts: %s\n' "$D"
+exit "$fail"

--- a/tests/test_home_env.py
+++ b/tests/test_home_env.py
@@ -1,0 +1,335 @@
+"""Editable installs must land in the home that asked for them.
+
+FAIL-BEFORE: every test here fails against the shipped CLI, where the install
+target is the literal ``sys.executable`` at three call sites and there is no
+per-home environment to land in.
+
+The behavior under test is the deeper fix for the incident recorded in
+``docs/lanes/q99f-amplifier-home-pth-bug/FINDINGS.md``: ``AMPLIFIER_HOME``
+selects the cache root but not the Python environment, so two homes write the
+same ``.pth`` filenames into one ``site-packages``. ``lib.venv_home_guard``
+refuses to run once that has happened; ``lib.home_env`` removes the shared
+resource so there is nothing to refuse.
+
+The isolation assertions below are the unit-level form of the host measurement
+quoted in ``docs/lanes/xq95-per-home-venv/FINDINGS.md``: an editable install
+directed at an overlay left the base environment's ``.pth`` count at 75 before
+and 75 after.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from amplifier_app_cli.lib.home_env import BASE_PTH_NAME
+from amplifier_app_cli.lib.home_env import CONSTRAINTS_NAME
+from amplifier_app_cli.lib.home_env import ENABLE_ENV
+from amplifier_app_cli.lib.home_env import activate_home_env
+from amplifier_app_cli.lib.home_env import base_constraints
+from amplifier_app_cli.lib.home_env import base_site_packages
+from amplifier_app_cli.lib.home_env import ensure_home_env
+from amplifier_app_cli.lib.home_env import env_python
+from amplifier_app_cli.lib.home_env import env_site_packages
+from amplifier_app_cli.lib.home_env import home_env_root
+from amplifier_app_cli.lib.home_env import is_enabled
+from amplifier_app_cli.lib.home_env import uv_target_args
+from amplifier_app_cli.lib.home_env import write_constraints
+
+PY_TAG = f"py{sys.version_info.major}.{sys.version_info.minor}"
+
+
+@pytest.fixture
+def on(monkeypatch):
+    """Per-home environments switched on for this test."""
+    monkeypatch.setenv(ENABLE_ENV, "1")
+
+
+def fake_venv(root: Path) -> Path:
+    """Materialize the parts of a venv this module reads, without running uv."""
+    if sys.platform == "win32":  # pragma: no cover - CI runs posix
+        site_packages = root / "Lib" / "site-packages"
+        python = root / "Scripts" / "python.exe"
+    else:
+        site_packages = root / "lib" / PY_TAG.replace("py", "python") / "site-packages"
+        python = root / "bin" / "python"
+    site_packages.mkdir(parents=True, exist_ok=True)
+    python.parent.mkdir(parents=True, exist_ok=True)
+    python.write_text("#!/bin/sh\n", encoding="utf-8")
+    return site_packages
+
+
+class RecordingRunner:
+    """A ``subprocess.run`` stand-in that creates the venv it is asked for."""
+
+    def __init__(self, *, returncode: int = 0, create: bool = True):
+        self.calls: list[list[str]] = []
+        self.returncode = returncode
+        self.create = create
+
+    def __call__(self, cmd, **kwargs):
+        self.calls.append(list(cmd))
+        if self.create and self.returncode == 0:
+            fake_venv(Path(cmd[-1]))
+        return subprocess.CompletedProcess(cmd, self.returncode, stdout="", stderr="")
+
+
+# --- the switch --------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " On "])
+def test_is_enabled_accepts_the_usual_truthy_spellings(value):
+    assert is_enabled({ENABLE_ENV: value}) is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "maybe"])
+def test_is_enabled_rejects_everything_else(value):
+    assert is_enabled({ENABLE_ENV: value}) is False
+
+
+def test_disabled_is_the_default(monkeypatch):
+    monkeypatch.delenv(ENABLE_ENV, raising=False)
+    assert is_enabled() is False
+
+
+# --- layout ------------------------------------------------------------------
+
+
+def test_root_is_under_the_home_and_keyed_by_interpreter_version(tmp_path):
+    root = home_env_root(tmp_path)
+    assert root == tmp_path / "env" / PY_TAG
+    # Version-keyed so a base-interpreter upgrade starts a fresh overlay rather
+    # than importing 3.13 builds into 3.14.
+    assert PY_TAG in root.parts
+
+
+def test_two_homes_get_two_roots(tmp_path):
+    a = home_env_root(tmp_path / "home-a")
+    b = home_env_root(tmp_path / "home-b")
+    assert a != b
+    assert not str(a).startswith(str(b))
+
+
+def test_env_python_exists_as_a_path_before_the_venv_does(tmp_path):
+    python = env_python(home_env_root(tmp_path))
+    assert python.name.startswith("python")
+    assert not python.exists()
+
+
+def test_site_packages_is_none_until_the_venv_exists(tmp_path):
+    assert env_site_packages(home_env_root(tmp_path)) is None
+
+
+def test_site_packages_found_once_the_venv_exists(tmp_path):
+    root = home_env_root(tmp_path)
+    expected = fake_venv(root)
+    assert env_site_packages(root) == expected
+
+
+# --- constraints -------------------------------------------------------------
+
+
+def test_base_constraints_pin_every_installed_distribution():
+    pins = base_constraints()
+    assert pins, "the running environment always has distributions installed"
+    assert all("==" in pin for pin in pins)
+    names = [pin.split("==")[0] for pin in pins]
+    assert names == sorted(names), "stable order keeps the file diff-friendly"
+    assert len(names) == len(set(names)), "one pin per distribution, no duplicates"
+
+
+def test_base_constraints_pin_a_distribution_that_is_certainly_present():
+    """``pytest`` is running this test, so it is installed by construction."""
+    assert any(pin.lower().startswith("pytest==") for pin in base_constraints())
+
+
+def test_write_constraints_lands_in_the_overlay(tmp_path):
+    root = tmp_path / "env"
+    root.mkdir()
+    path = write_constraints(root)
+    assert path == root / CONSTRAINTS_NAME
+    assert path.read_text(encoding="utf-8").splitlines() == base_constraints()
+
+
+# --- creation ----------------------------------------------------------------
+
+
+def test_ensure_is_a_no_op_while_disabled(monkeypatch, tmp_path):
+    monkeypatch.delenv(ENABLE_ENV, raising=False)
+    runner = RecordingRunner()
+    assert ensure_home_env(tmp_path, runner=runner) is None
+    assert runner.calls == [], "nothing may be created while the feature is off"
+
+
+def test_ensure_creates_the_overlay_with_uv(on, tmp_path):
+    runner = RecordingRunner()
+    python = ensure_home_env(tmp_path, runner=runner)
+    assert python == env_python(home_env_root(tmp_path))
+    assert len(runner.calls) == 1
+    cmd = runner.calls[0]
+    assert cmd[:2] == ["uv", "venv"]
+    assert cmd[-1] == str(home_env_root(tmp_path))
+    # Built from the interpreter Amplifier is running on, so the overlay can
+    # import the base environment's packages through the base .pth.
+    assert sys.executable in cmd
+
+
+def test_ensure_writes_the_base_pointer(on, tmp_path):
+    ensure_home_env(tmp_path, runner=RecordingRunner())
+    site_packages = env_site_packages(home_env_root(tmp_path))
+    assert site_packages is not None
+    pth = site_packages / BASE_PTH_NAME
+    assert pth.read_text(encoding="utf-8").strip() == str(base_site_packages())
+
+
+def test_ensure_writes_the_constraints_file(on, tmp_path):
+    ensure_home_env(tmp_path, runner=RecordingRunner())
+    assert (home_env_root(tmp_path) / CONSTRAINTS_NAME).exists()
+
+
+def test_ensure_is_idempotent_and_does_not_rerun_uv(on, tmp_path):
+    runner = RecordingRunner()
+    ensure_home_env(tmp_path, runner=runner)
+    ensure_home_env(tmp_path, runner=runner)
+    assert len(runner.calls) == 1
+
+
+def test_ensure_refreshes_the_constraints_on_every_call(on, tmp_path):
+    ensure_home_env(tmp_path, runner=RecordingRunner())
+    constraints = home_env_root(tmp_path) / CONSTRAINTS_NAME
+    constraints.write_text("stale==0.0.0\n", encoding="utf-8")
+    ensure_home_env(tmp_path, runner=RecordingRunner())
+    assert "stale==0.0.0" not in constraints.read_text(encoding="utf-8")
+
+
+# --- fallback: never fatal ---------------------------------------------------
+
+
+def test_missing_uv_falls_back_instead_of_raising(on, tmp_path):
+    def no_uv(cmd, **kwargs):
+        raise FileNotFoundError("uv")
+
+    assert ensure_home_env(tmp_path, runner=no_uv) is None
+
+
+def test_failed_creation_falls_back_instead_of_raising(on, tmp_path):
+    runner = RecordingRunner(returncode=1, create=False)
+    assert ensure_home_env(tmp_path, runner=runner) is None
+
+
+def test_silent_creation_failure_falls_back(on, tmp_path):
+    """uv exits 0 but writes nothing -- still a fallback, never a claim."""
+    runner = RecordingRunner(returncode=0, create=False)
+    assert ensure_home_env(tmp_path, runner=runner) is None
+
+
+# --- what the call sites splice in -------------------------------------------
+
+
+def test_uv_args_are_todays_behavior_while_disabled(monkeypatch, tmp_path):
+    monkeypatch.delenv(ENABLE_ENV, raising=False)
+    assert uv_target_args(tmp_path) == ["--python", sys.executable]
+
+
+def test_uv_args_target_the_overlay_when_enabled(on, tmp_path):
+    args = uv_target_args(tmp_path, runner=RecordingRunner())
+    root = home_env_root(tmp_path)
+    assert args == [
+        "--python",
+        str(env_python(root)),
+        "--constraint",
+        str(root / CONSTRAINTS_NAME),
+    ]
+
+
+def test_uv_args_never_target_the_base_environment_when_enabled(on, tmp_path):
+    args = uv_target_args(tmp_path, runner=RecordingRunner())
+    assert sys.executable not in args, (
+        "an install directed at sys.executable is exactly the collision this fixes"
+    )
+
+
+def test_uv_args_fall_back_to_the_base_environment_when_uv_is_missing(on, tmp_path):
+    def no_uv(cmd, **kwargs):
+        raise FileNotFoundError("uv")
+
+    # The fallback is deliberate: venv_home_guard turns the resulting cross-home
+    # collision into a refusal on the next run, so falling back is recoverable
+    # while making a missing uv fatal would not be.
+    assert uv_target_args(tmp_path, runner=no_uv) == ["--python", sys.executable]
+
+
+def test_two_homes_get_two_install_targets(on, tmp_path):
+    a = uv_target_args(tmp_path / "home-a", runner=RecordingRunner())
+    b = uv_target_args(tmp_path / "home-b", runner=RecordingRunner())
+    assert a[1] != b[1]
+    assert "home-a" in a[1] and "home-b" in b[1]
+
+
+# --- activation --------------------------------------------------------------
+
+
+def test_activate_is_a_no_op_while_disabled(monkeypatch, tmp_path):
+    monkeypatch.delenv(ENABLE_ENV, raising=False)
+    fake_venv(home_env_root(tmp_path))
+    before = list(sys.path)
+    assert activate_home_env(tmp_path) is None
+    assert sys.path == before
+
+
+def test_activate_is_a_no_op_when_the_overlay_does_not_exist(on, tmp_path):
+    before = list(sys.path)
+    assert activate_home_env(tmp_path) is None
+    assert sys.path == before
+
+
+def test_activate_appends_the_overlay(on, tmp_path, monkeypatch):
+    site_packages = fake_venv(home_env_root(tmp_path))
+    monkeypatch.setattr(sys, "path", list(sys.path))
+    added = activate_home_env(tmp_path)
+    assert added == site_packages
+    assert str(site_packages) in sys.path
+
+
+def test_activate_leaves_the_base_environment_ahead_of_the_overlay(
+    on, tmp_path, monkeypatch
+):
+    """Ordering is the reason a shared dependency resolves to one copy.
+
+    ``site.addsitedir`` appends, so a package present in both environments is
+    imported from the base one. Constraints then make a *different* version in
+    the overlay impossible, which is what keeps that ordering safe rather than
+    merely lucky.
+    """
+    site_packages = fake_venv(home_env_root(tmp_path))
+    base = str(base_site_packages())
+    monkeypatch.setattr(sys, "path", [base, *sys.path])
+    activate_home_env(tmp_path)
+    assert sys.path.index(base) < sys.path.index(str(site_packages))
+
+
+# --- the call sites actually route through the library -----------------------
+
+
+def test_provider_install_sites_no_longer_name_sys_executable():
+    """The three ``uv pip install -e`` call sites this repo owns.
+
+    Named individually rather than grepped for, so a future call site that
+    reintroduces ``sys.executable`` is caught by review of this list, not by
+    silence.
+    """
+    from amplifier_app_cli import provider_manager
+    from amplifier_app_cli import provider_sources
+
+    for module in (provider_sources, provider_manager):
+        source = Path(module.__file__).read_text(encoding="utf-8")
+        install_blocks = source.count('"install",')
+        assert install_blocks > 0, f"{module.__name__} installs nothing any more?"
+        assert "sys.executable" not in source, (
+            f"{module.__name__} still hardcodes the base environment as the "
+            "install target; route it through home_env.uv_target_args()"
+        )
+        assert "uv_target_args" in source


### PR DESCRIPTION
## What and why

`AMPLIFIER_HOME` isolates config, cache, registry and sessions. It does **not**
isolate the Python environment — modules are installed editable into
`sys.executable`, which under `uv tool install` is one venv per machine. Two
homes write the same `_editable_impl_<name>.pth` filenames into one
`site-packages`, and the second run silently repoints the first.

That is the defect `model_performance-q99f` measured in DTU `q99f-pth-repro`
(quoted verbatim in the design):

| step | `.pth` total | -> `home-a/cache` | -> `home-b/cache` |
|---|---:|---:|---:|
| after run A (`AMPLIFIER_HOME=/root/home-a`) | 37 | 36 | 0 |
| after run B (`AMPLIFIER_HOME=/root/home-b`) | 37 | 36 | 0 |
| after home-a's cache is deleted, then run B | 37 | **27** | **9** |

...and on the host that filed it, *"61 of 63 `_editable_impl_*.pth` files in the
owner's real install were silently rewritten"*, repaired by hand from a backup.
q99f shipped fix **(b)** — `lib/venv_home_guard.py`, which refuses to run once it
has happened (#325). It stops the corruption; it does not remove the shared
resource. **This is fix (a):** remove the shared resource, so there is nothing
left to refuse.

## The shape: an overlay, not a second Amplifier

The obvious reading — a whole second `uv tool install` per home, with Amplifier
re-exec'ing into it — is minutes, network, and a duplicate stack per home. It is
not necessary. The shared resource is not "Amplifier"; it is the one
`site-packages` that *runtime* editable installs write into.

So each home gets **`<AMPLIFIER_HOME>/env/py<major>.<minor>`** — a bare venv
holding only what Amplifier installs at runtime, plus one `.pth` pointing back at
the base environment. Installs target the overlay's interpreter; the running
process reaches them with `site.addsitedir`. **No re-exec, no duplicated stack.**

Every overlay install carries a constraints file pinning each base distribution,
because `site.addsitedir` appends and the base therefore wins at import — an
unpinned overlay could install a newer dependency that is then silently ignored,
which is the same class of quiet disagreement this item exists to end. Pinned, it
fails loudly at install time instead.

## Opt-in, and why

Behind `AMPLIFIER_HOME_ENV`, **default off**. foundation's `ModuleActivator`
performs most editable installs and still targets `sys.executable`; this repo
owns only the nine provider modules. Isolating those alone would make a home
*partly* isolated, which is harder to reason about than today's honest collision
plus the guard. With the flag unset every entry point is a no-op and
`uv_target_args()` returns today's exact arguments — verified by test.

## Measured, at $0 (uv 0.12.6, CPython 3.13.11, `UV_OFFLINE=1`)

| claim | measurement |
|---|---|
| overlay creation is cheap | `uv venv` **0.374 s**, offline |
| an install into it is cheap | **0.794 s** wall; uv: *"Installed 5 packages in 6 ms"* |
| **the base environment does not move** | `.pth` count **75 -> 75** against the real uv tool venv |
| uv cannot see the base env from the overlay (the cost driver) | `uv pip list` on a fresh overlay: **0** packages vs **156** `dist-info` in the base |
| version skew fails loudly | constrained install exits **1**, naming `rich>15.0.0` vs `rich==15.0.0` |

**Pass-after** — the q99f shape (one module name, two home cache roots) routed
through the library, against the very venv that collided:

```
  PASS  base .pth count unchanged                            75
  PASS  home-a .pth points into home-a                       yes
  PASS  home-b .pth points into home-b                       yes
  PASS  home-a survived home-b's install                     yes
  PASS  base environment has no probe .pth                   0
```

**Fail-before** — same probe, feature off, against a throwaway base venv it
builds itself:

```
  FAIL  base .pth count unchanged                            got 2, want 1
  FAIL  home-a survived home-b's install                     got no (missing), want yes
the shared .pth the two homes fought over, and who won:
  _editable_impl_amplifier_module_probe.pth -> .../home-b/cache/amplifier-module-probe-.../src
```

That last line is q99f's measured flip, reproduced at $0 and then removed.

## Migration: nothing is stranded

**A no-op by construction.** Existing base `.pth` files point at
`~/.amplifier/cache/...`, which still exists, in the running interpreter's own
`site-packages`, still first on `sys.path`. They keep working untouched; only
*new* installs go to the overlay. The base drains naturally as modules are
reinstalled, or deliberately via `amplifier reset --remove cache`. Automatically
moving them is explicitly **not** proposed — it buys nothing and adds a failure
mode.

## Does the q99f guard become unreachable? — retained, deliberately

Argued both ways in design section 5. **Recommendation: retain, unchanged.** The
strongest reason is that `ensure_home_env()` has a real fallback path — no `uv`,
unwritable home, read-only FS — that sends installs straight back to
`sys.executable`. The guard is what turns that from a silent cross-home rewrite
into a refusal naming both homes. Removing it would force the fallback to become
fatal instead. Secondary: the two repos ship on different trains, so there is a
window where a home is only partly isolated; and the guard costs a `*.pth` glob
with an escape hatch.

## Scope — the foundation half is NOT here

`ModuleActivator` (amplifier-foundation) does most editable installs. This lane
was given amplifier-app-cli only and edited nothing else. Proposed seam:
`ModuleActivator` gains an optional `install_python: str | None = None` (plus
`install_constraints`) defaulting to `sys.executable`, so foundation can ship it
with **zero** behaviour change; app-cli then passes it. **Foundation first,
app-cli second.** Filed as a linked follow-up.

**Also still open:** the two-homes DTU verification. Running it today would
measure nine provider modules isolated and every foundation-installed module
still colliding — a misleading result. Blocked on the foundation half.

## Tests

- `tests/test_home_env.py` — **40 tests**, all fail against `main` (the module
  does not exist; the call sites hardcode `sys.executable`).
- Full suite: `1990 passed, 2 skipped, 13 deselected, 1 xfailed, 7 failed`. The
  **7 failures are pre-existing on `origin/main`** — verified by `git stash`,
  same 7 fail at `2e2d6a0` without this branch's changes. Each fails cloning a
  fixture repo (`fatal: Remote branch <sha> not found in upstream origin`), an
  environment issue in this worktree. Delta from this branch: **0**.

## Review pointers

- `docs/designs/per-home-python-environment.md` — the design, including
  alternatives rejected and the six things left unmeasured.
- `docs/lanes/xq95-per-home-venv/` — probes, evidence, lane record.

Work item: `model_performance-xq95`.
