### PR TITLE
fix: use consistent status labels in update reports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,5 +49,7 @@ legacy limitation.
 
 Keep report labels separate from update eligibility: a missing mutable cache is
 a download, not a newer revision, and an unchecked source is not current.
+Use the same word-status vocabulary in every `amplifier update` section,
+including verbose output.
 Exercise the real Click command in `tests/test_update_reporting.py`; mock only
 status/apply boundaries so tests never touch a user's caches or installation.

--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -24,8 +24,6 @@ from ..paths import create_bundle_registry
 from ..paths import create_config_manager
 from ..utils.atomic_write import atomic_write_json
 from ..utils.display import create_sha_text
-from ..utils.display import create_status_symbol
-from ..utils.display import print_legend
 from ..utils.error_format import escape_markup
 from ..utils.settings_manager import save_update_last_check
 from ..utils.source_status import check_all_sources
@@ -114,6 +112,28 @@ def _classify_source_status(
     if not source.cached_commit:
         return "refresh_cache"
     return "update" if source.cached_commit != source.remote_commit else "not_checked"
+
+
+def _revision_report_state(
+    local_sha: str | None,
+    remote_sha: str | None,
+    *,
+    has_local_changes: bool = False,
+    checked: bool = True,
+) -> SourceReportState:
+    """Classify a known revision comparison for display only."""
+
+    if has_local_changes:
+        return "local_changes"
+    if (
+        not checked
+        or not local_sha
+        or not remote_sha
+        or local_sha == "unknown"
+        or remote_sha == "unknown"
+    ):
+        return "not_checked"
+    return "current" if local_sha == remote_sha else "update"
 
 
 def _bundle_source_states(status: "BundleStatus") -> tuple[SourceReportState, ...]:
@@ -961,14 +981,17 @@ def _create_local_package_table(packages: list[dict], title: str) -> Table | Non
     table.add_column("Package", style="green")
     table.add_column("Version", style="dim", justify="right")
     table.add_column("SHA", style="dim", justify="right")
-    table.add_column("", width=1, justify="center")
+    table.add_column("Status", justify="center")
 
     for pkg in packages:
-        # Status: ◦ only if actual uncommitted changes, otherwise ✓
-        if pkg["has_changes"]:
-            status_symbol = Text("◦", style="cyan")
-        else:
-            status_symbol = Text("✓", style="green")
+        status_text = _report_state_text(
+            _revision_report_state(
+                pkg["sha"],
+                None,
+                has_local_changes=pkg["has_changes"],
+                checked=False,
+            )
+        )
 
         # SHA display: show SHA if available, "local" if local but no git, "-" otherwise
         if pkg["sha"]:
@@ -982,7 +1005,7 @@ def _create_local_package_table(packages: list[dict], title: str) -> Table | Non
             pkg["name"],
             Text(pkg["version"], style="dim"),
             sha_display,
-            status_symbol,
+            status_text,
         )
 
     return table
@@ -999,7 +1022,7 @@ def _show_concise_report(
     """Show concise table format for all sources.
 
     Organized by type: Core → Application → Libraries → Modules → Collections → Bundles
-    Uses Rich Tables with status symbols: ✓ (up to date), ● (update available), ◦ (local changes)
+    Uses Rich Tables with plain-language statuses.
     """
     console.print()
 
@@ -1010,7 +1033,7 @@ def _show_concise_report(
         table.add_column("Package", style="green")
         table.add_column("Local", style="dim", justify="right")
         table.add_column("Remote", style="dim", justify="right")
-        table.add_column("", width=1, justify="center")
+        table.add_column("Status", justify="center")
 
         for dep in sorted(umbrella_deps, key=lambda x: x["name"]):
             # Handle local installs specially - show path indicator
@@ -1026,13 +1049,12 @@ def _show_concise_report(
                     name_display = f"{dep['name']} [dim]({path})[/dim]"
                 else:
                     name_display = f"{dep['name']} [dim](local)[/dim]"
-                # Local changes indicator
-                status_symbol = create_status_symbol(
+                status_text = _report_state_text(_revision_report_state(
                     dep["local_sha"],
-                    dep["local_sha"],
-                    dep.get("has_changes", False),
+                    dep.get("remote_sha"),
+                    has_local_changes=dep.get("has_changes", False),
                     checked=False,
-                )
+                ))
                 remote_display = Text("-", style="dim")
             elif dep.get("display_type") == "version":
                 # PyPI package: show full version strings, not 7-char SHA truncation.
@@ -1040,27 +1062,27 @@ def _show_concise_report(
                 name_display = dep["name"]
                 local_display = Text(dep["local_sha"] or "unknown", style="dim")
                 remote_display = Text(dep["remote_sha"] or "unknown", style="dim")
-                status_symbol = create_status_symbol(
+                status_text = _report_state_text(_revision_report_state(
                     dep["local_sha"],
                     dep["remote_sha"],
-                    checked=dep.get("remote_sha") not in (None, "unknown"),
-                )
+                    checked=dep.get("remote_sha") not in (None, "", "unknown"),
+                ))
             else:
                 # Standard git install - compare local vs remote
                 name_display = dep["name"]
                 local_display = create_sha_text(dep["local_sha"])
                 remote_display = create_sha_text(dep["remote_sha"])
-                status_symbol = create_status_symbol(
+                status_text = _report_state_text(_revision_report_state(
                     dep["local_sha"],
                     dep["remote_sha"],
-                    checked=dep.get("remote_sha") not in (None, "unknown"),
-                )
+                    checked=dep.get("remote_sha") not in (None, "", "unknown"),
+                ))
 
             table.add_row(
                 name_display,
                 local_display,
                 remote_display,
-                status_symbol,
+                status_text,
             )
 
         console.print(table)
@@ -1077,16 +1099,16 @@ def _show_concise_report(
         table.add_column("Name", style="green")
         table.add_column("SHA", style="dim", justify="right")
         table.add_column("Path", style="dim")
-        table.add_column("", width=1, justify="center")
+        table.add_column("Status", justify="center")
 
         for status in sorted(report.local_file_sources, key=lambda x: x.name):
             has_local_changes = status.uncommitted_changes or status.unpushed_commits
-            status_symbol = create_status_symbol(
+            status_text = _report_state_text(_revision_report_state(
                 status.local_sha,
-                status.local_sha,
-                has_local_changes,
+                status.remote_sha,
+                has_local_changes=has_local_changes,
                 checked=bool(status.has_remote and status.remote_sha),
-            )
+            ))
 
             # Truncate path for display
             path_str = str(status.path) if status.path else "-"
@@ -1097,7 +1119,7 @@ def _show_concise_report(
                 status.name,
                 create_sha_text(status.local_sha),
                 Text(path_str, style="dim"),
-                status_symbol,
+                status_text,
             )
 
         console.print(table)
@@ -1113,21 +1135,21 @@ def _show_concise_report(
         table.add_column("Name", style="green")
         table.add_column("Cached", style="dim", justify="right")
         table.add_column("Remote", style="dim", justify="right")
-        table.add_column("", width=1, justify="center")
+        table.add_column("Status", justify="center")
 
         for name in sorted(unified_modules.keys()):
             info = unified_modules[name]
-            status_symbol = create_status_symbol(
+            status_text = _report_state_text(_revision_report_state(
                 info["cached_sha"],
                 info["remote_sha"],
-                checked=info["remote_sha"] not in (None, "unknown"),
-            )
+                checked=info["remote_sha"] not in (None, "", "unknown"),
+            ))
 
             table.add_row(
                 name,
                 create_sha_text(info["cached_sha"]),
                 create_sha_text(info["remote_sha"]),
-                status_symbol,
+                status_text,
             )
 
         console.print(table)
@@ -1198,7 +1220,6 @@ def _show_concise_report(
         console.print(table)
 
     console.print()
-    print_legend()
 
 def _print_verbose_item(
     name: str,
@@ -1268,12 +1289,12 @@ def _show_verbose_report(
         for dep in sorted(umbrella_deps, key=lambda x: x["name"]):
             # Handle local installs specially
             if dep.get("is_local"):
-                status_symbol = create_status_symbol(
+                status_symbol = _report_state_text(_revision_report_state(
                     dep["local_sha"],
-                    dep["local_sha"],
-                    dep.get("has_changes", False),
+                    dep.get("remote_sha"),
+                    has_local_changes=dep.get("has_changes", False),
                     checked=False,
-                )
+                ))
                 _print_verbose_item(
                     name=dep["name"],
                     status_symbol=status_symbol,
@@ -1281,11 +1302,11 @@ def _show_verbose_report(
                     local_path=dep.get("path"),
                 )
             else:
-                status_symbol = create_status_symbol(
+                status_symbol = _report_state_text(_revision_report_state(
                     dep["local_sha"],
                     dep["remote_sha"],
-                    checked=dep.get("remote_sha") not in (None, "unknown"),
-                )
+                    checked=dep.get("remote_sha") not in (None, "", "unknown"),
+                ))
                 _print_verbose_item(
                     name=dep["name"],
                     status_symbol=status_symbol,
@@ -1320,6 +1341,7 @@ def _show_verbose_report(
             "remote_sha": status.remote_sha if status.has_remote else None,
             "remote_url": None,
             "ref": None,
+            "checked": bool(status.has_remote and status.remote_sha),
         }
 
     # Merge/add cached git sources
@@ -1331,6 +1353,11 @@ def _show_verbose_report(
                 status.url if hasattr(status, "url") else None
             )
             modules_by_name[status.name]["ref"] = status.ref
+            modules_by_name[status.name]["checked"] = status.remote_sha not in (
+                None,
+                "",
+                "unknown",
+            )
         else:
             # Add new entry
             modules_by_name[status.name] = {
@@ -1341,6 +1368,7 @@ def _show_verbose_report(
                 "remote_sha": status.remote_sha,
                 "remote_url": status.url if hasattr(status, "url") else None,
                 "ref": status.ref,
+                "checked": status.remote_sha not in (None, "", "unknown"),
             }
 
     if modules_by_name:
@@ -1348,12 +1376,12 @@ def _show_verbose_report(
         console.print()
 
         for mod in sorted(modules_by_name.values(), key=lambda x: x["name"]):
-            status_symbol = create_status_symbol(
+            status_symbol = _report_state_text(_revision_report_state(
                 mod["local_sha"],
                 mod["remote_sha"],
-                mod["has_local_changes"],
-                checked=mod["remote_sha"] not in (None, "unknown"),
-            )
+                has_local_changes=mod["has_local_changes"],
+                checked=mod["checked"],
+            ))
             _print_verbose_item(
                 name=mod["name"],
                 status_symbol=status_symbol,
@@ -1424,9 +1452,6 @@ def _show_verbose_report(
                         ),
                     )
                     console.print()
-
-    print_legend()
-
 
 def _format_update_progress(name: str, phase: str) -> str:
     """Format an update progress callback into a human-readable label for the spinner.

--- a/tests/test_update_reporting.py
+++ b/tests/test_update_reporting.py
@@ -13,9 +13,11 @@ from rich.console import Console
 
 from amplifier_app_cli.commands import update as update_module
 from amplifier_app_cli.commands.update import _classify_source_status
+from amplifier_app_cli.commands.update import _revision_report_state
 from amplifier_app_cli.commands.update import TransitiveBundleStatus
 from amplifier_app_cli.commands.update import update
 from amplifier_app_cli.utils.source_status import CachedGitStatus
+from amplifier_app_cli.utils.source_status import LocalFileStatus
 from amplifier_app_cli.utils.source_status import UpdateReport
 from amplifier_app_cli.utils.update_executor import ExecutionResult
 from amplifier_foundation.sources.protocol import SourceStatus
@@ -70,6 +72,31 @@ def test_source_status_current_requires_a_confirmed_equal_comparison(
     )
 
     assert _classify_source_status(source) == expected
+
+
+@pytest.mark.parametrize(
+    ("local_sha", "remote_sha", "has_local_changes", "checked", "expected"),
+    [
+        ("a", "a", False, True, "current"),
+        ("a", "b", False, True, "update"),
+        ("a", "", False, True, "not_checked"),
+        ("a", "unknown", False, True, "not_checked"),
+        ("a", "b", False, False, "not_checked"),
+        ("a", "b", True, False, "local_changes"),
+    ],
+)
+def test_revision_report_state_requires_a_known_checked_comparison(
+    local_sha, remote_sha, has_local_changes, checked, expected
+):
+    assert (
+        _revision_report_state(
+            local_sha,
+            remote_sha,
+            has_local_changes=has_local_changes,
+            checked=checked,
+        )
+        == expected
+    )
 
 
 def _command_patches(report, bundle_results, *, details=None, execute_calls=None):
@@ -374,8 +401,8 @@ def test_empty_bundle_is_unchecked_and_does_not_run_or_claim_all_current():
 
 
 @pytest.mark.parametrize("verbose", [False, True])
-def test_local_umbrella_dependencies_are_neutral_or_cyan_not_green(monkeypatch, verbose):
-    """Clean local dependencies are uncheckable; dirty ones retain cyan status."""
+def test_local_umbrella_dependencies_use_plain_language_statuses(monkeypatch, verbose):
+    """Clean local dependencies are unchecked; dirty ones report local changes."""
 
     details = [
         {
@@ -414,11 +441,144 @@ def test_local_umbrella_dependencies_are_neutral_or_cyan_not_green(monkeypatch, 
             report, True, False, umbrella_deps=details
         )
 
-    rows, _, _ = buffer.getvalue().partition("Legend:")
-    assert "clean-local" in rows
-    assert "?" in rows
-    assert "\x1b[32m?\x1b[0m" not in rows
-    assert "\x1b[36m◦" in rows
+    output = buffer.getvalue()
+    assert "clean-local" in output
+    assert "Not checked" in output
+    assert "Local changes" in output
+    assert "Legend:" not in output
+
+
+@pytest.fixture
+def _status_consistency_fixture():
+    report = UpdateReport(
+        local_file_sources=[
+            LocalFileStatus(name="clean-local", local_sha="a" * 7),
+            LocalFileStatus(
+                name="dirty-local",
+                local_sha="b" * 7,
+                uncommitted_changes=True,
+            ),
+            LocalFileStatus(
+                name="stale-local",
+                local_sha="c" * 7,
+                remote_sha="d" * 7,
+                has_remote=True,
+            ),
+        ],
+        cached_git_sources=[
+            CachedGitStatus(name="current-module", cached_sha="e" * 7, remote_sha="e" * 7),
+            CachedGitStatus(
+                name="stale-module",
+                cached_sha="f" * 7,
+                remote_sha="0" * 7,
+                has_update=False,
+            ),
+            CachedGitStatus(name="unknown-module", cached_sha="1" * 7, remote_sha="unknown"),
+        ],
+    )
+    dependencies = [
+        {
+            "name": "current-package",
+            "local_sha": "2" * 7,
+            "remote_sha": "2" * 7,
+            "source_url": "https://example.invalid/current",
+            "has_update": False,
+            "is_local": False,
+            "path": None,
+            "has_changes": False,
+        },
+        {
+            "name": "stale-package",
+            "local_sha": "3" * 7,
+            "remote_sha": "4" * 7,
+            "source_url": "https://example.invalid/stale",
+            "has_update": False,
+            "is_local": False,
+            "path": None,
+            "has_changes": False,
+        },
+        {
+            "name": "unknown-package",
+            "local_sha": "5" * 7,
+            "remote_sha": "",
+            "source_url": "https://example.invalid/unknown",
+            "has_update": False,
+            "is_local": False,
+            "path": None,
+            "has_changes": False,
+        },
+    ]
+    bundles = {
+        "current-bundle": _bundle(
+            "current-bundle",
+            _source(
+                "git+https://example.invalid/current-bundle@main",
+                is_cached=True,
+                has_update=False,
+                cached_commit="6" * 40,
+                remote_commit="6" * 40,
+            ),
+        ),
+        "missing-bundle": _bundle(
+            "missing-bundle",
+            _source(
+                "git+https://example.invalid/missing-bundle@main",
+                is_cached=False,
+                has_update=True,
+                remote_commit="7" * 40,
+            ),
+        ),
+        "pinned-bundle": _bundle(
+            "pinned-bundle",
+            _source(
+                "git+https://example.invalid/pinned-bundle@v1.0.0",
+                is_cached=True,
+                has_update=False,
+                cached_ref="v1.0.0",
+            ),
+        ),
+        "unknown-bundle": _bundle(
+            "unknown-bundle",
+            _source("file:///synthetic/unknown-bundle", is_cached=True, has_update=None),
+        ),
+    }
+    return report, dependencies, bundles
+
+
+@pytest.mark.parametrize("verbose", [False, True])
+def test_update_reports_consistent_word_statuses_without_a_legend(
+    _status_consistency_fixture, verbose
+):
+    """The real command renders source statuses as words without changing execution."""
+
+    report, dependencies, bundles = _status_consistency_fixture
+    execute_calls: list[tuple[tuple, dict]] = []
+    patches = _command_patches(
+        report,
+        bundles,
+        details=dependencies,
+        execute_calls=execute_calls,
+    )
+    with ExitStack() as stack:
+        for boundary in patches:
+            stack.enter_context(boundary)
+        runner = CliRunner()
+        result = runner.invoke(
+            update,
+            ["--check-only", *(["--verbose"] if verbose else [])],
+        )
+        declined = runner.invoke(update, input="n\n")
+
+    assert result.exit_code == 0, result.output
+    assert declined.exit_code == 0, declined.output
+    assert not execute_calls
+    for label in ("Current", "Update", "Not checked", "Local changes", "Download", "Pinned"):
+        assert label in result.output
+    assert "Legend:" not in result.output
+    if not verbose:
+        assert result.output.count("Status") == 4
+    for symbol in ("✓", "●", "◦", "?"):
+        assert symbol not in result.output
 
 
 def test_verbose_file_bundle_source_is_local_not_remote(monkeypatch):


### PR DESCRIPTION
## Summary
- Use one plain-language `Status` column across the main Amplifier update report, Modules (local and cached), and Bundles sections.
- Reuse the existing `SourceReportState` vocabulary, preserving update classification, action eligibility, execution, source inventory, and bundle behavior.
- Remove the obsolete symbol legend from concise and verbose reports; leave `utils/display.py` and the standalone amplifier module update command unchanged.

## Verification
- Focused suite: **83 passed** using the existing CLI virtualenv with offline, credential-scrubbed environment settings.
- Prior full suite evidence on the same base: **2075 passed, 3 skipped, 13 deselected, 1 xfailed**.
- Reviewed mocked-boundary terminal captures at 80- and 120-column widths for concise and verbose output; no live update, network, LLM, or DTU claims.
- Independent reviewer: PASS.

## Scope
- Exactly three files: `AGENTS.md`, `amplifier_app_cli/commands/update.py`, and `tests/test_update_reporting.py`.
- Diff: 243 insertions, 56 deletions.
- Tests cover word labels, shared status vocabulary, concise/verbose output, no legend, and unchanged execution behavior.

## Breaking changes
None expected.
