### PR TITLE
fix: distinguish bundle downloads from updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,3 +44,10 @@ context factory: hooks can wrap it with parent-specific state. Persist a
 nonempty resolved snapshot only in sub-session persistence metadata, never in
 `session.metadata` telemetry; keep subprocess self dispatch as its explicit
 legacy limitation.
+
+## Update reporting
+
+Keep report labels separate from update eligibility: a missing mutable cache is
+a download, not a newer revision, and an unchecked source is not current.
+Exercise the real Click command in `tests/test_update_reporting.py`; mock only
+status/apply boundaries so tests never touch a user's caches or installation.

--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -3,7 +3,7 @@
 import asyncio
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import click
 from rich.console import Console
@@ -58,6 +58,267 @@ class TransitiveBundleStatus(_BundleStatus):
 
     is_pinned: bool = False
     """Ref is a commit SHA or version tag: reported, never refreshed."""
+
+
+SourceReportState = Literal[
+    "current",
+    "download",
+    "update",
+    "refresh_cache",
+    "not_checked",
+    "pinned",
+    "pinned_missing",
+    "local_changes",
+    "mixed_actions",
+]
+
+_ACTIONABLE_REPORT_STATES = {"download", "update", "refresh_cache"}
+_REPORT_STATE_LABELS: dict[SourceReportState, str] = {
+    "current": "Current",
+    "download": "Download",
+    "update": "Update",
+    "refresh_cache": "Refresh cache",
+    "not_checked": "Not checked",
+    "pinned": "Pinned",
+    "pinned_missing": "Pinned; not cached",
+    "local_changes": "Local changes",
+    "mixed_actions": "Mixed actions",
+}
+
+
+def _classify_source_status(
+    source: Any, *, has_local_changes: bool = False
+) -> SourceReportState:
+    """Return a presentation-only status without deriving action eligibility."""
+
+    if getattr(source, "error", None):
+        return "not_checked"
+    if getattr(source, "is_pinned", False):
+        return "pinned" if source.is_cached else "pinned_missing"
+    if has_local_changes:
+        return "local_changes"
+    if source.has_update is not True:
+        if (
+            source.has_update is False
+            and source.is_cached
+            and source.cached_commit
+            and source.remote_commit
+            and source.cached_commit == source.remote_commit
+        ):
+            return "current"
+        return "not_checked"
+    if not source.remote_commit:
+        return "not_checked"
+    if not source.is_cached:
+        return "download"
+    if not source.cached_commit:
+        return "refresh_cache"
+    return "update" if source.cached_commit != source.remote_commit else "not_checked"
+
+
+def _bundle_source_states(status: "BundleStatus") -> tuple[SourceReportState, ...]:
+    """Classify every source, treating an empty bundle as unchecked."""
+
+    if not status.sources:
+        return ("not_checked",)
+    return tuple(
+        _classify_source_status(
+            source, has_local_changes=bool(getattr(source, "_has_local_changes", False))
+        )
+        for source in status.sources
+    )
+
+
+def _bundle_action_states(status: "BundleStatus") -> tuple[SourceReportState, ...]:
+    """Return each distinct actionable source state in stable display order."""
+
+    states = _bundle_source_states(status)
+    return tuple(
+        state
+        for state in ("download", "refresh_cache", "update")
+        if state in states
+    )
+
+
+def _classify_bundle_status(status: "BundleStatus") -> SourceReportState:
+    """Collapse a bundle's source statuses into one visible, non-counting label."""
+
+    if not status.sources:
+        return "not_checked"
+    if getattr(status, "is_pinned", False):
+        return "pinned_missing" if any(not s.is_cached for s in status.sources) else "pinned"
+
+    states = _bundle_source_states(status)
+    action_states = _bundle_action_states(status)
+    if len(action_states) > 1:
+        return "mixed_actions"
+    if action_states:
+        return action_states[0]
+    if "local_changes" in states:
+        return "local_changes"
+    if "not_checked" in states:
+        return "not_checked"
+    if "pinned_missing" in states:
+        return "pinned_missing"
+    if "pinned" in states:
+        return "pinned"
+    return "current"
+
+
+def _bundle_report_plan(
+    bundle_results: dict[str, "BundleStatus"] | None,
+) -> dict[str, SourceReportState]:
+    """Build the one presentation plan used by every update report surface."""
+
+    return {
+        name: _classify_bundle_status(status)
+        for name, status in (bundle_results or {}).items()
+    }
+
+
+def _report_state_text(state: SourceReportState) -> Text:
+    """Render a plain-language report state with the corresponding neutral color."""
+
+    style = (
+        "yellow"
+        if state in _ACTIONABLE_REPORT_STATES
+        else "cyan"
+        if state == "local_changes"
+        else "green"
+        if state == "current"
+        else "dim"
+    )
+    return Text(_REPORT_STATE_LABELS[state], style=style)
+
+
+def _bundle_report_state_text(
+    status: "BundleStatus", state: SourceReportState
+) -> Text:
+    """Describe a bundle's composite action plan without changing its selection."""
+
+    if state != "mixed_actions":
+        return _report_state_text(state)
+    actions = " + ".join(_REPORT_STATE_LABELS[action].lower() for action in _bundle_action_states(status))
+    return Text(f"Mixed actions ({actions})", style="yellow")
+
+
+def _bundle_action_phrase(status: "BundleStatus") -> str:
+    """Turn a composite action set into a compact, grammatical noun phrase."""
+
+    nouns = {
+        "download": "downloads",
+        "refresh_cache": "cache refreshes",
+        "update": "updates",
+    }
+    parts = [nouns[action] for action in _bundle_action_states(status)]
+    if len(parts) == 2:
+        return f"{parts[0]} and {parts[1]}"
+    if len(parts) > 2:
+        return f"{', '.join(parts[:-1])}, and {parts[-1]}"
+    return parts[0] if parts else "unconfirmed operations"
+
+
+def _bundle_action_lines(
+    bundle_names: list[str],
+    plan: dict[str, SourceReportState],
+    bundle_results: dict[str, "BundleStatus"],
+) -> list[str]:
+    """Group selected bundle targets by their existing, presentation-only plan."""
+
+    counts: dict[SourceReportState, int] = {}
+    mixed: dict[str, int] = {}
+    for name in bundle_names:
+        state = plan.get(name, "not_checked")
+        if state == "mixed_actions":
+            phrase = _bundle_action_phrase(bundle_results[name])
+            mixed[phrase] = mixed.get(phrase, 0) + 1
+        else:
+            counts[state] = counts.get(state, 0) + 1
+    lines = [
+        f"{_REPORT_STATE_LABELS[state]} {count} bundle{'s' if count != 1 else ''}"
+        for state in ("download", "refresh_cache", "update")
+        if (count := counts.get(state, 0))
+    ]
+    lines.extend(
+        f"Process {count} bundle{'s' if count != 1 else ''} with {phrase}"
+        for phrase, count in mixed.items()
+    )
+    lines.extend(
+        f"Process {count} bundle{'s' if count != 1 else ''} with "
+        f"{'local changes' if state == 'local_changes' else 'unconfirmed sources'}"
+        for state in ("local_changes", "not_checked")
+        if (count := counts.get(state, 0))
+    )
+    return lines
+
+
+def _bundle_completion_verb(state: SourceReportState | None) -> str:
+    """Use the checked report plan for a completed bundle operation."""
+
+    return {
+        "download": "Downloaded",
+        "refresh_cache": "Refreshed",
+        "update": "Updated",
+    }.get(state or "not_checked", "Processed")
+
+
+def _bundle_failure_verb(state: SourceReportState | None) -> str:
+    """Describe a failed operation without implying it completed successfully."""
+
+    return {
+        "download": "Failed to download",
+        "refresh_cache": "Failed to refresh",
+        "update": "Failed to update",
+    }.get(state or "not_checked", "Failed to process")
+
+
+def _unconfirmed_source_counts(
+    report, bundle_results: dict[str, "BundleStatus"] | None, umbrella_deps
+) -> tuple[int, int, int]:
+    """Count report rows that cannot support an all-current claim."""
+
+    unchecked: set[str] = set()
+    local_changes: set[str] = set()
+    pinned: set[str] = set()
+
+    for status in (bundle_results or {}).values():
+        if not status.sources:
+            unchecked.add(status.bundle_source or status.bundle_name)
+            continue
+        for source in status.sources:
+            key = source.source_uri
+            state = _classify_source_status(
+                source, has_local_changes=bool(getattr(source, "_has_local_changes", False))
+            )
+            if state == "not_checked":
+                unchecked.add(key)
+            elif state == "local_changes":
+                local_changes.add(key)
+            elif state in ("pinned", "pinned_missing"):
+                pinned.add(key)
+
+    for status in report.local_file_sources:
+        key = f"local:{status.name}"
+        if status.uncommitted_changes or status.unpushed_commits:
+            local_changes.add(key)
+        elif not status.has_remote or not status.remote_sha:
+            unchecked.add(key)
+
+    for status in report.cached_git_sources:
+        if not status.remote_sha or status.remote_sha == "unknown":
+            unchecked.add(f"module:{status.name}")
+
+    for dependency in umbrella_deps or []:
+        remote = dependency.get("remote_sha")
+        if dependency.get("is_local"):
+            if dependency.get("has_changes"):
+                local_changes.add(f"package:{dependency['name']}")
+            else:
+                unchecked.add(f"package:{dependency['name']}")
+        elif not remote or remote == "unknown":
+            unchecked.add(f"package:{dependency['name']}")
+
+    return len(unchecked), len(local_changes), len(pinned)
 
 
 def _normalize_git_url(url: str) -> str:
@@ -668,7 +929,7 @@ async def _get_file_bundle_status(
     if has_local_changes:
         summary = "Local editable install (with uncommitted changes)"
 
-    return SourceStatus(
+    status = SourceStatus(
         source_uri=file_uri,
         is_cached=True,
         has_update=has_update,
@@ -676,6 +937,8 @@ async def _get_file_bundle_status(
         remote_commit=remote_sha,
         summary=summary,
     )
+    status._has_local_changes = has_local_changes
+    return status
 
 
 def _get_active_bundle_name() -> str | None:
@@ -731,6 +994,7 @@ def _show_concise_report(
     has_umbrella_updates: bool,
     umbrella_deps=None,
     bundle_results: dict[str, "BundleStatus"] | None = None,
+    bundle_plan: dict[str, SourceReportState] | None = None,
 ) -> None:
     """Show concise table format for all sources.
 
@@ -764,7 +1028,10 @@ def _show_concise_report(
                     name_display = f"{dep['name']} [dim](local)[/dim]"
                 # Local changes indicator
                 status_symbol = create_status_symbol(
-                    dep["local_sha"], dep["local_sha"], dep.get("has_changes", False)
+                    dep["local_sha"],
+                    dep["local_sha"],
+                    dep.get("has_changes", False),
+                    checked=False,
                 )
                 remote_display = Text("-", style="dim")
             elif dep.get("display_type") == "version":
@@ -774,7 +1041,9 @@ def _show_concise_report(
                 local_display = Text(dep["local_sha"] or "unknown", style="dim")
                 remote_display = Text(dep["remote_sha"] or "unknown", style="dim")
                 status_symbol = create_status_symbol(
-                    dep["local_sha"], dep["remote_sha"]
+                    dep["local_sha"],
+                    dep["remote_sha"],
+                    checked=dep.get("remote_sha") not in (None, "unknown"),
                 )
             else:
                 # Standard git install - compare local vs remote
@@ -782,7 +1051,9 @@ def _show_concise_report(
                 local_display = create_sha_text(dep["local_sha"])
                 remote_display = create_sha_text(dep["remote_sha"])
                 status_symbol = create_status_symbol(
-                    dep["local_sha"], dep["remote_sha"]
+                    dep["local_sha"],
+                    dep["remote_sha"],
+                    checked=dep.get("remote_sha") not in (None, "unknown"),
                 )
 
             table.add_row(
@@ -811,7 +1082,10 @@ def _show_concise_report(
         for status in sorted(report.local_file_sources, key=lambda x: x.name):
             has_local_changes = status.uncommitted_changes or status.unpushed_commits
             status_symbol = create_status_symbol(
-                status.local_sha, status.local_sha, has_local_changes
+                status.local_sha,
+                status.local_sha,
+                has_local_changes,
+                checked=bool(status.has_remote and status.remote_sha),
             )
 
             # Truncate path for display
@@ -843,7 +1117,11 @@ def _show_concise_report(
 
         for name in sorted(unified_modules.keys()):
             info = unified_modules[name]
-            status_symbol = create_status_symbol(info["cached_sha"], info["remote_sha"])
+            status_symbol = create_status_symbol(
+                info["cached_sha"],
+                info["remote_sha"],
+                checked=info["remote_sha"] not in (None, "unknown"),
+            )
 
             table.add_row(
                 name,
@@ -863,9 +1141,10 @@ def _show_concise_report(
         table.add_column("Name", style="green")
         table.add_column("Cached", style="dim", justify="right")
         table.add_column("Remote", style="dim", justify="right")
-        table.add_column("", width=1, justify="center")
+        table.add_column("Status", justify="center")
 
         display_names = _bundle_display_names(bundle_results.keys())
+        bundle_plan = bundle_plan or _bundle_report_plan(bundle_results)
 
         for bundle_name in sorted(
             bundle_results.keys(),
@@ -883,12 +1162,9 @@ def _show_concise_report(
                 cached_sha = None
                 remote_sha = None
 
-            # Status symbol reflects aggregate bundle state (bundle repo + ALL module sources)
-            # not just the bundle repo's SHA - this makes status consistent with "Update X bundles" message
-            if bundle_status.has_updates:
-                status_symbol = Text("●", style="yellow")
-            else:
-                status_symbol = Text("✓", style="green")
+            status_text = _bundle_report_state_text(
+                bundle_status, bundle_plan[bundle_name]
+            )
 
             # Add "(active)" marker if this is the active bundle
             display_name = display_names[bundle_name]
@@ -916,25 +1192,13 @@ def _show_concise_report(
                 display_name,
                 create_sha_text(cached_sha),
                 remote_cell,
-                status_symbol,
+                status_text,
             )
 
         console.print(table)
 
     console.print()
     print_legend()
-
-    # Determine if there are bundle updates
-    has_bundle_updates = bundle_results and any(
-        s.has_updates for s in bundle_results.values()
-    )
-
-    if not check_only and (
-        report.has_updates or has_umbrella_updates or has_bundle_updates
-    ):
-        console.print()
-        console.print("Run [cyan]amplifier update[/cyan] to install")
-
 
 def _print_verbose_item(
     name: str,
@@ -945,6 +1209,7 @@ def _print_verbose_item(
     local_path: str | None = None,
     remote_url: str | None = None,
     ref: str | None = None,
+    status_text: Text | None = None,
 ) -> None:
     """Print a single item in verbose multi-line format."""
     # Header line: name + status
@@ -952,6 +1217,9 @@ def _print_verbose_item(
     header.append(name, style="green bold")
     header.append(" ")
     header.append(status_symbol)
+    if status_text:
+        header.append("  ")
+        header.append(status_text)
     if version:
         header.append(f"  v{version}", style="dim")
     console.print(header)
@@ -986,6 +1254,7 @@ def _show_verbose_report(
     check_only: bool,
     umbrella_deps=None,
     bundle_results: dict[str, "BundleStatus"] | None = None,
+    bundle_plan: dict[str, SourceReportState] | None = None,
 ) -> None:
     """Show detailed multi-line format for each source (no truncation)."""
 
@@ -1000,7 +1269,10 @@ def _show_verbose_report(
             # Handle local installs specially
             if dep.get("is_local"):
                 status_symbol = create_status_symbol(
-                    dep["local_sha"], dep["local_sha"], dep.get("has_changes", False)
+                    dep["local_sha"],
+                    dep["local_sha"],
+                    dep.get("has_changes", False),
+                    checked=False,
                 )
                 _print_verbose_item(
                     name=dep["name"],
@@ -1010,7 +1282,9 @@ def _show_verbose_report(
                 )
             else:
                 status_symbol = create_status_symbol(
-                    dep["local_sha"], dep["remote_sha"]
+                    dep["local_sha"],
+                    dep["remote_sha"],
+                    checked=dep.get("remote_sha") not in (None, "unknown"),
                 )
                 _print_verbose_item(
                     name=dep["name"],
@@ -1075,7 +1349,10 @@ def _show_verbose_report(
 
         for mod in sorted(modules_by_name.values(), key=lambda x: x["name"]):
             status_symbol = create_status_symbol(
-                mod["local_sha"], mod["remote_sha"], mod["has_local_changes"]
+                mod["local_sha"],
+                mod["remote_sha"],
+                mod["has_local_changes"],
+                checked=mod["remote_sha"] not in (None, "unknown"),
             )
             _print_verbose_item(
                 name=mod["name"],
@@ -1092,12 +1369,13 @@ def _show_verbose_report(
     if bundle_results:
         active_bundle = _get_active_bundle_name()
         display_names = _bundle_display_names(bundle_results.keys())
+        bundle_plan = bundle_plan or _bundle_report_plan(bundle_results)
         for bundle_name in sorted(
             bundle_results.keys(),
             key=lambda n: _bundle_row_sort_key(n, bundle_results[n], display_names),
         ):
             status = bundle_results[bundle_name]
-            if status.sources:
+            if status.sources is not None:
                 # Add "(active)" marker if this is the active bundle
                 title_suffix = " (active)" if bundle_name == active_bundle else ""
                 included_by = getattr(status, "included_by", "")
@@ -1106,6 +1384,9 @@ def _show_verbose_report(
                 console.print(
                     f"[bold cyan]Bundle: {display_names[bundle_name]}"
                     f"{title_suffix}[/bold cyan]"
+                )
+                console.print(
+                    _bundle_report_state_text(status, bundle_plan[bundle_name])
                 )
                 console.print()
 
@@ -1120,15 +1401,27 @@ def _show_verbose_report(
                         elif "@" in source_name:
                             source_name = source_name.split("@")[0]
 
-                    status_symbol = create_status_symbol(
-                        source.cached_commit, source.remote_commit
+                    source_state = _classify_source_status(
+                        source,
+                        has_local_changes=bool(
+                            getattr(source, "_has_local_changes", False)
+                        ),
                     )
                     _print_verbose_item(
                         name=source_name,
-                        status_symbol=status_symbol,
+                        status_symbol=_report_state_text(source_state),
                         local_sha=source.cached_commit,
                         remote_sha=source.remote_commit,
-                        remote_url=source.source_uri,
+                        local_path=(
+                            source.source_uri
+                            if source.source_uri.startswith("file://")
+                            else None
+                        ),
+                        remote_url=(
+                            None
+                            if source.source_uri.startswith("file://")
+                            else source.source_uri
+                        ),
                     )
                     console.print()
 
@@ -1345,6 +1638,8 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
     if not force:
         console.print("  Checking bundles...")
     bundle_results = asyncio.run(_check_all_bundle_status())
+    bundle_plan = _bundle_report_plan(bundle_results)
+    bundle_labels = _bundle_display_names(bundle_results.keys())
     has_bundle_updates = (
         any(s.has_updates for s in bundle_results.values()) if bundle_results else False
     )
@@ -1370,6 +1665,7 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
             check_only,
             umbrella_deps=umbrella_deps,
             bundle_results=bundle_results,
+            bundle_plan=bundle_plan,
         )
     else:
         _show_concise_report(
@@ -1378,6 +1674,7 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
             has_umbrella_updates,
             umbrella_deps=umbrella_deps,
             bundle_results=bundle_results,
+            bundle_plan=bundle_plan,
         )
 
     # Check if anything actually needs updating
@@ -1390,12 +1687,33 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
 
     # Exit early if nothing to update
     if nothing_to_update:
-        console.print("[green]✓ All sources up to date[/green]")
+        unchecked, local_changes, pinned = _unconfirmed_source_counts(
+            report, bundle_results, umbrella_deps
+        )
+        if unchecked:
+            console.print(
+                f"[dim]No confirmed updates; {unchecked} source"
+                f"{'s' if unchecked != 1 else ''} could not be checked[/dim]"
+            )
+        elif local_changes:
+            console.print(
+                f"[dim]No confirmed updates; {local_changes} source"
+                f"{'s' if local_changes != 1 else ''} "
+                f"{'have' if local_changes != 1 else 'has'} local changes[/dim]"
+            )
+        elif pinned:
+            console.print(
+                f"[dim]No confirmed updates; {pinned} pinned source"
+                f"{'s' if pinned != 1 else ''} "
+                f"{'were' if pinned != 1 else 'was'} not checked[/dim]"
+            )
+        else:
+            console.print("[green]✓ All sources up to date[/green]")
         return
 
     # Check-only mode (we know there ARE updates if we got here)
     if check_only:
-        console.print("\n[yellow]Updates available:[/yellow]")
+        console.print("\n[yellow]Available actions:[/yellow]")
         if has_umbrella_updates:
             console.print("  • Amplifier (umbrella dependencies have updates)")
         if report.has_updates:
@@ -1404,7 +1722,10 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
             bundles_with_updates = [
                 name for name, status in bundle_results.items() if status.has_updates
             ]
-            console.print(f"  • {len(bundles_with_updates)} bundle(s)")
+            for line in _bundle_action_lines(
+                bundles_with_updates, bundle_plan, bundle_results
+            ):
+                console.print(f"  • {line}")
         console.print("\nRun [cyan]amplifier update[/cyan] to install")
         return
 
@@ -1425,8 +1746,10 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
                 f"  • Update {count} cached module{'s' if count != 1 else ''}"
             )
         if bundles_with_updates:
-            count = len(bundles_with_updates)
-            console.print(f"  • Update {count} bundle{'s' if count != 1 else ''}")
+            for line in _bundle_action_lines(
+                bundles_with_updates, bundle_plan, bundle_results
+            ):
+                console.print(f"  • {line}")
         if has_umbrella_updates:
             console.print(
                 "  • Update Amplifier to latest version (dependencies have updates)"
@@ -1540,7 +1863,11 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
         for item in result.staged:
             console.print(f"  [yellow]→[/yellow] {item} [dim](staged)[/dim]")
         for bundle_name in bundle_updated:
-            console.print(f"  [green]✓[/green] Bundle: {bundle_name}")
+            console.print(
+                f"  [green]✓[/green] "
+                f"{_bundle_completion_verb(bundle_plan.get(bundle_name))} bundle: "
+                f"{escape_markup(bundle_labels[bundle_name])}"
+            )
         for msg in result.messages:
             console.print(f"  {msg}")
     else:
@@ -1553,14 +1880,20 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
         for item in result.staged:
             console.print(f"  [yellow]→[/yellow] {item} [dim](staged)[/dim]")
         for bundle_name in bundle_updated:
-            console.print(f"  [green]✓[/green] Bundle: {bundle_name}")
+            console.print(
+                f"  [green]✓[/green] "
+                f"{_bundle_completion_verb(bundle_plan.get(bundle_name))} bundle: "
+                f"{escape_markup(bundle_labels[bundle_name])}"
+            )
         for item in result.failed:
             error = result.errors.get(item, "Unknown error")
             console.print(f"  [red]✗[/red] {item}: {escape_markup(error)}")
         for bundle_name in bundle_failed:
             error = bundle_errors.get(bundle_name, "Unknown error")
             console.print(
-                f"  [red]✗[/red] Bundle: {bundle_name}: {escape_markup(error)}"
+                f"  [red]✗[/red] "
+                f"{_bundle_failure_verb(bundle_plan.get(bundle_name))} bundle: "
+                f"{escape_markup(bundle_labels[bundle_name])}: {escape_markup(error)}"
             )
         for msg in result.messages:
             console.print(f"  {msg}")

--- a/amplifier_app_cli/utils/display.py
+++ b/amplifier_app_cli/utils/display.py
@@ -11,16 +11,25 @@ from rich.text import Text
 console = Console()
 
 
-def create_status_symbol(local_sha: str | None, remote_sha: str | None, has_local_changes: bool = False) -> Text:
+def create_status_symbol(
+    local_sha: str | None,
+    remote_sha: str | None,
+    has_local_changes: bool = False,
+    *,
+    checked: bool = True,
+) -> Text:
     """Create styled status symbol based on update state.
 
     Returns:
         ● (yellow) - update available (remote has value and local is missing or different)
         ◦ (cyan) - local changes
         ✓ (green) - up to date
+        ? (dim) - comparison was not available
     """
     if has_local_changes:
         return Text("◦", style="cyan")
+    if not checked:
+        return Text("?", style="dim")
     # Update available if: remote exists AND (local is missing OR local differs from remote)
     if remote_sha and (not local_sha or local_sha != remote_sha):
         return Text("●", style="yellow")
@@ -35,7 +44,7 @@ def create_sha_text(sha: str | None, style: str = "dim") -> Text:
 def print_legend() -> None:
     """Print status symbol legend at the bottom of reports."""
     console.print(
-        "[dim]Legend: [green]✓[/green] up to date  [yellow]●[/yellow] update available  [cyan]◦[/cyan] local changes[/dim]"
+        "[dim]Legend: [green]✓[/green] up to date  [yellow]●[/yellow] update available  [cyan]◦[/cyan] local changes  ? not checked[/dim]"
     )
 
 

--- a/tests/test_bundle_commands.py
+++ b/tests/test_bundle_commands.py
@@ -11,6 +11,8 @@ from click.testing import CliRunner
 
 from amplifier_app_cli.utils.source_status import UpdateReport
 from amplifier_app_cli.utils.update_executor import ExecutionResult
+from amplifier_foundation.sources.protocol import SourceStatus
+from amplifier_foundation.updates import BundleStatus
 
 
 bundle_module = importlib.import_module("amplifier_app_cli.commands.bundle")
@@ -276,7 +278,19 @@ def test_global_update_loads_an_app_target_by_source_uri(monkeypatch):
     """Applying a global update must load an app bundle from its URI, not an alias."""
     import amplifier_foundation
 
-    status = SimpleNamespace(has_updates=True, bundle_source=_FRAGMENT_URI)
+    status = BundleStatus(
+        bundle_name="app target",
+        bundle_source=_FRAGMENT_URI,
+        sources=[
+            SourceStatus(
+                source_uri=_FRAGMENT_URI,
+                is_cached=True,
+                cached_commit="a" * 40,
+                remote_commit="b" * 40,
+                has_update=True,
+            )
+        ],
+    )
     loaded_uris = []
     updated_bundles = []
 

--- a/tests/test_update_reporting.py
+++ b/tests/test_update_reporting.py
@@ -1,0 +1,788 @@
+"""Regression coverage for update-reporting labels and summaries."""
+
+from __future__ import annotations
+
+from contextlib import ExitStack
+import io
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from click.testing import CliRunner
+import pytest
+from rich.console import Console
+
+from amplifier_app_cli.commands import update as update_module
+from amplifier_app_cli.commands.update import _classify_source_status
+from amplifier_app_cli.commands.update import TransitiveBundleStatus
+from amplifier_app_cli.commands.update import update
+from amplifier_app_cli.utils.source_status import CachedGitStatus
+from amplifier_app_cli.utils.source_status import UpdateReport
+from amplifier_app_cli.utils.update_executor import ExecutionResult
+from amplifier_foundation.sources.protocol import SourceStatus
+from amplifier_foundation.updates import BundleStatus
+
+
+def _source(
+    uri: str,
+    *,
+    is_cached: bool,
+    has_update: bool | None,
+    cached_commit: str | None = None,
+    remote_commit: str | None = None,
+    cached_ref: str | None = "main",
+    error: str | None = None,
+) -> SourceStatus:
+    return SourceStatus(
+        source_uri=uri,
+        is_cached=is_cached,
+        cached_ref=cached_ref,
+        has_update=has_update,
+        cached_commit=cached_commit,
+        remote_commit=remote_commit,
+        error=error,
+    )
+
+
+def _bundle(name: str, source: SourceStatus) -> BundleStatus:
+    return BundleStatus(bundle_name=name, bundle_source=source.source_uri, sources=[source])
+
+
+@pytest.mark.parametrize(
+    ("has_update", "is_cached", "cached_commit", "remote_commit", "expected"),
+    [
+        (False, True, "a" * 40, "a" * 40, "current"),
+        (False, True, "a" * 40, "b" * 40, "not_checked"),
+        (False, True, None, "a" * 40, "not_checked"),
+        (False, False, None, "a" * 40, "not_checked"),
+        (None, True, "a" * 40, "a" * 40, "not_checked"),
+        (None, True, "a" * 40, None, "not_checked"),
+    ],
+)
+def test_source_status_current_requires_a_confirmed_equal_comparison(
+    has_update, is_cached, cached_commit, remote_commit, expected
+):
+    source = _source(
+        "git+https://example.invalid/source@main",
+        is_cached=is_cached,
+        has_update=has_update,
+        cached_commit=cached_commit,
+        remote_commit=remote_commit,
+    )
+
+    assert _classify_source_status(source) == expected
+
+
+def _command_patches(report, bundle_results, *, details=None, execute_calls=None):
+    """Patch only status/update boundaries around the real Click command."""
+
+    async def fake_check_all_sources(**kwargs):
+        return report
+
+    async def fake_check_all_bundle_status():
+        return bundle_results
+
+    async def fake_pypi_check():
+        return False
+
+    async def fake_details(info):
+        return details or []
+
+    async def fake_execute_updates(*args, **kwargs):
+        if execute_calls is not None:
+            execute_calls.append((args, kwargs))
+        return ExecutionResult(success=True, updated=[], messages=[])
+
+    return (
+        patch(
+            "amplifier_app_cli.utils.umbrella_discovery.discover_umbrella_source",
+            return_value=SimpleNamespace(),
+        ),
+        patch(
+            "amplifier_app_cli.utils.update_executor.check_pypi_packages_for_updates",
+            side_effect=fake_pypi_check,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.check_all_sources",
+            side_effect=fake_check_all_sources,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update._check_all_bundle_status",
+            side_effect=fake_check_all_bundle_status,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update._get_umbrella_dependency_details",
+            side_effect=fake_details,
+        ),
+        patch(
+            "amplifier_app_cli.commands.update.execute_updates",
+            side_effect=fake_execute_updates,
+        ),
+        patch("amplifier_app_cli.commands.update._refresh_skills_cache"),
+        patch("amplifier_app_cli.commands.update.save_update_last_check"),
+    )
+
+
+def test_missing_bundle_caches_are_downloads_not_updates(monkeypatch):
+    """A cache reset keeps lazy downloads, but calls the first fetch a download."""
+
+    direct_uri = "git+https://example.invalid/direct@main"
+    direct = _bundle(
+        "direct",
+        _source(
+            direct_uri,
+            is_cached=False,
+            has_update=True,
+            remote_commit="a" * 40,
+        ),
+    )
+    transitives = {
+        f"git+https://example.invalid/transitive-{number}@main": TransitiveBundleStatus(
+            bundle_name=f"transitive-{number}",
+            bundle_source=f"git+https://example.invalid/transitive-{number}@main",
+            sources=[
+                _source(
+                    f"git+https://example.invalid/transitive-{number}@main",
+                    is_cached=False,
+                    has_update=True,
+                    remote_commit=f"{number:x}" * 40,
+                )
+            ],
+            included_by="direct",
+            included_under="direct",
+        )
+        for number in range(1, 9)
+    }
+    current = _bundle(
+        "cached-filesystem",
+        _source(
+            "git+https://example.invalid/current@main",
+            is_cached=True,
+            has_update=False,
+            cached_commit="b" * 40,
+            remote_commit="b" * 40,
+        ),
+    )
+    unchecked = {
+        f"local-{number}": _bundle(
+            f"local-{number}",
+            _source(
+                f"file:///workspace/local-{number}",
+                is_cached=True,
+                has_update=None,
+                cached_ref=None,
+            ),
+        )
+        for number in range(1, 4)
+    }
+    bundle_results = {"direct": direct, **transitives, "cached-filesystem": current, **unchecked}
+    report = UpdateReport(
+        local_file_sources=[],
+        cached_git_sources=[
+            CachedGitStatus(
+                name="current-module",
+                cached_sha="c" * 7,
+                remote_sha="c" * 7,
+                has_update=False,
+            )
+        ],
+    )
+    package_details = [
+        {
+            "name": "amplifier-core (PyPI)",
+            "local_sha": "1.0.0",
+            "remote_sha": "1.0.0",
+            "source_url": "https://pypi.org/project/amplifier-core/",
+            "has_update": False,
+            "is_local": False,
+            "path": None,
+            "has_changes": False,
+            "display_type": "version",
+        }
+    ]
+
+    direct_loads: list[str] = []
+    direct_updates: list[str] = []
+    refreshed: list[str] = []
+
+    async def fake_load_bundle(uri, *, auto_include):
+        direct_loads.append(uri)
+        return SimpleNamespace(uri=uri)
+
+    async def fake_update_bundle(bundle):
+        direct_updates.append(bundle.uri)
+
+    async def fake_refresh(uri, *, cache_dir):
+        refreshed.append(uri)
+
+    patches = _command_patches(report, bundle_results, details=package_details)
+    with ExitStack() as stack:
+        for boundary in patches:
+            stack.enter_context(boundary)
+        stack.enter_context(
+            patch("amplifier_foundation.load_bundle", side_effect=fake_load_bundle)
+        )
+        stack.enter_context(
+            patch("amplifier_foundation.update_bundle", side_effect=fake_update_bundle)
+        )
+        stack.enter_context(
+            patch(
+                "amplifier_app_cli.utils.include_graph.refresh_transitive_source",
+                side_effect=fake_refresh,
+            )
+        )
+        runner = CliRunner()
+        checked = runner.invoke(update, ["--check-only"])
+        declined = runner.invoke(update, input="n\n")
+        assert not direct_loads
+        assert not direct_updates
+        assert not refreshed
+        accepted = runner.invoke(update, ["--yes"])
+
+    assert checked.exit_code == 0, checked.output
+    assert "Download 9 bundles" in checked.output
+    assert "Update 9 bundles" not in checked.output
+    assert "Available actions:" in checked.output
+    assert "Updates available:" not in checked.output
+    assert "Download" in checked.output
+    assert "Not checked" in checked.output
+    assert "Current" in checked.output
+    assert direct_loads == [direct_uri]
+    assert direct_updates == [direct_uri]
+    assert refreshed == list(transitives)
+    assert "Downloaded bundle: direct" in accepted.output
+    assert accepted.output.count("Downloaded bundle:") == 9
+    assert declined.exit_code == 0, declined.output
+    assert "Download 9 bundles" in declined.output
+    assert "Update 9 bundles" not in declined.output
+    assert accepted.exit_code == 0, accepted.output
+
+
+def test_current_caches_with_unchecked_local_sources_are_not_all_current():
+    """Unknown local sources prevent a green all-current summary without an action."""
+
+    current = _bundle(
+        "current",
+        _source(
+            "git+https://example.invalid/current@main",
+            is_cached=True,
+            has_update=False,
+            cached_commit="a" * 40,
+            remote_commit="a" * 40,
+        ),
+    )
+    unchecked = {
+        f"local-{number}": _bundle(
+            f"local-{number}",
+            _source(
+                f"file:///workspace/local-{number}",
+                is_cached=True,
+                has_update=None,
+                cached_ref=None,
+            ),
+        )
+        for number in range(1, 4)
+    }
+    report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+    execute_calls: list[tuple[tuple, dict]] = []
+    patches = _command_patches(
+        report, {"current": current, **unchecked}, execute_calls=execute_calls
+    )
+    with ExitStack() as stack:
+        for boundary in patches:
+            stack.enter_context(boundary)
+        result = CliRunner().invoke(update, ["--check-only"])
+
+    assert result.exit_code == 0, result.output
+    assert "No confirmed updates; 3 sources could not be checked" in result.output
+    assert "All sources up to date" not in result.output
+    assert not execute_calls
+
+
+def test_all_confirmed_current_sources_keep_the_green_summary():
+    """The previous all-current summary remains for actual equal comparisons."""
+
+    current = _bundle(
+        "current",
+        _source(
+            "git+https://example.invalid/current@main",
+            is_cached=True,
+            has_update=False,
+            cached_commit="a" * 40,
+            remote_commit="a" * 40,
+        ),
+    )
+    report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+    patches = _command_patches(report, {"current": current})
+    with ExitStack() as stack:
+        for boundary in patches:
+            stack.enter_context(boundary)
+        result = CliRunner().invoke(update, ["--check-only"])
+
+    assert result.exit_code == 0, result.output
+    assert "All sources up to date" in result.output
+    assert "No confirmed updates" not in result.output
+
+
+def test_local_umbrella_dependency_prevents_a_false_all_current_summary():
+    """A local umbrella dependency is neutral, not confirmation of freshness."""
+
+    report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+    details = [
+        {
+            "name": "local-dependency",
+            "local_sha": "a" * 40,
+            "remote_sha": None,
+            "source_url": "file:///workspace/local-dependency",
+            "has_update": False,
+            "is_local": True,
+            "path": "/workspace/local-dependency",
+            "has_changes": False,
+        }
+    ]
+    patches = _command_patches(report, {}, details=details)
+    with ExitStack() as stack:
+        for boundary in patches:
+            stack.enter_context(boundary)
+        result = CliRunner().invoke(update, ["--check-only"])
+
+    assert result.exit_code == 0, result.output
+    assert "No confirmed updates; 1 source could not be checked" in result.output
+    assert "All sources up to date" not in result.output
+
+
+def test_empty_bundle_is_unchecked_and_does_not_run_or_claim_all_current():
+    """An empty status has no confirmed comparison, nor an executable update."""
+
+    report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+    execute_calls: list[tuple[tuple, dict]] = []
+    empty = BundleStatus(bundle_name="empty", bundle_source="file:///workspace/empty")
+    patches = _command_patches(report, {"empty": empty}, execute_calls=execute_calls)
+    with ExitStack() as stack:
+        for boundary in patches:
+            stack.enter_context(boundary)
+        result = CliRunner().invoke(update, ["--check-only"])
+        verbose = CliRunner().invoke(update, ["--check-only", "--verbose"])
+
+    assert result.exit_code == 0, result.output
+    assert verbose.exit_code == 0, verbose.output
+    assert "Not checked" in result.output
+    assert "Bundle: empty" in verbose.output
+    assert "Not checked" in verbose.output
+    assert "No confirmed updates; 1 source could not be checked" in result.output
+    assert "All sources up to date" not in result.output
+    assert not execute_calls
+
+
+@pytest.mark.parametrize("verbose", [False, True])
+def test_local_umbrella_dependencies_are_neutral_or_cyan_not_green(monkeypatch, verbose):
+    """Clean local dependencies are uncheckable; dirty ones retain cyan status."""
+
+    details = [
+        {
+            "name": "clean-local",
+            "local_sha": "a" * 40,
+            "remote_sha": None,
+            "source_url": "file:///workspace/clean-local",
+            "has_update": False,
+            "is_local": True,
+            "path": "/workspace/clean-local",
+            "has_changes": False,
+        },
+        {
+            "name": "dirty-local",
+            "local_sha": "b" * 40,
+            "remote_sha": None,
+            "source_url": "file:///workspace/dirty-local",
+            "has_update": False,
+            "is_local": True,
+            "path": "/workspace/dirty-local",
+            "has_changes": True,
+        },
+    ]
+    buffer = io.StringIO()
+    monkeypatch.setattr(
+        update_module,
+        "console",
+        Console(file=buffer, force_terminal=True, color_system="standard", width=200),
+    )
+    report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+
+    if verbose:
+        update_module._show_verbose_report(report, True, umbrella_deps=details)
+    else:
+        update_module._show_concise_report(
+            report, True, False, umbrella_deps=details
+        )
+
+    rows, _, _ = buffer.getvalue().partition("Legend:")
+    assert "clean-local" in rows
+    assert "?" in rows
+    assert "\x1b[32m?\x1b[0m" not in rows
+    assert "\x1b[36m◦" in rows
+
+
+def test_verbose_file_bundle_source_is_local_not_remote(monkeypatch):
+    """A file URI is a local path in a verbose bundle source entry."""
+
+    source = _source(
+        "file:///workspace/local-bundle",
+        is_cached=True,
+        has_update=None,
+        cached_commit="a" * 40,
+        cached_ref=None,
+    )
+    bundle = _bundle("local-bundle", source)
+    buffer = io.StringIO()
+    monkeypatch.setattr(update_module, "console", Console(file=buffer, width=200))
+
+    update_module._show_verbose_report(
+        UpdateReport(local_file_sources=[], cached_git_sources=[]),
+        True,
+        bundle_results={"local-bundle": bundle},
+    )
+
+    output = buffer.getvalue()
+    assert "Local:  aaaaaaa  file:///workspace/local-bundle" in output
+    assert "Remote: file:///workspace/local-bundle" not in output
+
+
+def test_mixed_bundle_states_render_the_same_plan_in_both_reports():
+    """Classification is independent of foundation summaries and has no side effects."""
+
+    dirty = _source(
+        "file:///workspace/dirty",
+        is_cached=True,
+        has_update=True,
+        cached_commit="1" * 40,
+        remote_commit="2" * 40,
+    )
+    dirty._has_local_changes = True
+    states = {
+        "stale": _bundle(
+            "stale",
+            _source(
+                "git+https://example.invalid/stale@main",
+                is_cached=True,
+                has_update=True,
+                cached_commit="3" * 40,
+                remote_commit="4" * 40,
+            ),
+        ),
+        "missing": _bundle(
+            "missing",
+            _source(
+                "git+https://example.invalid/missing@main",
+                is_cached=False,
+                has_update=True,
+                remote_commit="5" * 40,
+            ),
+        ),
+        "unreadable": _bundle(
+            "unreadable",
+            _source(
+                "git+https://example.invalid/unreadable@main",
+                is_cached=True,
+                has_update=True,
+                remote_commit="6" * 40,
+            ),
+        ),
+        "unknown": _bundle(
+            "unknown",
+            _source("file:///workspace/unknown", is_cached=True, has_update=None),
+        ),
+        "dirty": _bundle("dirty", dirty),
+        "pinned-cached": _bundle(
+            "pinned-cached",
+            _source(
+                "git+https://example.invalid/pinned@v1.0.0",
+                is_cached=True,
+                has_update=False,
+                cached_ref="v1.0.0",
+            ),
+        ),
+        "pinned-missing": _bundle(
+            "pinned-missing",
+            _source(
+                "git+https://example.invalid/pinned-missing@v1.0.0",
+                is_cached=False,
+                has_update=False,
+                cached_ref="v1.0.0",
+            ),
+        ),
+        "error": _bundle(
+            "error",
+            _source(
+                "git+https://example.invalid/error@main",
+                is_cached=True,
+                has_update=True,
+                cached_commit="7" * 40,
+                remote_commit="8" * 40,
+                error="remote failed",
+            ),
+        ),
+    }
+    report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+    before = [name for name, status in states.items() if status.has_updates]
+    patches = _command_patches(report, states)
+    with ExitStack() as stack:
+        for boundary in patches:
+            stack.enter_context(boundary)
+        concise = CliRunner().invoke(update, ["--check-only"])
+        verbose = CliRunner().invoke(update, ["--check-only", "--verbose"])
+    after = [name for name, status in states.items() if status.has_updates]
+
+    assert concise.exit_code == 0, concise.output
+    assert verbose.exit_code == 0, verbose.output
+    assert before == after == ["stale", "missing", "unreadable", "dirty", "error"]
+    for label in ("Update", "Download", "Refresh cache", "Not checked", "Local changes", "Pinned"):
+        assert label in concise.output
+        assert label in verbose.output
+    assert "Pinned; not cached" in concise.output
+    assert "Pinned; not cached" in verbose.output
+    assert "Download 1 bundle" in concise.output
+    assert "Refresh cache 1 bundle" in concise.output
+    assert "Update 1 bundle" in concise.output
+
+
+def test_mixed_actions_process_one_bundle_once_and_report_its_composition():
+    """A selected bundle with multiple actions is not counted in exclusive buckets."""
+
+    uri = "git+https://example.invalid/mixed@main"
+    mixed = BundleStatus(
+        bundle_name="mixed",
+        bundle_source=uri,
+        sources=[
+            _source(
+                uri,
+                is_cached=True,
+                has_update=False,
+                cached_commit="a" * 40,
+                remote_commit="a" * 40,
+            ),
+            _source(
+                "git+https://example.invalid/missing-child@main",
+                is_cached=False,
+                has_update=True,
+                remote_commit="b" * 40,
+            ),
+            _source(
+                "git+https://example.invalid/stale-child@main",
+                is_cached=True,
+                has_update=True,
+                cached_commit="c" * 40,
+                remote_commit="d" * 40,
+            ),
+            _source(
+                "file:///workspace/unchecked-child",
+                is_cached=True,
+                has_update=None,
+                cached_ref=None,
+            ),
+        ],
+    )
+    report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+    loads: list[str] = []
+    updates: list[str] = []
+
+    async def fake_load_bundle(source_uri, *, auto_include):
+        loads.append(source_uri)
+        return SimpleNamespace()
+
+    async def fake_update_bundle(bundle):
+        updates.append("called")
+
+    patches = _command_patches(report, {"mixed": mixed})
+    with ExitStack() as stack:
+        for boundary in patches:
+            stack.enter_context(boundary)
+        stack.enter_context(
+            patch("amplifier_foundation.load_bundle", side_effect=fake_load_bundle)
+        )
+        stack.enter_context(
+            patch("amplifier_foundation.update_bundle", side_effect=fake_update_bundle)
+        )
+        checked = CliRunner().invoke(update, ["--check-only"])
+        accepted = CliRunner().invoke(update, ["--yes", "--verbose"])
+
+    assert checked.exit_code == 0, checked.output
+    assert "Mixed actions (download + update)" in checked.output
+    assert "Process 1 bundle with downloads and updates" in checked.output
+    assert "Download 1 bundle" not in checked.output
+    assert "Update 1 bundle" not in checked.output
+    assert accepted.exit_code == 0, accepted.output
+    assert "Not checked" in accepted.output
+    assert "Processed bundle: mixed" in accepted.output
+    assert loads == [uri]
+    assert updates == ["called"]
+
+
+def test_selected_neutral_bundle_states_are_confirmed_and_processed_once():
+    """Legacy-selected local/error statuses are named honestly instead of omitted."""
+
+    mixed_uri = "git+https://example.invalid/mixed@main"
+    dirty_uri = "git+https://example.invalid/dirty@main"
+    error_uri = "git+https://example.invalid/error@main"
+    dirty_source = _source(
+        dirty_uri,
+        is_cached=True,
+        has_update=True,
+        cached_commit="a" * 40,
+        remote_commit="b" * 40,
+    )
+    dirty_source._has_local_changes = True
+    bundle_results = {
+        "mixed": BundleStatus(
+            bundle_name="mixed",
+            bundle_source=mixed_uri,
+            sources=[
+                _source(
+                    "git+https://example.invalid/missing@main",
+                    is_cached=False,
+                    has_update=True,
+                    remote_commit="c" * 40,
+                ),
+                _source(
+                    "git+https://example.invalid/stale@main",
+                    is_cached=True,
+                    has_update=True,
+                    cached_commit="d" * 40,
+                    remote_commit="e" * 40,
+                ),
+            ],
+        ),
+        "dirty": _bundle("dirty", dirty_source),
+        "error": _bundle(
+            "error",
+            _source(
+                error_uri,
+                is_cached=True,
+                has_update=True,
+                cached_commit="f" * 40,
+                remote_commit="0" * 40,
+                error="remote unavailable",
+            ),
+        ),
+    }
+    report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+    loads: list[str] = []
+
+    async def fake_load_bundle(uri, *, auto_include):
+        loads.append(uri)
+        return SimpleNamespace()
+
+    async def fake_update_bundle(bundle):
+        return None
+
+    patches = _command_patches(report, bundle_results)
+    with ExitStack() as stack:
+        for boundary in patches:
+            stack.enter_context(boundary)
+        stack.enter_context(
+            patch("amplifier_foundation.load_bundle", side_effect=fake_load_bundle)
+        )
+        stack.enter_context(
+            patch("amplifier_foundation.update_bundle", side_effect=fake_update_bundle)
+        )
+        result = CliRunner().invoke(update, input="\n")
+
+    assert result.exit_code == 0, result.output
+    assert "Process 1 bundle with downloads and updates" in result.output
+    assert "Process 1 bundle with local changes" in result.output
+    assert "Process 1 bundle with unconfirmed sources" in result.output
+    assert loads == [mixed_uri, dirty_uri, error_uri]
+    assert "Processed bundle: dirty" in result.output
+    assert "Processed bundle: error" in result.output
+
+
+def test_bundle_completion_reports_failed_operation_without_a_success_verb():
+    """Failures say failed to <operation>; past-tense verbs are success-only."""
+
+    download_uri = "git+https://example.invalid/download@main"
+    update_uri = "git+https://example.invalid/update@main"
+    bundle_results = {
+        "download": _bundle(
+            "download",
+            _source(download_uri, is_cached=False, has_update=True, remote_commit="a" * 40),
+        ),
+        "update": _bundle(
+            "update",
+            _source(
+                update_uri,
+                is_cached=True,
+                has_update=True,
+                cached_commit="b" * 40,
+                remote_commit="c" * 40,
+            ),
+        ),
+    }
+    report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+
+    async def fake_load_bundle(uri, *, auto_include):
+        if uri == download_uri:
+            raise RuntimeError("cannot load download")
+        if uri == update_uri:
+            raise RuntimeError("cannot load update")
+        return SimpleNamespace(uri=uri)
+
+    async def fake_update_bundle(bundle):
+        return None
+
+    patches = _command_patches(report, bundle_results)
+    with ExitStack() as stack:
+        for boundary in patches:
+            stack.enter_context(boundary)
+        stack.enter_context(
+            patch("amplifier_foundation.load_bundle", side_effect=fake_load_bundle)
+        )
+        stack.enter_context(
+            patch("amplifier_foundation.update_bundle", side_effect=fake_update_bundle)
+        )
+        result = CliRunner().invoke(update, ["--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "Failed to download bundle: download: cannot load download" in result.output
+    assert "Failed to update bundle: update: cannot load update" in result.output
+    assert "Downloaded bundle: download" not in result.output
+    assert "Updated bundle: update" not in result.output
+
+
+def test_mixed_bundle_failure_reports_processing_not_a_successful_action():
+    """A composite operation has no one success verb to reuse after failure."""
+
+    uri = "git+https://example.invalid/mixed-failure@main"
+    mixed = BundleStatus(
+        bundle_name="mixed-failure",
+        bundle_source=uri,
+        sources=[
+            _source(
+                "git+https://example.invalid/missing@main",
+                is_cached=False,
+                has_update=True,
+                remote_commit="a" * 40,
+            ),
+            _source(
+                "git+https://example.invalid/stale@main",
+                is_cached=True,
+                has_update=True,
+                cached_commit="b" * 40,
+                remote_commit="c" * 40,
+            ),
+        ],
+    )
+    report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+
+    async def fake_load_bundle(source_uri, *, auto_include):
+        raise RuntimeError("cannot process mixed")
+
+    patches = _command_patches(report, {"mixed-failure": mixed})
+    with ExitStack() as stack:
+        for boundary in patches:
+            stack.enter_context(boundary)
+        stack.enter_context(
+            patch("amplifier_foundation.load_bundle", side_effect=fake_load_bundle)
+        )
+        result = CliRunner().invoke(update, ["--yes"])
+
+    assert result.exit_code == 0, result.output
+    assert "Failed to process bundle: mixed-failure: cannot process mixed" in result.output
+    assert "Processed bundle: mixed-failure" not in result.output


### PR DESCRIPTION
## Summary
- Distinguish bundle downloads, updates, refresh-cache actions, unchecked sources, pinned sources, and local changes in `amplifier update` reporting.
- Keep aggregate mixed states and failure labels truthful, including completion verbs.
- Add a short reporting convention and real Click-command regression coverage for the nine-source download scenario.

## Verification
- Full offline suite in the isolated target environment: 2067 passed, 3 skipped, 13 deselected, 1 xfailed in 20.65s.
- Independent focused review: 60 tests passed.
- Regression tests exercise the real Click command while mocking only external status/apply boundaries.
- One initial environment-sensitive truststore check failed in an unisolated local run; a clean-environment rerun passed without source or package changes. This change does not alter truststore behavior.
- No live reset, network update, LLM, or DTU run was used for this fix.

## Scope
- Reporting-only CLI change. Bundle discovery/inventory, startup, action selection, force handling, and exit semantics are unchanged.
- CI expected: six unit-matrix jobs, two POSIX integration jobs, and the repository CLA check.
- No breaking changes.