### PR TITLE
fix(cli): preserve provider instances and child prompt isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,3 +34,13 @@ that load on demand (skills, agent-scoped context) over anything injected uncond
 
 This section exists to keep `data/` from becoming a junk drawer — re-run the three tests
 before adding, not after.
+
+## In-process self-child prompts
+
+For `agent_name: self`, `session_spawner` must build a new foundation prompt
+factory for the target child from the root prepared bundle, render it once, and
+install only that frozen result. Never copy or await a parent's installed
+context factory: hooks can wrap it with parent-specific state. Persist a
+nonempty resolved snapshot only in sub-session persistence metadata, never in
+`session.metadata` telemetry; keep subprocess self dispatch as its explicit
+legacy limitation.

--- a/amplifier_app_cli/commands/provider.py
+++ b/amplifier_app_cli/commands/provider.py
@@ -1133,13 +1133,27 @@ def provider_models(ctx: click.Context, provider_id: str | None) -> None:
             ctx.exit(1)
         provider_id = current.module_id
 
-    # Normalize provider ID (handle both "anthropic" and "provider-anthropic")
-    module_id = _normalize_module_id(provider_id)
-    display = _display_name(module_id)
-
-    # Get stored provider config (for credentials/endpoints)
-    manager = ProviderManager(config_manager)
-    stored_config = manager.get_provider_config(module_id)
+    # Resolve configured instance ids before normalizing module aliases.  An
+    # instance id such as "astra-fixture" is not itself a module, and turning
+    # it into "provider-astra-fixture" would lose the entry's module and
+    # per-instance endpoint/credentials.  _find_provider_entry delegates to
+    # the shared resolver, which checks exact ids first and applies the normal
+    # priority rule only for module aliases.
+    entry = _find_provider_entry(_get_settings().get_provider_overrides(), provider_id)
+    if entry is not None:
+        module_id = _normalize_module_id(entry["module"])
+        stored_config = entry.get("config", {})
+        display = (
+            provider_id
+            if entry.get("id") == provider_id
+            else _display_name(module_id)
+        )
+    else:
+        # Preserve the original fallback for an unconfigured module alias.
+        module_id = _normalize_module_id(provider_id)
+        display = _display_name(module_id)
+        manager = ProviderManager(config_manager)
+        stored_config = manager.get_provider_config(module_id)
 
     # Fetch models
     try:

--- a/amplifier_app_cli/commands/routing.py
+++ b/amplifier_app_cli/commands/routing.py
@@ -19,6 +19,7 @@ from amplifier_foundation.paths.resolution import get_amplifier_home
 from ..lib.bundle_loader.discovery import WELL_KNOWN_BUNDLES
 from ..lib.routing_provenance import resolve_matrix_origins, resolve_winning_paths
 from ..lib.settings import AppSettings, Scope, get_custom_routing_dir
+from ..provider_config_utils import _should_show_field
 from ..provider_loader import get_provider_info, get_provider_models
 from ..provider_manager import resolve_provider_entry
 from ..ui.item_renderer import ItemRenderer
@@ -1671,21 +1672,11 @@ def _edit_role(
             description = field_dict.get("description", "")
 
             # Check show_when conditions (simple key=value evaluation)
-            show_when = field_dict.get("show_when")
-            if show_when:
-                should_show = True
-                for sw_key, sw_val in show_when.items():
-                    current_val = str(candidate_config.get(sw_key, ""))
-                    if sw_val.startswith("contains:"):
-                        if sw_val[9:] not in current_val:
-                            should_show = False
-                    elif sw_val.startswith("not_contains:"):
-                        if sw_val[13:] in current_val:
-                            should_show = False
-                    elif current_val != sw_val:
-                        should_show = False
-                if not should_show:
-                    continue
+            # The selected model lives alongside config in a routing candidate,
+            # but model-dependent fields still need it to evaluate show_when.
+            predicate_context = {**candidate_config, "default_model": selected_model}
+            if not _should_show_field(field_dict, predicate_context):
+                continue
 
             try:
                 if description:

--- a/amplifier_app_cli/commands/tool.py
+++ b/amplifier_app_cli/commands/tool.py
@@ -433,7 +433,7 @@ async def _invoke_tool_from_bundle_async(
     await session.initialize()
 
     # Register session spawning (enables tools like recipes to spawn sub-sessions)
-    register_session_spawning(session)
+    register_session_spawning(session, prepared_bundle=prepared_bundle)
 
     failed = False
     try:

--- a/amplifier_app_cli/provider_config_utils.py
+++ b/amplifier_app_cli/provider_config_utils.py
@@ -363,6 +363,7 @@ def _should_show_field(field: dict[str, Any], collected_config: dict[str, Any]) 
         - "not_contains:substring" - Match if actual value does NOT contain substring
         - "startswith:prefix" - Match if actual value starts with prefix
         - "not_startswith:prefix" - Match if actual value does NOT start with prefix
+        - "matches:regex" - Match if actual value matches a case-insensitive regex
     """
     show_when = field.get("show_when")
     if not show_when:
@@ -375,7 +376,13 @@ def _should_show_field(field: dict[str, Any], collected_config: dict[str, Any]) 
         expected_str = str(expected_value).lower()
 
         # Check for pattern matching prefixes
-        if expected_str.startswith("not_contains:"):
+        if expected_str.startswith("matches:"):
+            try:
+                if re.search(str(expected_value)[8:], actual_value, re.IGNORECASE) is None:
+                    return False
+            except re.error:
+                return False
+        elif expected_str.startswith("not_contains:"):
             pattern = expected_str[13:]  # Remove "not_contains:" prefix
             if pattern in actual_value:
                 return False

--- a/amplifier_app_cli/session_runner.py
+++ b/amplifier_app_cli/session_runner.py
@@ -574,7 +574,7 @@ async def _create_bundle_session(
     register_mention_handling(session)
 
     # Step 6: Register session spawning
-    register_session_spawning(session)
+    register_session_spawning(session, prepared_bundle=prepared_bundle)
 
     return session
 
@@ -604,7 +604,9 @@ def register_mention_handling(session: AmplifierSession) -> None:
     session.coordinator.register_capability("mention_resolver", mention_resolver)
 
 
-def register_session_spawning(session: AmplifierSession) -> None:
+def register_session_spawning(
+    session: AmplifierSession, prepared_bundle: Any | None = None
+) -> None:
     """Register session spawning capabilities for agent delegation.
 
     This is app-layer policy that enables kernel modules (like tool-task) to
@@ -619,7 +621,16 @@ def register_session_spawning(session: AmplifierSession) -> None:
 
     Args:
         session: The AmplifierSession to register capabilities on
+        prepared_bundle: Optional root PreparedBundle. When supplied, register
+            its clean public prompt-factory builder for in-process self
+            delegation before the standard spawning capabilities. Omitted for
+            backwards compatibility with external callers and child sessions.
     """
+    if prepared_bundle is not None:
+        from .session_spawner import register_base_system_prompt_builder
+
+        register_base_system_prompt_builder(session, prepared_bundle)
+
     from .session_spawner import get_partial_output
     from .session_spawner import resume_sub_session
     from .session_spawner import spawn_sub_session

--- a/amplifier_app_cli/session_spawner.py
+++ b/amplifier_app_cli/session_spawner.py
@@ -20,6 +20,139 @@ from .agent_config import merge_configs
 
 logger = logging.getLogger(__name__)
 
+BASE_SYSTEM_PROMPT_BUILDER_CAPABILITY = "session.base_system_prompt_builder"
+BASE_SYSTEM_PROMPT_BUILDER_ERROR_CAPABILITY = (
+    "session.base_system_prompt_builder_error"
+)
+SYSTEM_PROMPT_SNAPSHOT_KEY = "base-prompt-snapshot"
+SYSTEM_PROMPT_SNAPSHOT_SCHEMA = 1
+
+
+def _prepared_bundle_has_system_prompt_source(prepared_bundle: Any) -> bool:
+    """Match foundation's factory-registration eligibility without rendering."""
+    bundle = getattr(prepared_bundle, "bundle", None)
+    return bool(
+        bundle
+        and (
+            getattr(bundle, "instruction", None)
+            or getattr(bundle, "context", None)
+            or getattr(bundle, "_pending_context", None)
+        )
+    )
+
+
+def register_base_system_prompt_builder(
+    session: "AmplifierSession", prepared_bundle: Any
+) -> None:
+    """Register a clean root-prompt builder without retaining parent context."""
+    if not _prepared_bundle_has_system_prompt_source(prepared_bundle):
+        return
+
+    if not callable(
+        getattr(prepared_bundle, "create_system_prompt_factory", None)
+    ):
+        session.coordinator.register_capability(
+            BASE_SYSTEM_PROMPT_BUILDER_ERROR_CAPABILITY,
+            "Self delegation requires amplifier-foundation with the public "
+            "PreparedBundle.create_system_prompt_factory API because this root "
+            "bundle has prompt sources. Upgrade amplifier-foundation, then start "
+            "a new self delegation.",
+        )
+        return
+
+    def build_for(target_session: "AmplifierSession"):
+        target_cwd = target_session.coordinator.get_capability("session.working_dir")
+        return prepared_bundle.create_system_prompt_factory(
+            target_session,
+            session_cwd=Path(target_cwd) if target_cwd else None,
+        )
+
+    session.coordinator.register_capability(
+        BASE_SYSTEM_PROMPT_BUILDER_CAPABILITY, build_for
+    )
+
+
+def _get_self_base_prompt_builder(parent_session: "AmplifierSession"):
+    """Return the safe builder or fail when a source-bearing root lacks its API."""
+    builder = parent_session.coordinator.get_capability(
+        BASE_SYSTEM_PROMPT_BUILDER_CAPABILITY
+    )
+    if callable(builder):
+        return builder
+
+    error = parent_session.coordinator.get_capability(
+        BASE_SYSTEM_PROMPT_BUILDER_ERROR_CAPABILITY
+    )
+    if error:
+        raise RuntimeError(str(error))
+    return None
+
+
+def _load_system_prompt_snapshot(metadata: dict[str, Any]) -> str:
+    """Return a valid persisted snapshot, never a guessed reconstruction."""
+    persisted_snapshot = metadata.get(SYSTEM_PROMPT_SNAPSHOT_KEY)
+    if (
+        isinstance(persisted_snapshot, dict)
+        and persisted_snapshot.get("schema") == SYSTEM_PROMPT_SNAPSHOT_SCHEMA
+        and isinstance(persisted_snapshot.get("content"), str)
+        and persisted_snapshot["content"]
+    ):
+        return persisted_snapshot["content"]
+    return ""
+
+
+def _register_frozen_base_system_prompt_builder(
+    session: "AmplifierSession", snapshot: str
+) -> None:
+    """Let nested self-delegation reuse an immutable resolved base prompt."""
+
+    def build_for(_target_session: "AmplifierSession"):
+        async def factory() -> str:
+            return snapshot
+
+        return factory
+
+    session.coordinator.register_capability(
+        BASE_SYSTEM_PROMPT_BUILDER_CAPABILITY, build_for
+    )
+
+
+async def _install_frozen_system_prompt(context: Any, snapshot: str) -> bool:
+    """Install a frozen base prompt without importing any parent factory."""
+    if not snapshot:
+        return False
+    if hasattr(context, "set_system_prompt_factory"):
+        async def factory() -> str:
+            return snapshot
+
+        await context.set_system_prompt_factory(factory)
+        return True
+    if hasattr(context, "add_message"):
+        await context.add_message({"role": "system", "content": snapshot})
+        return True
+    return False
+
+
+async def _expand_system_instruction(
+    instruction: str, child_session: "AmplifierSession"
+) -> str:
+    """Expand one source using state local to the child and this source."""
+    resolver = child_session.coordinator.get_capability("mention_resolver")
+    if resolver is None:
+        return instruction
+
+    from amplifier_foundation.mentions import ContentDeduplicator
+    from amplifier_foundation.mentions import expand_mentions_in_instruction
+
+    working_dir = child_session.coordinator.get_capability("session.working_dir")
+    return await expand_mentions_in_instruction(
+        instruction,
+        resolver=resolver,
+        # Persona and task text must not deduplicate one another.
+        deduplicator=ContentDeduplicator(),
+        relative_to=Path(working_dir) if working_dir else Path.cwd(),
+    )
+
 
 # =============================================================================
 # Partial-output preservation for delegates that never finish
@@ -978,6 +1111,12 @@ async def spawn_sub_session(
     if use_subprocess or spawn_mode == "subprocess":
         from amplifier_foundation.subprocess_runner import run_session_in_subprocess
 
+        if agent_name == "self":
+            logger.warning(
+                "Self-delegated subprocess %s cannot inherit the in-process base "
+                "system prompt; preserving legacy subprocess dispatch.",
+                sub_session_id,
+            )
         project_path = str(
             parent_session.coordinator.get_capability("session.working_dir")
             or Path.cwd()
@@ -1039,6 +1178,13 @@ async def spawn_sub_session(
             "turn_count": 1,
             "metadata": {},
         }
+
+    self_base_prompt_builder = None
+    if agent_name == "self":
+        # A source-bearing root without the public Foundation factory must
+        # refuse before creating a child. A no-source root intentionally has
+        # neither capability and preserves its ordinary child behavior.
+        self_base_prompt_builder = _get_self_base_prompt_builder(parent_session)
 
     # Create child session with parent_id and inherited UX systems (kernel mechanism)
     # NOTE: We intentionally do NOT share parent's loader here.
@@ -1185,19 +1331,12 @@ async def spawn_sub_session(
             "mention_resolver", AppMentionResolver()
         )
 
-    # Mention deduplicator - inherit from parent to preserve session-wide deduplication state
-    parent_deduplicator = parent_session.coordinator.get_capability(
-        "mention_deduplicator"
+    # A child must not reuse the parent's deduplicator.  Persona and task
+    # expansion use distinct fresh instances below, and the capability remains
+    # child-owned for consumers that need one.
+    child_session.coordinator.register_capability(
+        "mention_deduplicator", ContentDeduplicator()
     )
-    if parent_deduplicator:
-        child_session.coordinator.register_capability(
-            "mention_deduplicator", parent_deduplicator
-        )
-    else:
-        # Fallback to fresh deduplicator if parent doesn't have one
-        child_session.coordinator.register_capability(
-            "mention_deduplicator", ContentDeduplicator()
-        )
 
     # Routing capability — inherit so child's hooks-routing can compose runtime overrides.
     # When the parent has a session.routing capability (registered by the routing-matrix
@@ -1289,45 +1428,43 @@ async def spawn_sub_session(
         register_provider_fn(approval_provider)
         logger.debug(f"Registered approval provider for child session {sub_session_id}")
 
-    # Inject agent's system instruction
-    # Check top-level instruction first (from agent .md file body), then nested system.instruction
+    # Render exactly one immutable base prompt AFTER child initialization and
+    # child-owned cwd/mention capabilities are ready.  Never await or copy the
+    # parent's installed factory: hooks may have wrapped it with parent-specific
+    # status/routing/skills state.
     system_instruction = agent_config.get("instruction") or agent_config.get(
         "system", {}
     ).get("instruction")
+    base_prompt_snapshot = ""
     if system_instruction:
         context = child_session.coordinator.get("context")
-        # Expand @-mentions in the agent body before injecting as system message.
-        # Content lands inline as <context_file> XML blocks prepended to the instruction.
-        _resolver = child_session.coordinator.get_capability("mention_resolver")
-        if _resolver is not None:
-            from amplifier_foundation.mentions import expand_mentions_in_instruction
-
-            _deduplicator = child_session.coordinator.get_capability(
-                "mention_deduplicator"
+        base_prompt_snapshot = await _expand_system_instruction(
+            system_instruction, child_session
+        )
+    elif agent_name == "self":
+        if self_base_prompt_builder is not None:
+            child_factory = self_base_prompt_builder(child_session)
+            base_prompt_snapshot = await child_factory()
+        else:
+            logger.warning(
+                "Self-delegated child %s has no reconstructable base-prompt "
+                "builder; preserving existing child context behavior without "
+                "installing an empty system-prompt factory.",
+                sub_session_id,
             )
-            _wd = child_session.coordinator.get_capability("session.working_dir")
-            _rel_to = Path(_wd) if _wd else Path.cwd()
-            system_instruction = await expand_mentions_in_instruction(
-                system_instruction,
-                resolver=_resolver,
-                deduplicator=_deduplicator,
-                relative_to=_rel_to,
+
+    if base_prompt_snapshot:
+        context = child_session.coordinator.get("context")
+        if await _install_frozen_system_prompt(context, base_prompt_snapshot):
+            _register_frozen_base_system_prompt_builder(
+                child_session, base_prompt_snapshot
             )
-        if context and hasattr(context, "set_system_prompt_factory"):
-            # Register a factory rather than a static system message so
-            # hooks that compose onto the system prompt (e.g. the skills
-            # visibility hook's "prefix" placement) have a surface to wrap.
-            # Without this, those hooks fall back to re-injecting their
-            # content on every provider:request, outside the cached prefix.
-            # Mirrors amplifier-foundation _prepared.py spawn path.
-            _resolved_system_instruction = system_instruction
-
-            async def _system_prompt_factory() -> str:
-                return _resolved_system_instruction
-
-            await context.set_system_prompt_factory(_system_prompt_factory)
-        elif context and hasattr(context, "add_message"):
-            await context.add_message({"role": "system", "content": system_instruction})
+        else:
+            logger.warning(
+                "Child %s has no system-prompt installation surface; resolved "
+                "base prompt will not be installed.",
+                sub_session_id,
+            )
 
     # Register temporary hook to capture orchestrator:complete data
     # This gives us status, turn_count, and metadata from the orchestrator
@@ -1355,21 +1492,7 @@ async def spawn_sub_session(
     # Expand @-mentions in delegation instruction before executing.
     # Content lands inline as <context_file> XML blocks prepended to the instruction.
     if instruction:
-        _instr_resolver = child_session.coordinator.get_capability("mention_resolver")
-        if _instr_resolver is not None:
-            from amplifier_foundation.mentions import expand_mentions_in_instruction
-
-            _instr_dedup = child_session.coordinator.get_capability(
-                "mention_deduplicator"
-            )
-            _instr_wd = child_session.coordinator.get_capability("session.working_dir")
-            _instr_rel = Path(_instr_wd) if _instr_wd else Path.cwd()
-            instruction = await expand_mentions_in_instruction(
-                instruction,
-                resolver=_instr_resolver,
-                deduplicator=_instr_dedup,
-                relative_to=_instr_rel,
-            )
+        instruction = await _expand_system_instruction(instruction, child_session)
 
     # ---------------------------------------------------------------------
     # Build persistence state BEFORE execute()
@@ -1412,6 +1535,13 @@ async def spawn_sub_session(
         # Store working_dir for session sync between CLI and web
         "working_dir": str(Path.cwd().resolve()),
     }
+    # This persistence metadata is intentionally outside config/session
+    # metadata, so it is never emitted through kernel telemetry.
+    if base_prompt_snapshot:
+        metadata[SYSTEM_PROMPT_SNAPSHOT_KEY] = {
+            "schema": SYSTEM_PROMPT_SNAPSHOT_SCHEMA,
+            "content": base_prompt_snapshot,
+        }
 
     store = SessionStore()
     unregister_checkpoint = await _install_transcript_checkpoint(
@@ -1678,6 +1808,17 @@ async def resume_sub_session(
             f"Corrupted session metadata for '{sub_session_id}'. Cannot reconstruct session without config."
         )
 
+    parent_id = metadata.get("parent_id")
+    agent_name = metadata.get("agent_name", "unknown")
+    trace_id = metadata.get("trace_id")
+    if agent_name == "self" and not _load_system_prompt_snapshot(metadata):
+        raise RuntimeError(
+            f"Cannot resume self-delegated sub-session '{sub_session_id}': its "
+            "persisted base-prompt snapshot is missing or invalid, so its "
+            "historical root identity cannot be reconstructed safely. Start a "
+            "new self delegation instead."
+        )
+
     # --- Credential refresh ---------------------------------------------------
     # On-disk metadata has secrets (provider api_keys, and hook/destination
     # secrets like the context-intelligence hook's private destination
@@ -1831,10 +1972,6 @@ async def resume_sub_session(
                 _REDACTION_SENTINEL,
                 _redacted_paths,
             )
-
-    parent_id = metadata.get("parent_id")
-    agent_name = metadata.get("agent_name", "unknown")
-    trace_id = metadata.get("trace_id")
 
     # --- Rebuild the provider promotion --------------------------------------
     # The spawn path applies model_role/provider_preferences here (see
@@ -2145,77 +2282,48 @@ async def resume_sub_session(
         if _promotion_fallback:
             await hooks.emit("provider:fallback", _promotion_fallback)
 
-    # Re-register the agent's system prompt on resume.
-    #
-    # Mirrors the spawn path (see the "Inject agent's system instruction"
-    # block above, ~line 764). That block registers the system instruction
-    # via context.set_system_prompt_factory() rather than a persisted
-    # message: context-simple builds the system message into a per-request
-    # COPY and never writes it into self.messages, so it is never present in
-    # the saved transcript. SessionStore._save_transcript also explicitly
-    # skips system/developer role messages when persisting, so this holds
-    # even for a context module using the add_message() fallback below.
-    #
-    # Restoring the transcript alone (next block) therefore restores ZERO
-    # system-role messages -- every subsequent request on a resumed
-    # sub-session ran with no system prompt at all, and omitting it on a
-    # chained request CLEARS the provider's server-held prompt rather than
-    # preserving it. Recover the same instruction the original spawn used
-    # and re-register it through the same mechanism.
+    # Restore the resolved frozen snapshot first.  Old named children did not
+    # persist one, so retain their overlay/config reconstruction fallback.
+    # Do not manufacture an empty factory: a legacy static context may still
+    # provide a system message outside the unavailable reconstruction source.
     context = child_session.coordinator.get("context")
-    agent_overlay = metadata.get("agent_overlay") or {}
-    resume_system_instruction = agent_overlay.get("instruction") or agent_overlay.get(
-        "system", {}
-    ).get("instruction")
-    if not resume_system_instruction:
-        # Fallback for metadata saved before agent_overlay existed, or an
-        # empty inherit-as-is overlay: recover the declaration from the
-        # merged config's own agents map, keyed by agent_name.
-        _resume_agents_cfg = merged_config.get("agents") or {}
-        _resume_agent_decl = _resume_agents_cfg.get(agent_name) or {}
-        resume_system_instruction = _resume_agent_decl.get(
+    resume_base_prompt = _load_system_prompt_snapshot(metadata)
+    if not resume_base_prompt and agent_name != "self":
+        agent_overlay = metadata.get("agent_overlay") or {}
+        resume_system_instruction = agent_overlay.get(
             "instruction"
-        ) or _resume_agent_decl.get("system", {}).get("instruction")
-
-    if resume_system_instruction:
-        # Expand @-mentions exactly like the spawn path does, using the
-        # just-restored resolver/deduplicator/working_dir capabilities.
-        _resume_sys_resolver = child_session.coordinator.get_capability(
-            "mention_resolver"
-        )
-        if _resume_sys_resolver is not None:
-            from amplifier_foundation.mentions import expand_mentions_in_instruction
-
-            _resume_sys_dedup = child_session.coordinator.get_capability(
-                "mention_deduplicator"
+        ) or agent_overlay.get("system", {}).get("instruction")
+        if not resume_system_instruction:
+            _resume_agents_cfg = merged_config.get("agents") or {}
+            _resume_agent_decl = _resume_agents_cfg.get(agent_name) or {}
+            resume_system_instruction = _resume_agent_decl.get(
+                "instruction"
+            ) or _resume_agent_decl.get("system", {}).get("instruction")
+        if resume_system_instruction:
+            resume_base_prompt = await _expand_system_instruction(
+                resume_system_instruction, child_session
             )
-            _resume_sys_wd = child_session.coordinator.get_capability(
-                "session.working_dir"
-            )
-            _resume_sys_rel = Path(_resume_sys_wd) if _resume_sys_wd else Path.cwd()
-            resume_system_instruction = await expand_mentions_in_instruction(
-                resume_system_instruction,
-                resolver=_resume_sys_resolver,
-                deduplicator=_resume_sys_dedup,
-                relative_to=_resume_sys_rel,
-            )
-        if context and hasattr(context, "set_system_prompt_factory"):
-            _resolved_resume_system_instruction = resume_system_instruction
+            metadata[SYSTEM_PROMPT_SNAPSHOT_KEY] = {
+                "schema": SYSTEM_PROMPT_SNAPSHOT_SCHEMA,
+                "content": resume_base_prompt,
+            }
 
-            async def _resume_system_prompt_factory() -> str:
-                return _resolved_resume_system_instruction
-
-            await context.set_system_prompt_factory(_resume_system_prompt_factory)
-        elif context and hasattr(context, "add_message"):
-            await context.add_message(
-                {"role": "system", "content": resume_system_instruction}
+    if resume_base_prompt:
+        if await _install_frozen_system_prompt(context, resume_base_prompt):
+            _register_frozen_base_system_prompt_builder(
+                child_session, resume_base_prompt
+            )
+        else:
+            logger.warning(
+                "Resumed sub-session %s has no system-prompt installation "
+                "surface; resolved base prompt will not be installed.",
+                sub_session_id,
             )
     else:
         logger.warning(
-            "Sub-session %s (agent=%s): no system instruction recoverable from "
-            "persisted metadata (agent_overlay / config.agents) on resume. "
-            "This resumed session will run WITHOUT a system prompt for all "
-            "subsequent requests -- proceeding with resume anyway.",
+            "Sub-session %s (agent=%s): no persisted base-prompt snapshot or "
+            "legacy named instruction is reconstructable. Preserving existing "
+            "context behavior without installing an empty system-prompt factory.",
             sub_session_id,
             agent_name,
         )
@@ -2268,21 +2376,7 @@ async def resume_sub_session(
     # Expand @-mentions in the resumed instruction (consistent with spawn path).
     # Content lands inline as <context_file> XML blocks prepended to the instruction.
     if instruction:
-        _resume_resolver = child_session.coordinator.get_capability("mention_resolver")
-        if _resume_resolver is not None:
-            from amplifier_foundation.mentions import expand_mentions_in_instruction
-
-            _resume_dedup = child_session.coordinator.get_capability(
-                "mention_deduplicator"
-            )
-            _resume_wd = child_session.coordinator.get_capability("session.working_dir")
-            _resume_rel = Path(_resume_wd) if _resume_wd else Path.cwd()
-            instruction = await expand_mentions_in_instruction(
-                instruction,
-                resolver=_resume_resolver,
-                deduplicator=_resume_dedup,
-                relative_to=_resume_rel,
-            )
+        instruction = await _expand_system_instruction(instruction, child_session)
 
     # Checkpoint the transcript DURING the run so a wall-clock timeout on this
     # resume does not discard the turn (same defect, same fix, as the spawn

--- a/docs/SPAWN_PRECEDENCE.md
+++ b/docs/SPAWN_PRECEDENCE.md
@@ -69,6 +69,41 @@ The kernel doesn't enforce any precedence. The capability contract is just
 "spawn a sub-session" — what each implementation does with provider preferences
 is its own choice.
 
+## In-process system-prompt inheritance
+
+For an in-process `agent_name: self` child, the CLI renders the root prepared
+bundle's clean, unwrapped prompt factory once for the child, then installs that
+resolved text as the child's frozen base prompt. It deliberately does **not**
+copy or await the parent's installed context factory: application hooks may
+have wrapped that factory with parent-specific state. The child can still apply
+its own prompt wrappers around this base; this rule only prevents parent prompt
+wrappers from leaking into the child.
+
+An instructed named agent still takes precedence over that root base. Its
+top-level `instruction` wins over `system.instruction`, and its mentions are
+expanded against the child's capabilities before the frozen base is installed.
+The nonempty snapshot is stored only in sub-session persistence metadata so
+resume can restore the same base without placing it in `session.metadata`
+telemetry. Runtime skills overlay and `session.routing` continue to be inherited
+as child discovery and model-policy inputs; neither is parent-prompt leakage.
+
+This behavior has a Foundation release gate: a root bundle with prompt sources
+requires the public `PreparedBundle.create_system_prompt_factory` API. If that
+API is unavailable, in-process self delegation refuses before child execution
+and instructs the user to upgrade `amplifier-foundation` and start a new self
+delegation. Ordinary roots, named instructed agents, and no-source root bundles
+remain supported. Do not update the CLI lockfile's Foundation revision until the
+upstream Foundation merge is available.
+
+Historic self-delegated sessions require a valid persisted frozen snapshot to
+resume. The current root cannot safely establish a historic child's identity,
+so missing or invalid snapshots fail with an instruction to start a new self
+delegation. Older named sessions still use their saved overlay/config fallback.
+
+Subprocess self delegation remains a known limitation. Dispatch happens before
+an in-process child can be initialized, so it preserves legacy dispatch and
+logs that clean base-prompt inheritance is unavailable.
+
 ## Cross-references
 
 - `amplifier_app_cli/session_spawner.py` — reference implementation of

--- a/tests/test_provider_commands.py
+++ b/tests/test_provider_commands.py
@@ -1392,6 +1392,173 @@ class TestProviderTest:
 
 
 # ============================================================
+# provider models: configured instance resolution
+# ============================================================
+
+
+class TestProviderModelsConfiguredInstances:
+    """Configured instance ids must retain their module and exact config."""
+
+    @staticmethod
+    def _model(model_id: str) -> MagicMock:
+        model = MagicMock()
+        model.id = model_id
+        model.display_name = model_id
+        model.context_window = 0
+        model.max_output_tokens = 0
+        model.capabilities = []
+        return model
+
+    def test_instance_id_uses_its_module_and_not_another_instances_config(self):
+        """A configured id resolves before same-module alias selection."""
+        from amplifier_app_cli.commands.provider import provider
+
+        providers = [
+            {
+                "id": "other-fixture",
+                "module": "provider-openai",
+                "config": {
+                    "default_model": "other-model",
+                    "base_url": "http://127.0.0.1:8766/v1",
+                    "priority": 1,
+                },
+            },
+            {
+                "id": "astra-fixture",
+                "module": "provider-openai",
+                "config": {
+                    "default_model": "gpt-6-astra",
+                    "base_url": "http://127.0.0.1:8765/v1",
+                    "priority": 99,
+                },
+            },
+        ]
+        settings = MagicMock()
+        settings.get_provider_overrides.return_value = providers
+        requested: list[tuple[str, dict | None]] = []
+
+        def list_models(module_id, config_manager, collected_config=None):
+            requested.append((module_id, collected_config))
+            return [self._model(collected_config["default_model"])]
+
+        with (
+            patch(
+                "amplifier_app_cli.commands.provider._get_settings",
+                return_value=settings,
+            ),
+            patch("amplifier_app_cli.commands.provider._ensure_providers_ready"),
+            patch(
+                "amplifier_app_cli.commands.provider.create_config_manager",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "amplifier_app_cli.commands.provider.get_provider_models",
+                side_effect=list_models,
+            ),
+        ):
+            result = CliRunner().invoke(provider, ["models", "astra-fixture"])
+
+        assert result.exit_code == 0, result.output
+        assert "Models for astra-fixture" in result.output
+        assert "gpt-6-astra" in result.output
+        assert requested == [
+            (
+                "provider-openai",
+                {
+                    "default_model": "gpt-6-astra",
+                    "base_url": "http://127.0.0.1:8765/v1",
+                    "priority": 99,
+                },
+            )
+        ]
+
+    def test_module_alias_uses_the_shared_resolvers_priority_selection(self):
+        """A module alias still resolves to the configured priority winner."""
+        from amplifier_app_cli.commands.provider import provider
+
+        selected_config = {"default_model": "priority-model", "priority": 1}
+        settings = MagicMock()
+        settings.get_provider_overrides.return_value = [
+            {
+                "id": "lower-priority",
+                "module": "provider-openai",
+                "config": {"default_model": "wrong-model", "priority": 9},
+            },
+            {
+                "id": "higher-priority",
+                "module": "provider-openai",
+                "config": selected_config,
+            },
+        ]
+
+        with (
+            patch(
+                "amplifier_app_cli.commands.provider._get_settings",
+                return_value=settings,
+            ),
+            patch("amplifier_app_cli.commands.provider._ensure_providers_ready"),
+            patch(
+                "amplifier_app_cli.commands.provider.create_config_manager",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "amplifier_app_cli.commands.provider.get_provider_models",
+                return_value=[self._model("priority-model")],
+            ) as get_models,
+        ):
+            result = CliRunner().invoke(provider, ["models", "openai"])
+
+        assert result.exit_code == 0, result.output
+        assert "priority-model" in result.output
+        get_models.assert_called_once()
+        assert get_models.call_args.args[0] == "provider-openai"
+        assert get_models.call_args.kwargs["collected_config"] == selected_config
+
+    def test_unknown_id_falls_back_to_its_module_without_borrowing_config(self):
+        """An unknown selector is an unconfigured module alias, not another instance."""
+        from amplifier_app_cli.commands.provider import provider
+
+        settings = MagicMock()
+        settings.get_provider_overrides.return_value = [
+            {
+                "id": "configured-openai",
+                "module": "provider-openai",
+                "config": {"default_model": "must-not-be-used", "priority": 1},
+            }
+        ]
+        manager = MagicMock()
+        manager.get_provider_config.return_value = None
+
+        with (
+            patch(
+                "amplifier_app_cli.commands.provider._get_settings",
+                return_value=settings,
+            ),
+            patch("amplifier_app_cli.commands.provider._ensure_providers_ready"),
+            patch(
+                "amplifier_app_cli.commands.provider.create_config_manager",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "amplifier_app_cli.commands.provider.ProviderManager",
+                return_value=manager,
+            ),
+            patch(
+                "amplifier_app_cli.commands.provider.get_provider_models",
+                return_value=[],
+            ) as get_models,
+        ):
+            result = CliRunner().invoke(provider, ["models", "unconfigured"])
+
+        assert result.exit_code == 0, result.output
+        assert "No models available for provider 'unconfigured'" in result.output
+        manager.get_provider_config.assert_called_once_with("provider-unconfigured")
+        get_models.assert_called_once()
+        assert get_models.call_args.args[0] == "provider-unconfigured"
+        assert get_models.call_args.kwargs["collected_config"] is None
+
+
+# ============================================================
 # Task 11: Remove old commands, first-run detection
 # ============================================================
 

--- a/tests/test_provider_config_unset_fields.py
+++ b/tests/test_provider_config_unset_fields.py
@@ -306,6 +306,23 @@ class TestShouldShowFieldPredicates:
         assert pcu._should_show_field(field, {"default_model": "gpt-4o"}) is True
         assert pcu._should_show_field(field, {"default_model": "gpt-5.6-mini"}) is False
 
+    def test_matches_pattern_and_invalid_regex(self):
+        field = {
+            "show_when": {
+                "default_model": r"matches:^(?:gpt-5\.6(?:-.*)?|gpt-6-astra)$"
+            }
+        }
+        assert pcu._should_show_field(field, {"default_model": "gpt-5.6-terra"}) is True
+        assert pcu._should_show_field(field, {"default_model": "gpt-6-astra"}) is True
+        assert pcu._should_show_field(field, {"default_model": "gpt-6-other"}) is False
+        assert (
+            pcu._should_show_field(
+                {"show_when": {"default_model": "matches:("}},
+                {"default_model": "gpt-6-astra"},
+            )
+            is False
+        )
+
     def test_missing_key_treated_as_empty_string(self):
         field = {"show_when": {"default_model": "contains:sonnet"}}
         assert pcu._should_show_field(field, {}) is False

--- a/tests/test_resume_system_prompt.py
+++ b/tests/test_resume_system_prompt.py
@@ -34,6 +34,9 @@ from unittest.mock import patch
 
 import pytest
 from amplifier_app_cli.session_spawner import resume_sub_session
+from amplifier_app_cli.session_spawner import BASE_SYSTEM_PROMPT_BUILDER_CAPABILITY
+from amplifier_app_cli.session_spawner import SYSTEM_PROMPT_SNAPSHOT_KEY
+from amplifier_app_cli.session_spawner import SYSTEM_PROMPT_SNAPSHOT_SCHEMA
 from amplifier_app_cli.session_store import SessionStore
 
 pytestmark = pytest.mark.anyio
@@ -105,7 +108,7 @@ def _base_metadata(session_id: str, **overrides) -> dict:
 
 async def _resume_with_fake_context(
     fake_context, session_id: str, instruction: str = "follow-up"
-) -> None:
+) -> dict:
     """Run resume_sub_session() against a fully mocked AmplifierSession.
 
     `fake_context` is wired in as the resumed session's "context" capability
@@ -118,7 +121,10 @@ async def _resume_with_fake_context(
         return None
 
     mock_coordinator = MagicMock()
-    mock_coordinator.register_capability = MagicMock()
+    registered_capabilities = {}
+    mock_coordinator.register_capability = MagicMock(
+        side_effect=lambda name, value: registered_capabilities.setdefault(name, value)
+    )
     # mention_resolver intentionally returns None: the mention-expansion
     # branch (both for the follow-up instruction AND the system instruction)
     # is exercised elsewhere (test_session_spawner.py); returning None here
@@ -141,6 +147,7 @@ async def _resume_with_fake_context(
             with patch("amplifier_app_cli.ui.CLIDisplaySystem"):
                 with patch("amplifier_app_cli.paths.create_foundation_resolver"):
                     await resume_sub_session(session_id, instruction)
+    return registered_capabilities
 
 
 class TestResumeSystemPromptReinjection:
@@ -243,6 +250,78 @@ class TestResumeSystemPromptReinjection:
         assert fake_context.factory is not None
         produced = await fake_context.factory()
         assert SENTINEL_INSTRUCTION in produced
+
+    async def test_resume_snapshot_wins_over_legacy_named_instruction(
+        self, tmp_path, monkeypatch
+    ):
+        """A resolved snapshot preserves self identity without re-expanding."""
+        store = SessionStore()
+        session_id = "test-resume-frozen-base-snapshot"
+        metadata = _base_metadata(
+            session_id,
+            agent_name="self",
+            agent_overlay={"instruction": "LEGACY_NAMED_PERSONA"},
+            **{
+                SYSTEM_PROMPT_SNAPSHOT_KEY: {
+                    "schema": SYSTEM_PROMPT_SNAPSHOT_SCHEMA,
+                    "content": "ROOT_BASE_SNAPSHOT",
+                }
+            },
+        )
+        store.save(session_id, [], metadata)
+
+        fake_context = _FakeContextWithFactory()
+        registered_capabilities = await _resume_with_fake_context(
+            fake_context, session_id
+        )
+
+        assert fake_context.factory is not None
+        assert await fake_context.factory() == "ROOT_BASE_SNAPSHOT"
+        nested_factory = registered_capabilities[
+            BASE_SYSTEM_PROMPT_BUILDER_CAPABILITY
+        ](MagicMock())
+        assert await nested_factory() == "ROOT_BASE_SNAPSHOT"
+
+    @pytest.mark.parametrize("has_parent", [False, True])
+    @pytest.mark.parametrize(
+        "snapshot",
+        [
+            None,
+            {"schema": SYSTEM_PROMPT_SNAPSHOT_SCHEMA + 1, "content": "OLD_ROOT"},
+        ],
+    )
+    async def test_historic_self_without_valid_snapshot_refuses_before_child_creation(
+        self, tmp_path, monkeypatch, has_parent, snapshot
+    ):
+        """A current root must never supply identity to a historic self child."""
+        store = SessionStore()
+        session_id = "test-resume-historic-self-without-snapshot"
+        metadata = _base_metadata(session_id, agent_name="self", agent_overlay={})
+        if snapshot is not None:
+            metadata[SYSTEM_PROMPT_SNAPSHOT_KEY] = snapshot
+        store.save(session_id, [{"role": "user", "content": "saved turn"}], metadata)
+
+        child = MagicMock()
+        child.initialize = AsyncMock()
+        child.execute = AsyncMock()
+        child.cleanup = AsyncMock()
+        parent = MagicMock() if has_parent else None
+
+        with (
+            patch(
+                "amplifier_app_cli.session_spawner.AmplifierSession",
+                return_value=child,
+            ) as session_class,
+            pytest.raises(RuntimeError, match="Start a new self delegation"),
+        ):
+            await resume_sub_session(
+                session_id, "follow-up", parent_session=parent
+            )
+
+        session_class.assert_not_called()
+        child.initialize.assert_not_awaited()
+        child.execute.assert_not_awaited()
+        child.cleanup.assert_not_awaited()
 
     async def test_resume_with_no_recoverable_instruction_warns_but_succeeds(
         self, tmp_path, monkeypatch, caplog

--- a/tests/test_routing_commands.py
+++ b/tests/test_routing_commands.py
@@ -1964,6 +1964,53 @@ class TestEditRole:
             f"Hidden field should not appear in config, got: {result['config']}"
         )
 
+    def test_edit_role_shows_model_dependent_field_for_selected_astra_model(
+        self, tmp_path
+    ):
+        """A routing candidate keeps its model outside config, but predicates
+        must still evaluate against that just-selected model."""
+        from amplifier_app_cli.commands.routing import _edit_role
+
+        settings = _make_settings(tmp_path)
+        _seed_provider(
+            settings,
+            [{"module": "provider-openai", "config": {"default_model": "gpt-5.6-sol"}}],
+        )
+        long_context_field = {
+            "id": "enable_long_context",
+            "display_name": "Enable long context",
+            "field_type": "boolean",
+            "show_when": {
+                "default_model": r"matches:^(?:gpt-5\.6(?:-.*)?|gpt-6-astra)$"
+            },
+        }
+
+        con, _ = _make_test_console()
+        with (
+            patch("amplifier_app_cli.commands.routing.console", con),
+            patch("amplifier_app_cli.commands.routing.Prompt") as mock_prompt,
+            patch("amplifier_app_cli.commands.routing.Confirm") as mock_confirm,
+            patch(
+                "amplifier_app_cli.provider_config_utils._prompt_model_selection",
+                return_value="gpt-6-astra",
+            ),
+            patch(
+                "amplifier_app_cli.commands.routing._get_routing_config_fields",
+                return_value=[long_context_field],
+            ),
+        ):
+            mock_prompt.ask.return_value = "1"
+            mock_confirm.ask.return_value = True
+            result = _edit_role(
+                role_name="general",
+                role_desc="General purpose",
+                provider_names=["openai"],
+                settings=settings,
+            )
+
+        assert result is not None
+        assert result["config"]["enable_long_context"] == "true"
+
 
 # ============================================================
 # Fix 5: _get_provider_config() helper

--- a/tests/test_self_child_prompt.py
+++ b/tests/test_self_child_prompt.py
@@ -1,0 +1,323 @@
+"""Focused regressions for in-process self-child base prompt inheritance."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from amplifier_app_cli.session_runner import register_session_spawning
+from amplifier_app_cli.session_spawner import (
+    BASE_SYSTEM_PROMPT_BUILDER_CAPABILITY,
+    BASE_SYSTEM_PROMPT_BUILDER_ERROR_CAPABILITY,
+    spawn_sub_session,
+)
+
+pytestmark = pytest.mark.anyio
+
+
+@pytest.fixture(scope="module")
+def anyio_backend():
+    return "asyncio"
+
+
+class _Context:
+    def __init__(self, messages=None):
+        self.factory = None
+        self.messages = list(messages or [])
+        self.set_calls = 0
+
+    async def set_system_prompt_factory(self, factory):
+        self.factory = factory
+        self.set_calls += 1
+
+    async def add_message(self, message):
+        self.messages.append(message)
+
+    async def get_messages(self):
+        return self.messages
+
+
+class _StaticContext:
+    def __init__(self):
+        self.messages = [{"role": "system", "content": "STATIC_SYSTEM"}]
+
+    async def add_message(self, message):
+        self.messages.append(message)
+
+    async def get_messages(self):
+        return self.messages
+
+
+def _child(context):
+    child = MagicMock()
+    child.session_id = "child-id"
+    child_context = MagicMock()
+    child_context.cancellation = MagicMock()
+    child_context.hooks = MagicMock()
+    child_context.hooks.register = MagicMock(return_value=lambda: None)
+    child_context.mount = AsyncMock()
+    child_context.display_system = MagicMock()
+    caps = {}
+
+    def register(name, value):
+        caps[name] = value
+
+    def get_cap(name):
+        return caps.get(name)
+
+    def get(name):
+        if name == "context":
+            return context
+        if name == "hooks":
+            return child_context.hooks
+        return None
+
+    child_context.register_capability = register
+    child_context.get_capability = get_cap
+    child_context.get = get
+    child.coordinator = child_context
+    child.initialize = AsyncMock()
+
+    async def execute(_instruction):
+        factory = getattr(context, "factory", None)
+        return await factory() if factory else "no factory"
+
+    child.execute = AsyncMock(side_effect=execute)
+    child.cleanup = AsyncMock()
+    return child, caps
+
+
+def _parent(clean_builder=None, builder_error=None):
+    parent = MagicMock()
+    parent.session_id = "parent-id"
+    parent.trace_id = "parent-trace"
+    parent.loader = None
+    parent.config = {"session": {"orchestrator": "loop-basic"}}
+    coordinator = MagicMock()
+    coordinator.config = {}
+    coordinator.approval_system = MagicMock()
+    coordinator.display_system = MagicMock()
+    coordinator.cancellation = MagicMock()
+    coordinator.cancellation.register_child = MagicMock()
+    coordinator.cancellation.unregister_child = MagicMock()
+    coordinator.get = MagicMock(return_value=None)
+    coordinator.get_capability = MagicMock(
+        side_effect=lambda name: {
+            "session.working_dir": "/child/cwd",
+            BASE_SYSTEM_PROMPT_BUILDER_CAPABILITY: clean_builder,
+            BASE_SYSTEM_PROMPT_BUILDER_ERROR_CAPABILITY: builder_error,
+        }.get(name)
+    )
+    parent.coordinator = coordinator
+    return parent
+
+
+async def test_root_registration_creates_target_bound_factory_from_prepared_bundle():
+    """The root capability retains only the prepared bundle, never root context."""
+    root = MagicMock()
+    registered = {}
+    root.coordinator.register_capability.side_effect = (
+        lambda name, value: registered.setdefault(name, value)
+    )
+    prepared = MagicMock()
+    prepared.bundle.instruction = "ROOT_BASE"
+    prepared.bundle.context = {}
+    prepared.bundle._pending_context = {}
+    target = MagicMock()
+    target.coordinator.get_capability.return_value = "/target/cwd"
+
+    async def target_factory():
+        return "ROOT_BASE"
+
+    prepared.create_system_prompt_factory.return_value = target_factory
+    register_session_spawning(root, prepared_bundle=prepared)
+
+    factory = registered[BASE_SYSTEM_PROMPT_BUILDER_CAPABILITY](target)
+    assert await factory() == "ROOT_BASE"
+    assert prepared.create_system_prompt_factory.call_args.args == (target,)
+    assert prepared.create_system_prompt_factory.call_args.kwargs["session_cwd"].as_posix() == (
+        "/target/cwd"
+    )
+
+
+async def test_source_bearing_root_without_foundation_api_refuses_self_before_child_creation():
+    """A missing public Foundation API must not fall back to parent prompt state."""
+    root = MagicMock()
+    root_capabilities = {}
+    root.coordinator.register_capability.side_effect = (
+        lambda name, value: root_capabilities.setdefault(name, value)
+    )
+    prepared = SimpleNamespace(
+        bundle=SimpleNamespace(instruction="ROOT_BASE", context=None, _pending_context=None)
+    )
+    register_session_spawning(root, prepared_bundle=prepared)
+
+    assert BASE_SYSTEM_PROMPT_BUILDER_CAPABILITY not in root_capabilities
+    assert BASE_SYSTEM_PROMPT_BUILDER_ERROR_CAPABILITY in root_capabilities
+
+    parent = _parent(
+        builder_error=root_capabilities[BASE_SYSTEM_PROMPT_BUILDER_ERROR_CAPABILITY]
+    )
+    parent_prompt_factory = AsyncMock()
+    parent_context = SimpleNamespace(factory=parent_prompt_factory)
+    parent.coordinator.get.side_effect = lambda name: (
+        parent_context if name == "context" else None
+    )
+
+    with (
+        patch("amplifier_app_cli.session_spawner.AmplifierSession") as session_class,
+        patch(
+            "amplifier_app_cli.session_spawner.generate_sub_session_id",
+            return_value="child-id",
+        ),
+        pytest.raises(
+            RuntimeError,
+            match="PreparedBundle.create_system_prompt_factory.*Upgrade amplifier-foundation",
+        ),
+    ):
+        await spawn_sub_session("self", "TASK", parent, {})
+
+    session_class.assert_not_called()
+    parent_prompt_factory.assert_not_awaited()
+
+
+async def test_self_child_uses_clean_builder_not_parent_factory_and_freezes_once():
+    """ROOT_BASE is rendered for the child, never from parent hook state."""
+    calls = []
+
+    def clean_builder(target):
+        calls.append(target)
+
+        async def factory():
+            return "ROOT_BASE"
+
+        return factory
+
+    parent = _parent(clean_builder)
+    parent_context = _Context(messages=[{"role": "user", "content": "PARENT_ONLY"}])
+
+    async def parent_factory():
+        raise AssertionError("parent factory must never be read by a child")
+
+    parent_context.factory = parent_factory
+    parent.coordinator.get.side_effect = lambda name: (
+        parent_context if name == "context" else None
+    )
+    context = _Context()
+    child, caps = _child(context)
+    store = MagicMock()
+
+    with (
+        patch("amplifier_app_cli.session_spawner.AmplifierSession", return_value=child),
+        patch(
+            "amplifier_app_cli.session_spawner.generate_sub_session_id",
+            return_value="child-id",
+        ),
+        patch("amplifier_app_cli.session_spawner.bridge_child_cost", new_callable=AsyncMock),
+        patch("amplifier_app_cli.session_spawner._extract_bundle_context", return_value=None),
+        patch("amplifier_app_cli.session_store.SessionStore", return_value=store),
+    ):
+        result = await spawn_sub_session("self", "TASK", parent, {})
+
+    assert result["output"] == "ROOT_BASE"
+    assert calls == [child]
+    assert context.set_calls == 1
+    assert context.messages == []
+    nested_factory = caps[BASE_SYSTEM_PROMPT_BUILDER_CAPABILITY](MagicMock())
+    assert await nested_factory() == "ROOT_BASE"
+    assert calls == [child], "nested self uses its frozen child snapshot"
+    persisted = store.save.call_args_list[0].args[2]
+    assert persisted["base-prompt-snapshot"] == {
+        "schema": 1,
+        "content": "ROOT_BASE",
+    }
+    assert "base-prompt-snapshot" not in persisted["config"].get(
+        "session", {}
+    ).get("metadata", {})
+
+
+async def test_named_persona_wins_over_clean_root_builder():
+    """Named agent bodies retain precedence over an inheritable root base."""
+    parent = _parent(
+        builder_error="self delegation must upgrade Foundation before proceeding"
+    )
+    context = _Context()
+    child, _ = _child(context)
+
+    with (
+        patch("amplifier_app_cli.session_spawner.AmplifierSession", return_value=child),
+        patch(
+            "amplifier_app_cli.session_spawner.generate_sub_session_id",
+            return_value="child-id",
+        ),
+        patch("amplifier_app_cli.session_spawner.bridge_child_cost", new_callable=AsyncMock),
+        patch("amplifier_app_cli.session_spawner._extract_bundle_context", return_value=None),
+        patch("amplifier_app_cli.session_store.SessionStore"),
+    ):
+        result = await spawn_sub_session(
+            "named", "TASK", parent, {"named": {"instruction": "NAMED_PERSONA"}}
+        )
+
+    assert result["output"] == "NAMED_PERSONA"
+
+
+async def test_tool_root_registration_receives_the_prepared_bundle():
+    """Tool invocation registers the same root prompt policy as the interactive runner."""
+    tool_mod = importlib.import_module("amplifier_app_cli.commands.tool")
+    tool_instance = MagicMock()
+    tool_instance.execute = AsyncMock(return_value="tool result")
+    session = MagicMock()
+    session.initialize = AsyncMock()
+    session.cleanup = AsyncMock()
+    session.coordinator.get.side_effect = lambda name: (
+        {"probe": tool_instance} if name == "tools" else None
+    )
+    prepared = MagicMock()
+    prepared.resolver = MagicMock()
+    prepared.create_session = AsyncMock(return_value=session)
+    settings = MagicMock()
+    settings.get_merged_settings.return_value = {}
+
+    with (
+        patch(
+            "amplifier_app_cli.runtime.config.resolve_config_async",
+            new=AsyncMock(return_value=({}, prepared)),
+        ),
+        patch("amplifier_app_cli.lib.settings.AppSettings", return_value=settings),
+        patch("amplifier_app_cli.commands.tool.inject_user_providers"),
+        patch("amplifier_app_cli.paths.create_foundation_resolver"),
+        patch("amplifier_app_cli.lib.bundle_loader.AppModuleResolver"),
+        patch(
+            "amplifier_app_cli.session_runner.register_session_spawning"
+        ) as register_spawning,
+    ):
+        assert await tool_mod._invoke_tool_from_bundle_async(
+            "bundle", "probe", {}
+        ) == "tool result"
+
+    register_spawning.assert_called_once_with(session, prepared_bundle=prepared)
+
+
+async def test_self_without_source_preserves_static_context_without_empty_factory(caplog):
+    """Missing reconstruction never overwrites a legacy static system message."""
+    parent = _parent()
+    context = _StaticContext()
+    child, _ = _child(context)
+
+    with (
+        patch("amplifier_app_cli.session_spawner.AmplifierSession", return_value=child),
+        patch(
+            "amplifier_app_cli.session_spawner.generate_sub_session_id",
+            return_value="child-id",
+        ),
+        patch("amplifier_app_cli.session_spawner.bridge_child_cost", new_callable=AsyncMock),
+        patch("amplifier_app_cli.session_spawner._extract_bundle_context", return_value=None),
+        patch("amplifier_app_cli.session_store.SessionStore"),
+    ):
+        await spawn_sub_session("self", "TASK", parent, {})
+
+    assert context.messages == [{"role": "system", "content": "STATIC_SYSTEM"}]
+    assert "without installing an empty system-prompt factory" in caplog.text

--- a/tests/test_session_spawner_subprocess.py
+++ b/tests/test_session_spawner_subprocess.py
@@ -9,10 +9,12 @@ Also verifies spawn_mode is stripped from child config before passing to subproc
 """
 
 import sys
+import logging
 from types import ModuleType
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from amplifier_app_cli.session_spawner import spawn_sub_session
 
 # Configure anyio for async tests (asyncio backend only)
 pytestmark = pytest.mark.anyio
@@ -122,6 +124,28 @@ class TestSubprocessRouting:
         assert result["status"] == "success"
         assert result["turn_count"] == 1
         assert result["metadata"] == {}
+
+    async def test_self_subprocess_warns_that_base_prompt_cannot_inherit(
+        self, monkeypatch, caplog
+    ):
+        """Subprocess dispatch remains legacy, with a self-specific limitation."""
+        parent = _make_parent_session()
+        fake_module = _make_subprocess_runner_module()
+        monkeypatch.setitem(
+            sys.modules, "amplifier_foundation.subprocess_runner", fake_module
+        )
+
+        with caplog.at_level(logging.WARNING):
+            await spawn_sub_session(
+                agent_name="self",
+                instruction="Do something",
+                parent_session=parent,
+                agent_configs={},
+                sub_session_id="self-subprocess-id",
+                use_subprocess=True,
+            )
+
+        assert "cannot inherit the in-process base system prompt" in caplog.text
 
     async def test_live_registry_agents_propagate_to_subprocess_config(
         self, monkeypatch

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 [[package]]
 name = "amplifier-foundation"
 version = "1.0.0"
-source = { git = "https://github.com/microsoft/amplifier-foundation?branch=main#0d5c5204befc33febfc2bdb8cd8d72ff0a3e6c84" }
+source = { git = "https://github.com/microsoft/amplifier-foundation?branch=main#4f7c482438e05bd678eb92e899ef181a8a0e267e" }
 dependencies = [
     { name = "amplifier-core" },
     { name = "pyyaml" },


### PR DESCRIPTION
## Why

Finalize the reviewed CLI fixes for provider-instance correctness and in-process self-child prompt isolation, with the merged Foundation prompt-factory API pinned explicitly.

## Changes

- Preserve configured provider instance IDs and their per-instance configuration during provider inspection.
- Build self-child prompt factories from the root prepared bundle for the target child, render once, and install only the frozen result.
- Keep nested self-child behavior based on the already-rendered child prompt rather than reusing a parent-installed factory.
- Pin `amplifier-foundation` to merged commit `4f7c482438e05bd678eb92e899ef181a8a0e267e`.
- Includes the four current `main` commits already present before this fix branch was prepared.
- Foundation prerequisite: #380. Provider prerequisite: #87.

## Tests

- Locked dependency sync passed with the merged Foundation revision.
- Focused child-prompt and resume tests: **15 passed**.
- No live model/API calls were made.
- Full CI remains the release gate.

## Limitations

- This PR does not add WebSocket transport, async tool orchestration, mid-turn steering, Batch transport, or other new feature surfaces.
- No live acceptance claim is made.
