### PR TITLE
fix(highway): gate watchdog refill on runnable work

### DIFF
--- a/amplifier_app_cli/data/skills/ten-lane-highway/SKILL.md
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/SKILL.md
@@ -43,9 +43,9 @@ New to the highway? Do a throwaway run first — a scratch repo you can break,
 **width 2**. Invoke `/highway` with a small outcome + that repo + "width 2";
 approve at the Phase 3 gate (nothing launches before you say go); then watch
 **gate → 2 lanes → watchdog → merges**, refilling until the queue drains. Stop
-everything with `tmux -L hw kill-session -t hw-watchdog__<batch>` (plus any
-`hw__<batch>__*` lane sessions), then delete `BATCH_DIR`. Full command sequence
-and expected output: `examples/first-run.md`.
+everything through the batch's explicit `HIGHWAY_TMUX_SOCKET` (default
+`hw-<sanitized-batch>`), then delete `BATCH_DIR`. Full command sequence and
+expected output: `examples/first-run.md`.
 
 ## You are the Highway Manager — a strategist, not an intake clerk
 
@@ -85,7 +85,8 @@ repo** (a real run left `.amplifier/bin/` behind as untracked pollution).
 
 | Script | Job | Rule it mechanizes |
 |---|---|---|
-| `highway_status.sh BATCH_DIR WIDTH READY` | ONE call reports every lane + watchdog liveness and **computes DEFICIT by code** | "Keep lanes full" stopped being prose the day a run sat at 1 lane with work for 10 |
+| `highway_readiness.sh publish BATCH_DIR RUNNABLE` | Atomically publishes the manager's current batch-runnable count | The watchdog must not mistake unused capacity for work to invent |
+| `highway_status.sh BATCH_DIR WIDTH [RUNNABLE]` | ONE call reports every lane + watchdog liveness and **computes DEFICIT by code** from shared readiness | "Keep lanes full" stopped being prose the day a run sat at 1 lane with work for 10 |
 | `launch_lane.sh BATCH_DIR LANE REPO GOAL [BASE_REF]` | Worktree + branch + tmux + `/goal` session, idempotent; the ONLY writer of `manifest.tsv` | Hand-written manifests diverged on column count and broke a real batch |
 | `verify_lane.sh BATCH_DIR LANE` | Git-facts probe for one landed lane (DONE.json, ahead-count, three-dot diffstat, uncommitted work) | "Ground truth from git and the filesystem, not from what any session said about itself" |
 | `highway_watchdog.sh BATCH_DIR WIDTH SESSION_ID [INTERVAL] [MAX_HOURS]` | Detached tmux loop that re-wakes THIS session (`amplifier run --resume`) on lane-end / under-width / stale heartbeat | The highway once froze overnight because the manager stopped monitoring the moment it reported status |
@@ -140,7 +141,8 @@ State lives in `BATCH_DIR` (create one per highway, e.g. `~/dev/hw-<name>`):
 `manifest.tsv` (scripts write), `HIGHWAY.md` (you write), `goals/` (pre-composed
 goal files), `lanes/` (worktrees), `.width` (authoritative width), `infra.tsv`
 (the infra ledger), `infra.owners.tsv` (which lane claimed which row),
-`.manager-heartbeat`, `wake-needed`, `watchdog.log`.
+`.manager-heartbeat`, `.runnable-work` (an atomic batch-runnable snapshot),
+`wake-needed`, `watchdog.log`.
 
 ## Phase 1 — Intake
 
@@ -232,23 +234,32 @@ not depend on context:
 printf '%s\n' "<SESSION_ID>" > <BATCH_DIR>/.session-id
 printf '%s\n' "<WIDTH>" > <BATCH_DIR>/.width   # authoritative width — the single
                                                # source of truth the scripts read
+# Publish the manager's verified batch-runnable count before the watchdog can
+# decide whether unused capacity needs attention. This is not raw tracker-ready:
+# exclude conflicts, dependencies, and work without a pre-composed goal.
+<skill_directory>/scripts/highway_readiness.sh publish <BATCH_DIR> <RUNNABLE>
 touch <BATCH_DIR>/.manager-heartbeat   # BEFORE the watchdog starts, so it never
                                         # sees an absent heartbeat and wakes a
                                         # concurrent instance mid-saturation
 BATCH=$(printf '%s' "$(basename <BATCH_DIR>)" | tr -c 'A-Za-z0-9_-' '_')   # same sanitization the scripts use
-tmux -L hw new-session -d -s "hw-watchdog__${BATCH}" \
+HIGHWAY_TMUX_SOCKET="${HIGHWAY_TMUX_SOCKET:-hw-${BATCH}}"
+export HIGHWAY_TMUX_SOCKET
+tmux -L "$HIGHWAY_TMUX_SOCKET" new-session -d -s "hw-watchdog__${BATCH}" \
   "<skill_directory>/scripts/highway_watchdog.sh <BATCH_DIR> <WIDTH> <SESSION_ID> 300 12 2>&1 | tee -a <BATCH_DIR>/watchdog.log"
 ```
 Then touch `<BATCH_DIR>/.manager-heartbeat` again at the start of every Phase 5
 cycle (step 1) and after each merge, so the watchdog defers while your turn is
 active and only takes over once you have genuinely gone idle.
 
-**Width, the tmux socket, and escalation.** `<BATCH_DIR>/.width` is the single
+**Width, readiness, the tmux socket, and escalation.** `<BATCH_DIR>/.width` is the single
 source of truth for the target lane count (the scripts read it there); changing
 width mid-run is an explicit act — **edit `<BATCH_DIR>/.width` AND log it in the
 weave-in log**, nothing else moves width. Every highway tmux command runs on the
-socket `HIGHWAY_TMUX_SOCKET` (default `hw`) — hence the `-L hw` above and on the
-Phase 7 kill. A wake whose prompt begins `HIGHWAY ESCALATION` means go straight
+per-batch socket `HIGHWAY_TMUX_SOCKET` (default `hw-<sanitized-batch>`) — hence
+the explicit `-L "$HIGHWAY_TMUX_SOCKET"` above and on the Phase 7 kill. The
+manager publishes its current batch-runnable count through `highway_readiness.sh`;
+`drained` means zero fresh runnable work, while `unknown` or `stale` readiness is
+never a zero and must be investigated. A wake whose prompt begins `HIGHWAY ESCALATION` means go straight
 to Phase 6 and lead with `NEEDS YOU:`; the watchdog stays alive throughout.
 
 Verify launch: run `highway_status.sh` once — every lane LIVE past its first
@@ -272,8 +283,12 @@ capacity 135–286s while 15–20 items waited. That is the exact failure this
 invariant exists to prevent.)
 
 1. `touch $BATCH_DIR/.manager-heartbeat`.
-2. Get READY (count of ready, unblocked items) from the work queue.
-3. **Run `highway_status.sh BATCH_DIR WIDTH READY` and paste its output.**
+2. Get RUNNABLE (the batch's ready, dependency-clear, non-conflicting items with
+   pre-composed goals) from the work queue and current lane board.
+3. **Run `highway_status.sh BATCH_DIR WIDTH RUNNABLE` and paste its output.**
+   This atomically refreshes `.runnable-work`; use
+   `highway_readiness.sh publish BATCH_DIR RUNNABLE` when publishing without a
+   status report.
 4. **If `DEFICIT>0`: refill FIRST** — before merging, before reporting, before
    anything. Pick the top-priority ready items (strategist's choice) and
    `launch_lane.sh` each from its pre-composed `BATCH_DIR/goals/` file — refill
@@ -313,7 +328,7 @@ invariant exists to prevent.)
    context_depth="none", model_role="fast")` — with an instruction that
    includes ALL of:
    - the exact loop: sleep `<interval>`, then ONE
-     `highway_status.sh <BATCH_DIR> <WIDTH> <READY>` call, repeat up to N times;
+     `highway_status.sh <BATCH_DIR> <WIDTH> <RUNNABLE>` call, repeat up to N times;
    - **SEQUENTIAL-ONLY — never issue checks in parallel** (a batched watcher
      once issued 15 simultaneous checks sampling the same instant and
      reported success);
@@ -350,7 +365,8 @@ until morning. Before ANY turn-ending message while lanes run:
    `DONE:` / `NEEDS YOU:` / `PAUSED:` / or a one-line highway status — because
    the notification renders from those characters.
 
-The watchdog will re-wake you on lane-end, under-width, or stale heartbeat;
+The watchdog will re-wake you on lane-end, fresh runnable work under width, or
+stale heartbeat with live lanes; each wake runs Phase 5.
 each wake runs Phase 5.
 
 ## Phase 7 — Close the highway
@@ -379,7 +395,7 @@ is the manager's batch-close override; without it `sweep` refuses (exit 3) the
 moment the open rows span more than one lane, which is the guard that stops a
 lane from destroying its neighbours' infrastructure. Kill the
 watchdog by the exact name `highway_status.sh` reports
-(`tmux -L hw kill-session -t <wd_name>`). **Archive
+(`tmux -L "$HIGHWAY_TMUX_SOCKET" kill-session -t <wd_name>`). **Archive
 the per-lane evidence BEFORE pruning** — pruning the lane dirs otherwise deletes
 `lane.log` and the markers with them:
 ```bash

--- a/amplifier_app_cli/data/skills/ten-lane-highway/SKILL.md
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/SKILL.md
@@ -395,7 +395,7 @@ is the manager's batch-close override; without it `sweep` refuses (exit 3) the
 moment the open rows span more than one lane, which is the guard that stops a
 lane from destroying its neighbours' infrastructure. Kill the
 watchdog by the exact name `highway_status.sh` reports
-(`tmux -L "$HIGHWAY_TMUX_SOCKET" kill-session -t <wd_name>`). **Archive
+(`tmux -L "$HIGHWAY_TMUX_SOCKET" kill-session -t "=<wd_name>"`). **Archive
 the per-lane evidence BEFORE pruning** — pruning the lane dirs otherwise deletes
 `lane.log` and the markers with them:
 ```bash

--- a/amplifier_app_cli/data/skills/ten-lane-highway/examples/first-run.md
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/examples/first-run.md
@@ -35,7 +35,8 @@ small enough to watch every moving part.
    Reply `go`. Nothing launched before this.
 
 4. **Saturate (Phase 4).** Two lanes come up — each a worktree + branch + tmux
-   session running `/goal` — then the **watchdog** starts on the `hw` tmux
+   session running `/goal` — then the **watchdog** starts on its isolated batch
+   tmux
    socket. Confirm with the status instrument: both lanes LIVE, watchdog LIVE,
    `DEFICIT=0`.
 
@@ -62,14 +63,17 @@ small enough to watch every moving part.
 ## Stop everything (panic button)
 
 ```bash
-# BATCH is the sanitized batch name (basename of BATCH_DIR, non-alnum → _)
-tmux -L hw kill-session -t "hw-watchdog__${BATCH}"        # the watchdog
-tmux -L hw list-sessions -F '#{session_name}' \
-  | grep "^hw__${BATCH}__" | xargs -r -n1 tmux -L hw kill-session -t   # lanes
+# BATCH is the sanitized batch name (basename of BATCH_DIR, non-alnum → _).
+# Every tmux call names this batch's private server, never the user's mux.
+HIGHWAY_TMUX_SOCKET="${HIGHWAY_TMUX_SOCKET:-hw-${BATCH}}"
+export HIGHWAY_TMUX_SOCKET
+tmux -L "$HIGHWAY_TMUX_SOCKET" kill-session -t "hw-watchdog__${BATCH}" # watchdog
+tmux -L "$HIGHWAY_TMUX_SOCKET" list-sessions -F '#{session_name}' \
+  | grep "^hw__${BATCH}__" | xargs -r -n1 tmux -L "$HIGHWAY_TMUX_SOCKET" kill-session -t # lanes
 infra_ledger.sh "$BATCH_DIR" sweep    # tear down anything lanes stood up
 rm -rf "$BATCH_DIR"                   # worktrees, goals, HIGHWAY.md, logs
 ```
 
-All highway tmux commands use `-L hw` (the `HIGHWAY_TMUX_SOCKET`, default `hw`),
-so a stray `tmux kill-server` on the default socket never touches the highway,
-and this never touches your other tmux work.
+All highway tmux commands use the explicitly named `-L "$HIGHWAY_TMUX_SOCKET"`
+(default `hw-<sanitized-batch>`), so a stray `tmux kill-server` on the default
+socket never touches the highway, and one batch cannot touch another's lanes.

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_readiness.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_readiness.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# highway_readiness.sh — one batch-local observation of runnable Highway work.
+#
+# Usage: highway_readiness.sh publish BATCH_DIR RUNNABLE
+#
+# Runnable work is deliberately supplied by the manager: it has the batch's
+# priority, conflict, and pre-composed-goal context that a generic queue probe
+# cannot know. Consumers source this file so status and watchdog use precisely
+# the same validation and freshness rules.
+READINESS_FILE_NAME=.runnable-work
+
+readiness_publish() {
+  local batch_dir=${1:?BATCH_DIR required}
+  local runnable=${2:?RUNNABLE required}
+  local target tmp
+  case "$runnable" in
+    ''|*[!0-9]*) echo "ERROR: RUNNABLE must be a non-negative integer (got '$runnable')" >&2; return 2 ;;
+  esac
+  [ -d "$batch_dir" ] || { echo "ERROR: batch directory not found: $batch_dir" >&2; return 2; }
+
+  target="$batch_dir/$READINESS_FILE_NAME"
+  tmp=$(mktemp "$batch_dir/.runnable-work.XXXXXX")
+  printf 'v1\t%s\n' "$runnable" > "$tmp"
+  mv -f "$tmp" "$target"
+}
+
+readiness_load() {
+  local batch_dir=${1:?BATCH_DIR required}
+  local max_age=${2:-${HIGHWAY_READINESS_MAX:-1800}}
+  local target line version runnable extra now mtime
+
+  READINESS_STATE=unknown
+  READINESS_RUNNABLE=
+  READINESS_AGE_SECONDS=
+  case "$max_age" in
+    ''|*[!0-9]*) return 0 ;;
+  esac
+
+  target="$batch_dir/$READINESS_FILE_NAME"
+  [ -f "$target" ] || return 0
+  [ "$(wc -l < "$target")" -eq 1 ] || return 0
+  IFS= read -r line < "$target" || return 0
+  IFS=$'\t' read -r version runnable extra <<< "$line"
+  [ "$version" = v1 ] && [ -n "$runnable" ] && [ -z "${extra:-}" ] || return 0
+  case "$runnable" in
+    *[!0-9]*) return 0 ;;
+  esac
+
+  now=$(date +%s)
+  mtime=$(stat -c %Y "$target" 2>/dev/null) || return 0
+  READINESS_AGE_SECONDS=$(( now - mtime ))
+  [ "$READINESS_AGE_SECONDS" -lt 0 ] && READINESS_AGE_SECONDS=0
+  if [ "$READINESS_AGE_SECONDS" -gt "$max_age" ]; then
+    READINESS_STATE=stale
+    return 0
+  fi
+
+  READINESS_RUNNABLE=$runnable
+  if [ "$runnable" -gt 0 ]; then READINESS_STATE=runnable; else READINESS_STATE=drained; fi
+}
+
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  set -euo pipefail
+  case "${1:-}" in
+    publish)
+      [ "$#" -eq 3 ] || { echo "Usage: $0 publish BATCH_DIR RUNNABLE" >&2; exit 2; }
+      readiness_publish "$2" "$3"
+      ;;
+    *)
+      echo "Usage: $0 publish BATCH_DIR RUNNABLE" >&2
+      exit 2
+      ;;
+  esac
+fi

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
 # highway_status.sh — THE instrument. One call reports every lane AND computes the deficit.
 #
-# Usage: highway_status.sh BATCH_DIR WIDTH READY
+# Usage: highway_status.sh BATCH_DIR WIDTH [RUNNABLE]
 #   WIDTH  target lane count (the number written in HIGHWAY.md)
-#   READY  count of ready, unblocked work items (read it from the work queue and pass it)
+#   RUNNABLE optional fresh batch-runnable count to publish before reporting
 #
 # The deficit is COMPUTED HERE, BY CODE — never "noticed" by a model.
 #   deficit = min(READY, max(0, WIDTH - live))
@@ -30,7 +30,10 @@ export HIGHWAY_TMUX_SOCKET
 # ---------------------------------------------------------------------------
 
 WIDTH=${2:?WIDTH required}
-READY=${3:?READY required (ready unblocked work item count)}
+RUNNABLE=${3:-}
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=highway_readiness.sh
+source "$SCRIPT_DIR/highway_readiness.sh"
 
 MANIFEST="$BATCH_DIR/manifest.tsv"
 STALL_SECS=${HIGHWAY_STALL_SECS:-900}
@@ -53,6 +56,8 @@ fi
 # (stat -c %Y below is GNU/Linux; adjust for macOS if this ever travels.)
 BATCH=$(printf '%s' "$(basename "$BATCH_DIR")" | tr -c 'A-Za-z0-9_-' '_')
 [ -f "$MANIFEST" ] || { echo "ERROR: no manifest at $MANIFEST (launch_lane.sh creates it)" >&2; exit 1; }
+if [ -n "$RUNNABLE" ]; then readiness_publish "$BATCH_DIR" "$RUNNABLE"; fi
+readiness_load "$BATCH_DIR"
 
 now=$(date +%s)
 live=0; ended=0; done_n=0; stalled=0; gone=0; needs_mgr_n=0
@@ -190,21 +195,31 @@ fi
 # ---------------------------------------------------------------------------
 
 open=$(( WIDTH - live )); if [ "$open" -lt 0 ]; then open=0; fi
-if [ "$READY" -lt "$open" ]; then deficit=$READY; else deficit=$open; fi
+if [ "$READINESS_STATE" = runnable ] || [ "$READINESS_STATE" = drained ]; then
+  READY=$READINESS_RUNNABLE
+  if [ "$READY" -lt "$open" ]; then deficit=$READY; else deficit=$open; fi
+  ready_json=$READY
+  deficit_json=$deficit
+else
+  READY=UNKNOWN
+  deficit=UNKNOWN
+  ready_json=null
+  deficit_json=null
+fi
 
 if [ "$JSON" = 1 ]; then
   # The owner list is ledger-derived text landing inside a JSON string; keep it
   # to characters that cannot terminate one.
   oo=$(printf '%s' "$orphan_owners" | tr -c 'A-Za-z0-9_,()<>.:-' '_')
-  printf '{"ts":"%s","batch":"%s","live":%d,"ended":%d,"done_marker":%d,"stalled":%d,"needs_manager":%d,"gone":%d,"width":%d,"width_source":"%s","ready":%d,"deficit":%d,"watchdog":"%s","orphan_rows":%d,"orphan_owners":"%s"}\n' \
-    "$(date -u +%FT%TZ)" "$BATCH" "$live" "$ended" "$done_n" "$stalled" "$needs_mgr_n" "$gone" "$WIDTH" "$width_source" "$READY" "$deficit" "$wd_st" "$orphan_rows" "$oo"
+  printf '{"ts":"%s","batch":"%s","live":%d,"ended":%d,"done_marker":%d,"stalled":%d,"needs_manager":%d,"gone":%d,"width":%d,"width_source":"%s","readiness":"%s","readiness_age_seconds":%s,"ready":%s,"deficit":%s,"watchdog":"%s","orphan_rows":%d,"orphan_owners":"%s"}\n' \
+    "$(date -u +%FT%TZ)" "$BATCH" "$live" "$ended" "$done_n" "$stalled" "$needs_mgr_n" "$gone" "$WIDTH" "$width_source" "$READINESS_STATE" "${READINESS_AGE_SECONDS:-null}" "$ready_json" "$deficit_json" "$wd_st" "$orphan_rows" "$oo"
   exit 0
 fi
 
 echo
-echo "SUMMARY batch=$BATCH live=$live ended=$ended done_marker=$done_n stalled=$stalled needs_manager=$needs_mgr_n gone=$gone width=$WIDTH width_source=$width_source ready=$READY watchdog=$wd_st orphan_rows=$orphan_rows"
+echo "SUMMARY batch=$BATCH live=$live ended=$ended done_marker=$done_n stalled=$stalled needs_manager=$needs_mgr_n gone=$gone width=$WIDTH width_source=$width_source readiness=$READINESS_STATE readiness_age_seconds=${READINESS_AGE_SECONDS:--} ready=$READY watchdog=$wd_st orphan_rows=$orphan_rows"
 echo "DEFICIT=$deficit"
-if [ "$deficit" -gt 0 ]; then
+if [ "$deficit" != UNKNOWN ] && [ "$deficit" -gt 0 ]; then
   echo "ACTION: launch $deficit lane(s) NOW - refill before anything else."
 fi
 if [ "$needs_mgr_n" -gt 0 ]; then

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh
@@ -68,7 +68,7 @@ live_lanes=""; all_lanes=""
 while IFS=$'\t' read -r lane wt branch base tmuxn goal log ts; do
   [ "$lane" = "lane" ] && continue
 
-  if tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "$tmuxn" 2>/dev/null; then st=LIVE; else st=ENDED; fi
+  if tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "=$tmuxn" 2>/dev/null; then st=LIVE; else st=ENDED; fi
 
   age="-"; ahead="-"; dj="-"; wt_present=yes; needs_mgr=no
   if [ -d "$wt" ]; then
@@ -116,7 +116,7 @@ while IFS=$'\t' read -r lane wt branch base tmuxn goal log ts; do
 done < "$MANIFEST"
 
 WD="hw-watchdog__${BATCH}"
-if tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "$WD" 2>/dev/null; then wd_st=LIVE; else wd_st=DEAD; fi
+if tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "=$WD" 2>/dev/null; then wd_st=LIVE; else wd_st=DEAD; fi
 
 # --- ORPHAN ROWS (model_performance-ye80) -----------------------------------
 # Join lane liveness (above) to infra-ledger row ownership. Nothing else does.

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_watchdog.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_watchdog.sh
@@ -99,7 +99,7 @@ live_lanes() {
   local n=0 lane wt branch base tmuxn rest
   while IFS=$'\t' read -r lane wt branch base tmuxn rest; do
     [ "$lane" = "lane" ] && continue
-    tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "$tmuxn" 2>/dev/null && n=$((n+1))
+    tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "=$tmuxn" 2>/dev/null && n=$((n+1))
   done < "$MANIFEST"
   echo "$n"
 }
@@ -108,7 +108,7 @@ ended_list() {
   local lane wt branch base tmuxn rest
   while IFS=$'\t' read -r lane wt branch base tmuxn rest; do
     [ "$lane" = "lane" ] && continue
-    tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "$tmuxn" 2>/dev/null || echo "$lane"
+    tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "=$tmuxn" 2>/dev/null || echo "$lane"
   done < "$MANIFEST"
 }
 

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_watchdog.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_watchdog.sh
@@ -8,7 +8,7 @@
 #   tmux -L "$HIGHWAY_TMUX_SOCKET" new-session -d -s "hw-watchdog__<batch>" \
 #     "<skill_dir>/scripts/highway_watchdog.sh BATCH_DIR WIDTH SESSION_ID [INTERVAL] [MAX_HOURS]"
 #
-# Wake triggers: a lane ended since last poll | live < WIDTH | manager heartbeat stale.
+# Wake triggers: a lane ended | fresh runnable work below WIDTH | stale live manager.
 # Wake path: `amplifier run --resume SESSION_ID "<wake prompt>"` (verified CLI flag),
 # plus a durable `wake-needed` file in BATCH_DIR in case the resume fails.
 # The orchestrator touches BATCH_DIR/.manager-heartbeat every cycle and deletes
@@ -58,6 +58,9 @@ ACTIVE_WINDOW=${HIGHWAY_ACTIVE_WINDOW:-120}
 WIDTH_ARG=$WIDTH
 WIDTH_FILE="$BATCH_DIR/.width"
 width_source=arg
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=highway_readiness.sh
+source "$SCRIPT_DIR/highway_readiness.sh"
 resolve_width() {
   width_source=arg
   WIDTH=$WIDTH_ARG
@@ -76,8 +79,9 @@ resolve_width() {
 # BATCH_DIR/escalation-needed and switch the wake prompt to the escalation form.
 ESCALATE_AFTER=${HIGHWAY_ESCALATE_AFTER:-3}
 prev_live=-1        # -1 so the very first poll never looks like a non-increase
-ineffective=0       # consecutive ineffective (under-width, non-recovering) polls
+ineffective=0       # consecutive ineffective runnable-under-width polls
 escalate=0          # 1 while the ineffective count is at/over the threshold
+prev_readiness=
 
 deadline=$(( $(date +%s) + MAX_HOURS * 3600 ))
 START_TS=$(date +%s)
@@ -86,6 +90,8 @@ START_TS=$(date +%s)
 # pre-first-heartbeat race window (graded trial 01).
 GRACE=${HIGHWAY_HB_GRACE:-300}
 last_wake=0
+# Test-only bounded loop control. Zero retains the production infinite loop.
+MAX_POLLS=${HIGHWAY_WATCHDOG_MAX_POLLS:-0}
 
 log() { echo "$(date -u +%FT%TZ) $*" >> "$LOGF"; }
 
@@ -140,6 +146,8 @@ touch "$STATE"
 
 while :; do
   sleep "$INTERVAL"
+  polls=${polls:-0}
+  polls=$((polls + 1))
 
   if [ "$(date +%s)" -ge "$deadline" ]; then
     wake "watchdog max runtime (${MAX_HOURS}h) reached - restart me if the highway is still open"
@@ -177,18 +185,22 @@ while :; do
   # treat as stale so the safety-net wakes below still fire.
   [ "$hb_age" -lt 0 ] && hb_age=$(( HB_MAX + 1 ))
 
-  # ESCALATION LADDER: count consecutive polls where live < width AND live did
-  # not increase vs the previous poll; reset the moment live increases or the
-  # deficit clears. Computed on non-deferred polls only (a deferred poll means
-  # the manager is active and refilling inline, so it is not an ineffective wake).
-  if [ "$live" -ge "$WIDTH" ]; then
-    ineffective=0          # deficit cleared
-  elif [ "$live" -gt "$prev_live" ]; then
-    ineffective=0          # live increased since the previous poll
+  readiness_load "$BATCH_DIR"
+  readiness_changed=0
+  [ "$READINESS_STATE" != "$prev_readiness" ] && readiness_changed=1
+  prev_readiness=$READINESS_STATE
+  log "readiness=$READINESS_STATE runnable=${READINESS_RUNNABLE:--} age=${READINESS_AGE_SECONDS:--}s"
+
+  # ESCALATION LADDER: only fresh runnable work below capacity is ineffective.
+  # Missing, malformed, and stale observations are explicit unknown states,
+  # never a quiet claim that the queue drained.
+  if [ "$READINESS_STATE" = runnable ] && [ "$live" -lt "$WIDTH" ]; then
+    if [ "$live" -gt "$prev_live" ]; then ineffective=0; else ineffective=$(( ineffective + 1 )); fi
+    prev_live=$live
   else
-    ineffective=$(( ineffective + 1 ))
+    ineffective=0
+    prev_live=-1
   fi
-  prev_live=$live
   escalate=0
   if [ "$ineffective" -ge "$ESCALATE_AFTER" ]; then
     escalate=1
@@ -196,9 +208,17 @@ while :; do
     log "ESCALATION: ineffective=$ineffective >= ${ESCALATE_AFTER} (live=$live width=$WIDTH) - marker touched"
   fi
 
-  if [ -n "${new_ended// /}" ]; then wake "lane(s) ended: ${new_ended}"; continue; fi
-  if [ "$live" -lt "$WIDTH" ]; then wake "under width: live=$live < width=$WIDTH"; continue; fi
-  if [ "$hb_age" -gt "$HB_MAX" ] && [ "$live" -gt 0 ]; then
+  if [ -n "${new_ended// /}" ]; then
+    wake "lane(s) ended: ${new_ended}"
+  elif [ "$READINESS_STATE" = runnable ] && [ "$live" -lt "$WIDTH" ]; then
+    wake "under width with runnable work: live=$live < width=$WIDTH runnable=$READINESS_RUNNABLE"
+  elif [ "$hb_age" -gt "$HB_MAX" ] && [ "$live" -gt 0 ]; then
     wake "manager heartbeat stale (${hb_age}s) with $live live lanes"
+  elif { [ "$READINESS_STATE" = unknown ] || [ "$READINESS_STATE" = stale ]; } && [ "$readiness_changed" = 1 ]; then
+    wake "readiness $READINESS_STATE (runnable work cannot be determined)"
+  fi
+  if [ "$MAX_POLLS" -gt 0 ] && [ "$polls" -ge "$MAX_POLLS" ]; then
+    log "exit: max polls ($MAX_POLLS) reached"
+    exit 0
   fi
 done

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/launch_lane.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/launch_lane.sh
@@ -96,7 +96,7 @@ merge time.
   $DONE_MARKER
 EOF
 
-if tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "$TMUX_NAME" 2>/dev/null; then
+if tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "=$TMUX_NAME" 2>/dev/null; then
   echo "SKIP: $TMUX_NAME already running"
 else
   tmux -L "$HIGHWAY_TMUX_SOCKET" new-session -d -s "$TMUX_NAME" -c "$WT" \

--- a/amplifier_app_cli/data/skills/ten-lane-highway/scripts/verify_lane.sh
+++ b/amplifier_app_cli/data/skills/ten-lane-highway/scripts/verify_lane.sh
@@ -36,7 +36,7 @@ row=$(awk -F'\t' -v l="$LANE" 'NR>1 && $1==l' "$MANIFEST" || true)
 IFS=$'\t' read -r lane wt branch base tmuxn goal log ts <<< "$row"
 
 echo "== lane=$lane branch=$branch base=${base:0:8} wt=$wt"
-if tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "$tmuxn" 2>/dev/null; then
+if tmux -L "$HIGHWAY_TMUX_SOCKET" has-session -t "=$tmuxn" 2>/dev/null; then
   echo "TMUX: LIVE (still running - do NOT merge yet)"
 else
   echo "TMUX: ended"

--- a/tests/test_ten_lane_highway_exact_tmux.py
+++ b/tests/test_ten_lane_highway_exact_tmux.py
@@ -1,0 +1,248 @@
+"""Regression coverage for exact Highway tmux lane-session lookups.
+
+The fake tmux deliberately implements tmux's prefix matching for an ordinary
+target and exact matching for the ``=<session>`` target form.  It never starts
+or talks to a real tmux server.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux" or shutil.which("bash") is None,
+    reason="the Highway scripts require GNU/Linux bash (stat -c %Y)",
+)
+
+SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / "amplifier_app_cli/data/skills/ten-lane-highway/scripts"
+)
+READINESS = SCRIPTS / "highway_readiness.sh"
+STATUS = SCRIPTS / "highway_status.sh"
+WATCHDOG = SCRIPTS / "highway_watchdog.sh"
+LAUNCH = SCRIPTS / "launch_lane.sh"
+VERIFY = SCRIPTS / "verify_lane.sh"
+
+OLD_LANE = "close-team-ci"
+REPLACEMENT_LANE = "close-team-ci-r2"
+OLD_SESSION = f"hw__batch__{OLD_LANE}"
+REPLACEMENT_SESSION = f"hw__batch__{REPLACEMENT_LANE}"
+
+
+def make_batch(tmp_path: Path) -> Path:
+    """Write the old and replacement lanes into one manifest."""
+    batch = tmp_path / "batch"
+    batch.mkdir()
+    rows = ["lane\tworktree\tbranch\tbase_sha\ttmux\tgoal\tlog\tlaunched_at"]
+    for lane in (OLD_LANE, REPLACEMENT_LANE):
+        worktree = batch / f"worktree-{lane}"
+        worktree.mkdir()
+        log = batch / f"{lane}.log"
+        log.write_text("", encoding="utf-8")
+        rows.append(
+            f"{lane}\t{worktree}\tlane/{lane}\tHEAD\thw__batch__{lane}\t"
+            f"goal\t{log}\t0"
+        )
+    (batch / "manifest.tsv").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return batch
+
+
+def make_prefix_matching_fakes(tmp_path: Path) -> Path:
+    """Create PATH fakes that model only the tmux behavior under test."""
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "tmux").write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = -L ] && [ "$2" = "$EXPECTED_SOCKET" ] || exit 97
+printf '%s\\n' "$*" >> "$TMUX_CALLS"
+target=
+for ((i = 1; i <= $#; i++)); do
+  if [ "${!i}" = -t ]; then
+    next=$((i + 1))
+    target=${!next}
+    break
+  fi
+done
+case " $* " in
+  *" has-session "*)
+    if [[ "$target" = =* ]]; then
+      target=${target#=}
+      for live in ${LIVE_SESSIONS:-}; do [ "$live" = "$target" ] && exit 0; done
+    else
+      for live in ${LIVE_SESSIONS:-}; do [[ "$live" = "$target"* ]] && exit 0; done
+    fi
+    exit 1
+    ;;
+  *" new-session "*) exit 0 ;;
+esac
+exit 98
+""",
+        encoding="utf-8",
+    )
+    (bindir / "amplifier").write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$AMPLIFIER_CALLS"
+""",
+        encoding="utf-8",
+    )
+    for command in bindir.iterdir():
+        command.chmod(0o755)
+    return bindir
+
+
+def env_for(tmp_path: Path, bindir: Path) -> dict[str, str]:
+    socket = f"exact-tmux-test-{tmp_path.name}"
+    return {
+        **{
+            key: value
+            for key, value in os.environ.items()
+            if key not in {"BASH_ENV", "HIGHWAY_TMUX_SOCKET"}
+        },
+        "PATH": f"{bindir}{os.pathsep}{os.environ['PATH']}",
+        "EXPECTED_SOCKET": socket,
+        "HIGHWAY_TMUX_SOCKET": socket,
+        "LIVE_SESSIONS": REPLACEMENT_SESSION,
+        "TMUX_CALLS": str(tmp_path / "tmux-calls"),
+        "AMPLIFIER_CALLS": str(tmp_path / "amplifier-calls"),
+        "HIGHWAY_HB_GRACE": "0",
+        "HIGHWAY_ACTIVE_WINDOW": "0",
+        "HIGHWAY_WAKE_GAP": "0",
+    }
+
+
+def publish(batch: Path, env: dict[str, str], runnable: int = 0) -> None:
+    result = subprocess.run(
+        ["bash", str(READINESS), "publish", str(batch), str(runnable)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_status_counts_only_the_exact_replacement_session(tmp_path: Path) -> None:
+    batch = make_batch(tmp_path)
+    env = env_for(tmp_path, make_prefix_matching_fakes(tmp_path))
+    publish(batch, env)
+
+    result = subprocess.run(
+        ["bash", str(STATUS), str(batch), "2"],
+        capture_output=True,
+        text=True,
+        env={**env, "HIGHWAY_JSON": "1"},
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    assert report["live"] == 1
+    assert report["ended"] == 1
+
+
+def test_watchdog_wakes_for_old_lane_ended_beside_live_replacement(
+    tmp_path: Path,
+) -> None:
+    batch = make_batch(tmp_path)
+    env = env_for(tmp_path, make_prefix_matching_fakes(tmp_path))
+    publish(batch, env)
+
+    result = subprocess.run(
+        ["bash", str(WATCHDOG), str(batch), "2", "manager-session", "0", "1"],
+        capture_output=True,
+        text=True,
+        env={**env, "HIGHWAY_WATCHDOG_MAX_POLLS": "1"},
+        timeout=10,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert f"lane(s) ended: {OLD_LANE}" in (batch / "wake-needed").read_text(
+        encoding="utf-8"
+    )
+    assert "poll live=1" in (batch / "watchdog.log").read_text(encoding="utf-8")
+
+
+def make_git_repo(tmp_path: Path) -> Path:
+    """Make the disposable repository/worktree fixture needed by launch_lane."""
+    repo = tmp_path / "repo"
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", str(repo)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    (repo / "README").write_text("fixture\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "README"], check=True)
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo),
+            "-c",
+            "user.name=Highway Test",
+            "-c",
+            "user.email=highway-test@example.invalid",
+            "commit",
+            "-m",
+            "fixture",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return repo
+
+
+def test_launcher_and_verify_do_not_treat_replacement_as_old_lane(
+    tmp_path: Path,
+) -> None:
+    """An old target must launch and verify as ended despite a live old-r2."""
+    batch = tmp_path / "batch"
+    repo = make_git_repo(tmp_path)
+    goal = tmp_path / "goal.md"
+    goal.write_text("temporary fixture goal\n", encoding="utf-8")
+    env = env_for(tmp_path, make_prefix_matching_fakes(tmp_path))
+
+    launch = subprocess.run(
+        [
+            "bash",
+            str(LAUNCH),
+            str(batch),
+            OLD_LANE,
+            str(repo),
+            str(goal),
+            "HEAD",
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert launch.returncode == 0, launch.stderr
+    assert f"LAUNCHED: {OLD_SESSION}" in launch.stdout
+    tmux_calls = Path(env["TMUX_CALLS"]).read_text(encoding="utf-8")
+    assert f"has-session -t ={OLD_SESSION}" in tmux_calls
+    assert f"new-session -d -s {OLD_SESSION}" in tmux_calls
+
+    verify = subprocess.run(
+        ["bash", str(VERIFY), str(batch), OLD_LANE],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+    assert verify.returncode == 0, verify.stderr
+    assert "TMUX: ended" in verify.stdout

--- a/tests/test_ten_lane_highway_orphan_rows.py
+++ b/tests/test_ten_lane_highway_orphan_rows.py
@@ -109,6 +109,7 @@ def _stub_tmux(tmp_path: Path) -> Path:
         'for a in "$@"; do [ "$a" = "has-session" ] && want=1; done\n'
         'last="${@: -1}"\n'
         'if [ "${want:-0}" = 1 ]; then\n'
+        '  last="${last#=}"\n'
         '  case " ${LIVE_SESSIONS:-} " in *" $last "*) exit 0 ;; *) exit 1 ;; esac\n'
         "fi\n"
         "exit 0\n",

--- a/tests/test_ten_lane_highway_readiness.py
+++ b/tests/test_ten_lane_highway_readiness.py
@@ -50,6 +50,7 @@ def make_fakes(tmp_path: Path) -> Path:
 set -euo pipefail
 [ "$1" = -L ] && [ "$2" = "$EXPECTED_SOCKET" ] || exit 97
 last="${@: -1}"
+last="${last#=}"
 for arg in "$@"; do
   if [ "$arg" = has-session ]; then
     case " ${LIVE_SESSIONS:-} " in *" $last "*) exit 0 ;; *) exit 1 ;; esac

--- a/tests/test_ten_lane_highway_readiness.py
+++ b/tests/test_ten_lane_highway_readiness.py
@@ -1,0 +1,229 @@
+"""Observable readiness and watchdog behavior for the shipped Highway scripts."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "linux" or shutil.which("bash") is None,
+    reason="the Highway scripts require GNU/Linux bash (stat -c %Y)",
+)
+
+SCRIPTS = (
+    Path(__file__).resolve().parents[1]
+    / "amplifier_app_cli/data/skills/ten-lane-highway/scripts"
+)
+READINESS = SCRIPTS / "highway_readiness.sh"
+STATUS = SCRIPTS / "highway_status.sh"
+WATCHDOG = SCRIPTS / "highway_watchdog.sh"
+
+
+def make_batch(tmp_path: Path, lanes: tuple[str, ...] = ()) -> Path:
+    batch = tmp_path / "batch"
+    batch.mkdir()
+    rows = ["lane\tworktree\tbranch\tbase_sha\ttmux\tgoal\tlog\tlaunched_at"]
+    for lane in lanes:
+        worktree = batch / f"worktree-{lane}"
+        worktree.mkdir()
+        log = batch / f"{lane}.log"
+        log.write_text("", encoding="utf-8")
+        rows.append(
+            f"{lane}\t{worktree}\tlane/{lane}\tHEAD\thw__batch__{lane}\tgoal\t{log}\t0"
+        )
+    (batch / "manifest.tsv").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return batch
+
+
+def make_fakes(tmp_path: Path) -> Path:
+    bindir = tmp_path / "bin"
+    bindir.mkdir()
+    (bindir / "tmux").write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+[ "$1" = -L ] && [ "$2" = "$EXPECTED_SOCKET" ] || exit 97
+last="${@: -1}"
+for arg in "$@"; do
+  if [ "$arg" = has-session ]; then
+    case " ${LIVE_SESSIONS:-} " in *" $last "*) exit 0 ;; *) exit 1 ;; esac
+  fi
+done
+exit 98
+""",
+        encoding="utf-8",
+    )
+    (bindir / "amplifier").write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$AMPLIFIER_CALLS"
+""",
+        encoding="utf-8",
+    )
+    for command in bindir.iterdir():
+        command.chmod(0o755)
+    return bindir
+
+
+def env_for(tmp_path: Path, bindir: Path, *, live: str = "") -> dict[str, str]:
+    calls = tmp_path / "amplifier-calls"
+    return {
+        **{key: value for key, value in os.environ.items() if key != "BASH_ENV"},
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "EXPECTED_SOCKET": f"readiness-test-{tmp_path.name}",
+        "HIGHWAY_TMUX_SOCKET": f"readiness-test-{tmp_path.name}",
+        "LIVE_SESSIONS": live,
+        "AMPLIFIER_CALLS": str(calls),
+        "HIGHWAY_HB_GRACE": "0",
+        "HIGHWAY_ACTIVE_WINDOW": "0",
+        "HIGHWAY_WAKE_GAP": "0",
+    }
+
+
+def publish(batch: Path, runnable: int, env: dict[str, str]) -> None:
+    result = subprocess.run(
+        ["bash", str(READINESS), "publish", str(batch), str(runnable)],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def run_watchdog(batch: Path, env: dict[str, str], polls: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(WATCHDOG), str(batch), "10", "manager-session", "0", "1"],
+        capture_output=True,
+        text=True,
+        env={**env, "HIGHWAY_WATCHDOG_MAX_POLLS": str(polls)},
+        timeout=10,
+        check=False,
+    )
+
+
+def call_count(env: dict[str, str]) -> int:
+    calls = Path(env["AMPLIFIER_CALLS"])
+    return len(calls.read_text(encoding="utf-8").splitlines()) if calls.exists() else 0
+
+
+def test_drained_batch_does_not_wake_or_escalate(tmp_path: Path) -> None:
+    batch = make_batch(tmp_path)
+    env = env_for(tmp_path, make_fakes(tmp_path))
+    publish(batch, 0, env)
+
+    result = run_watchdog(batch, env, polls=4)
+
+    assert result.returncode == 0, result.stderr
+    assert call_count(env) == 0
+    assert not (batch / "wake-needed").exists()
+    assert not (batch / "escalation-needed").exists()
+
+
+def test_refilled_work_wakes_and_status_reports_shared_readiness(tmp_path: Path) -> None:
+    batch = make_batch(tmp_path)
+    env = env_for(tmp_path, make_fakes(tmp_path))
+    publish(batch, 0, env)
+    assert run_watchdog(batch, env, polls=2).returncode == 0
+
+    publish(batch, 1, env)
+    result = run_watchdog(batch, env, polls=1)
+    status = subprocess.run(
+        ["bash", str(STATUS), str(batch), "10"],
+        capture_output=True,
+        text=True,
+        env={**env, "HIGHWAY_JSON": "1"},
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert call_count(env) == 1
+    report = json.loads(status.stdout)
+    assert report["readiness"] == "runnable"
+    assert report["ready"] == 1
+    assert report["deficit"] == 1
+
+
+def test_persisting_runnable_work_escalates_after_launch_failure(tmp_path: Path) -> None:
+    batch = make_batch(tmp_path)
+    env = env_for(tmp_path, make_fakes(tmp_path))
+    publish(batch, 1, env)
+
+    result = run_watchdog(
+        batch, {**env, "HIGHWAY_ESCALATE_AFTER": "3"}, polls=4
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert call_count(env) == 4
+    assert (batch / "escalation-needed").exists()
+    assert "ESCALATION WAKE" in (batch / "watchdog.log").read_text(encoding="utf-8")
+
+
+@pytest.mark.parametrize("kind", ("missing", "stale", "malformed", "extra-field"))
+def test_unknown_or_stale_readiness_is_explicit_not_zero(tmp_path: Path, kind: str) -> None:
+    batch = make_batch(tmp_path)
+    env = env_for(tmp_path, make_fakes(tmp_path))
+    if kind == "stale":
+        publish(batch, 1, env)
+        old = time.time() - 3601
+        os.utime(batch / ".runnable-work", (old, old))
+    elif kind == "malformed":
+        (batch / ".runnable-work").write_text("v0\t1\n", encoding="utf-8")
+    elif kind == "extra-field":
+        (batch / ".runnable-work").write_text("v1\t1\tunexpected\n", encoding="utf-8")
+
+    status = subprocess.run(
+        ["bash", str(STATUS), str(batch), "10"],
+        capture_output=True,
+        text=True,
+        env={**env, "HIGHWAY_JSON": "1", "HIGHWAY_READINESS_MAX": "60"},
+        check=False,
+    )
+    result = run_watchdog(
+        batch, {**env, "HIGHWAY_READINESS_MAX": "60"}, polls=3
+    )
+
+    assert status.returncode == 0, status.stderr
+    report = json.loads(status.stdout)
+    assert report["readiness"] == ("stale" if kind == "stale" else "unknown")
+    assert report["ready"] is None
+    assert report["deficit"] is None
+    assert result.returncode == 0, result.stderr
+    assert call_count(env) == 1
+    assert not (batch / "escalation-needed").exists()
+
+
+def test_ended_lane_wakes_even_when_batch_is_drained(tmp_path: Path) -> None:
+    batch = make_batch(tmp_path, ("ended",))
+    env = env_for(tmp_path, make_fakes(tmp_path))
+    publish(batch, 0, env)
+
+    result = run_watchdog(batch, env, polls=1)
+
+    assert result.returncode == 0, result.stderr
+    assert call_count(env) == 1
+    assert "lane(s) ended: ended" in (batch / "wake-needed").read_text(encoding="utf-8")
+
+
+def test_stale_heartbeat_wakes_while_a_drained_batch_has_live_lanes(tmp_path: Path) -> None:
+    batch = make_batch(tmp_path, ("live",))
+    env = env_for(
+        tmp_path, make_fakes(tmp_path), live="hw__batch__live"
+    )
+    publish(batch, 0, env)
+    heartbeat = batch / ".manager-heartbeat"
+    heartbeat.touch()
+    old = time.time() - 1900
+    os.utime(heartbeat, (old, old))
+
+    result = run_watchdog(batch, env, polls=1)
+
+    assert result.returncode == 0, result.stderr
+    assert call_count(env) == 1
+    assert "heartbeat stale" in (batch / "wake-needed").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

- Add a batch-local, atomically written `.runnable-work` snapshot with shared validation and freshness handling.
- Make `highway_status.sh` publish/read the snapshot and report `runnable`, `drained`, `unknown`, or `stale` without treating missing data as zero.
- Make `highway_watchdog.sh` refill/escalate only for fresh runnable work below width, while preserving lane-end and stale-heartbeat wakes.
- Document the readiness publication flow and add observable shell-script coverage.

## Why

The watchdog previously interpreted every under-width board as actionable, even when the manager's queue was drained or its readiness observation was unavailable. The shared snapshot keeps the manager's runnable-work decision authoritative and prevents invented refill work or silent false-drained states.

## How to verify

- `env -u BASH_ENV uv run pytest -q tests/test_ten_lane_highway_readiness.py tests/test_ten_lane_highway_socket_default.py tests/test_ten_lane_highway_orphan_rows.py tests/test_ten_lane_highway_infra_ledger.py` -> **46 passed**.
- `bash -n amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_readiness.sh amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_status.sh amplifier_app_cli/data/skills/ten-lane-highway/scripts/highway_watchdog.sh` -> passed.
- Full suite had an unrelated environment failure in `test_truststore_wrap_bio_shim.py::test_real_truststore_is_covered_at_cli_import` reporting `SHIM_STATUS='skipped: truststore is not importable'` (**2045 passed, 1 failure**).

## Breaking changes

None. The optional readiness argument preserves the existing status invocation shape; callers that do not publish readiness receive an explicit unknown state rather than an inferred zero.