### PR TITLE
fix(session): hide persisted reminders in resume history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,3 +62,11 @@ Use the same word-status vocabulary in every `amplifier update` section,
 including verbose output.
 Exercise the real Click command in `tests/test_update_reporting.py`; mock only
 status/apply boundaries so tests never touch a user's caches or installation.
+
+## Persisted reminder display
+
+`ui.is_displayable_session_message()` is display-only: history and replay hide
+only persisted transcript entries marked `ephemeral is True` and
+`persisted is True` whose content is a reminder envelope. Keep the original
+transcript and its source metadata intact so resume context restores the reminders;
+`reminder_placement` controls ordering, not display eligibility.

--- a/amplifier_app_cli/commands/session.py
+++ b/amplifier_app_cli/commands/session.py
@@ -10,11 +10,16 @@ from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import click
 from rich.panel import Panel
 from rich.prompt import Prompt
 from rich.table import Table
+
+if TYPE_CHECKING:
+    from amplifier_foundation.bundle import PreparedBundle
+    from rich.console import Console
 
 from amplifier_foundation.paths.resolution import get_amplifier_home
 from ..console import console
@@ -39,7 +44,6 @@ try:
         get_session_lineage,
         get_turn_summary,
         count_turns,
-        ForkResult,
     )
 
     HAS_SESSION_FORK = True
@@ -182,7 +186,7 @@ def _display_session_history(
         show_thinking: Whether to show thinking blocks
         max_messages: Max messages to show (0 = all, default 10)
     """
-    from ..ui import render_message
+    from ..ui import is_displayable_session_message, render_message
 
     # Build banner with session info
     session_id = metadata.get("session_id", "unknown")
@@ -214,8 +218,8 @@ def _display_session_history(
     console.print(Panel.fit(banner_text, border_style="cyan"))
     console.print()
 
-    # Filter to user/assistant messages only
-    display_messages = [m for m in transcript if m.get("role") in ("user", "assistant")]
+    # Filter display-only persisted reminders before applying the history limit.
+    display_messages = [m for m in transcript if is_displayable_session_message(m)]
 
     # Handle message limiting
     skipped_count = 0
@@ -251,7 +255,7 @@ async def _replay_session_history(
         speed: Speed multiplier (2.0 = twice as fast)
         show_thinking: Whether to show thinking blocks
     """
-    from ..ui import render_message
+    from ..ui import is_displayable_session_message, render_message
 
     # Build banner with session info and replay status
     session_id = metadata.get("session_id", "unknown")
@@ -289,10 +293,7 @@ async def _replay_session_history(
 
     for idx, message in enumerate(transcript):
         try:
-            role = message.get("role")
-
-            # Skip system/developer messages
-            if role not in ("user", "assistant"):
+            if not is_displayable_session_message(message):
                 continue
 
             # Calculate delay (uses timestamps if available, else content-based)
@@ -325,7 +326,7 @@ async def _replay_session_history(
     # Show remaining messages if interrupted
     if interrupted:
         for remaining_message in transcript[interrupt_index + 1 :]:
-            if remaining_message.get("role") in ("user", "assistant"):
+            if is_displayable_session_message(remaining_message):
                 render_message(remaining_message, console, show_thinking=show_thinking)
 
 
@@ -591,7 +592,6 @@ def register_session_commands(
 
             # Show current session
             current_indent = "  " * len(ancestors)
-            session_info = _get_session_display_info(store, session_id)
             forked_info = ""
             if lineage.get("forked_from_turn"):
                 forked_info = (
@@ -865,7 +865,7 @@ def register_session_commands(
             # Load transcript to count turns
             transcript_path = session_dir / "transcript.jsonl"
             if not transcript_path.exists():
-                console.print(f"[red]Error:[/red] No transcript found for session")
+                console.print("[red]Error:[/red] No transcript found for session")
                 sys.exit(1)
 
             messages = []
@@ -935,7 +935,7 @@ def register_session_commands(
         try:
             preview = get_fork_preview(session_dir, turn)
             console.print()
-            console.print(f"[bold]Fork Preview:[/bold]")
+            console.print("[bold]Fork Preview:[/bold]")
             console.print(f"  Parent: {preview['parent_id'][:8]}...")
             console.print(f"  Fork at turn: {turn} of {preview['max_turns']}")
             console.print(f"  Messages to copy: {preview['message_count']}")
@@ -1311,7 +1311,7 @@ def _interactive_resume_impl(
 
     # If only one session, auto-select it
     if len(all_session_ids) == 1:
-        console.print(f"[dim]Only one session found, resuming...[/dim]")
+        console.print("[dim]Only one session found, resuming...[/dim]")
         ctx.invoke(
             sessions_resume_cmd,
             session_id=all_session_ids[0],

--- a/amplifier_app_cli/ui/__init__.py
+++ b/amplifier_app_cli/ui/__init__.py
@@ -2,7 +2,7 @@
 
 from .approval import CLIApprovalSystem
 from .display import CLIDisplaySystem
-from .message_renderer import render_message
+from .message_renderer import is_displayable_session_message, render_message
 from .scope import (
     is_scope_change_available,
     print_scope_indicator,
@@ -13,6 +13,7 @@ from .scope import (
 __all__ = [
     "CLIApprovalSystem",
     "CLIDisplaySystem",
+    "is_displayable_session_message",
     "render_message",
     "is_scope_change_available",
     "print_scope_indicator",

--- a/amplifier_app_cli/ui/message_renderer.py
+++ b/amplifier_app_cli/ui/message_renderer.py
@@ -6,9 +6,100 @@ messages, used consistently across live chat, history display, and replay mode.
 Zero duplication: All message rendering goes through these functions.
 """
 
+from collections.abc import Mapping
+
 from rich.console import Console
 
 from ..console import Markdown
+
+
+def is_displayable_session_message(message: Mapping[str, object]) -> bool:
+    """Return whether a persisted message belongs in session history or replay.
+
+    Persisted ephemeral reminder envelopes remain part of the session context,
+    but do not represent user-facing conversation history.
+    """
+    if not isinstance(message, Mapping):
+        return False
+
+    role = message.get("role")
+    if role == "assistant":
+        return True
+    if role != "user":
+        return False
+
+    metadata = message.get("metadata")
+    is_persisted_ephemeral_reminder = (
+        isinstance(metadata, Mapping)
+        and metadata.get("ephemeral") is True
+        and metadata.get("persisted") is True
+        and _is_reminder_content(message.get("content"))
+    )
+    return not is_persisted_ephemeral_reminder
+
+
+def _is_reminder_content(content: object) -> bool:
+    """Recognize only complete persisted reminder envelopes."""
+    if isinstance(content, str):
+        return _is_reminder_envelope(content.strip())
+
+    if not isinstance(content, list) or not content:
+        return False
+
+    found_envelope = False
+    for block in content:
+        if not isinstance(block, Mapping) or block.get("type") != "text":
+            return False
+        text = block.get("text")
+        if not isinstance(text, str):
+            return False
+        stripped_text = text.strip()
+        if stripped_text:
+            if not _is_reminder_envelope(stripped_text):
+                return False
+            found_envelope = True
+    return found_envelope
+
+
+def _is_reminder_envelope(text: str) -> bool:
+    """Recognize one complete singular or plural reminder wrapper."""
+    singular_open = "<system-reminder"
+    singular_close = "</system-reminder>"
+    plural_open = "<system-reminders>"
+    plural_close = "</system-reminders>"
+
+    if text.startswith(plural_open) and text.endswith(plural_close):
+        body = text[len(plural_open) : -len(plural_close)]
+        return not _contains_tag(body, "system-reminders")
+
+    if not text.startswith(singular_open) or not text.endswith(singular_close):
+        return False
+
+    opening_end = len(singular_open)
+    if text[opening_end : opening_end + 1] == ">":
+        opening_end += 1
+    elif text.startswith(' source="', opening_end):
+        source_end = text.find('"', opening_end + len(' source="'))
+        if source_end == -1 or text[source_end + 1 : source_end + 2] != ">":
+            return False
+        opening_end = source_end + 2
+    else:
+        return False
+
+    body = text[opening_end : -len(singular_close)]
+    return not _contains_tag(body, "system-reminder")
+
+
+def _contains_tag(text: str, name: str) -> bool:
+    """Return whether text contains an opening or closing tag with this exact name."""
+    for prefix in (f"<{name}", f"</{name}"):
+        position = text.find(prefix)
+        while position != -1:
+            boundary = position + len(prefix)
+            if text[boundary : boundary + 1] in (">", " ", "\t", "\r", "\n"):
+                return True
+            position = text.find(prefix, boundary)
+    return False
 
 
 def render_message(

--- a/tests/test_message_renderer.py
+++ b/tests/test_message_renderer.py
@@ -9,7 +9,9 @@ All existing callers (history display, replay) use the default (True), so
 their behaviour is unchanged.
 """
 
+import copy
 import io
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from rich.console import Console
@@ -22,6 +24,36 @@ def _make_console() -> tuple[Console, io.StringIO]:
     # ANSI detection on the StringIO; the text still flows through.
     con = Console(file=buf, highlight=False, no_color=True)
     return con, buf
+
+
+def _persisted_reminder(content: object, *, role: str = "user") -> dict:
+    return {
+        "role": role,
+        "content": content,
+        "metadata": {"ephemeral": True, "persisted": True},
+    }
+
+
+def _capture_history(transcript: list[dict], *, max_messages: int) -> str:
+    import amplifier_app_cli.commands.session as session_commands
+
+    original_console = session_commands.console
+    console, buffer = _make_console()
+    session_commands.console = console
+    try:
+        session_commands._display_session_history(
+            transcript,
+            {
+                "session_id": "test-session",
+                "created": "2026-09-08T00:00:00+00:00",
+                "bundle": "test",
+                "model": "test/model",
+            },
+            max_messages=max_messages,
+        )
+        return buffer.getvalue()
+    finally:
+        session_commands.console = original_console
 
 
 # ---------------------------------------------------------------------------
@@ -139,3 +171,339 @@ def test_render_message_tool_only_assistant_skips_label():
     assert "Amplifier:" not in output, (
         f"Tool-only message should not print label; got: {output!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# is_displayable_session_message — persisted reminder display policy
+# ---------------------------------------------------------------------------
+
+
+def test_is_displayable_session_message_hides_only_complete_persisted_envelopes():
+    """Canonical singular and plural persisted reminders are display-only."""
+    from amplifier_app_cli.ui import is_displayable_session_message
+
+    singular = (
+        '<system-reminder source="hook">Use the current workspace.</system-reminder>'
+    )
+    plural = (
+        "<system-reminders>\n"
+        "The blocks below were injected by the system, not the user.\n"
+        '<system-reminder source="hooks-status-context">Today is Tuesday.</system-reminder>\n'
+        '<system-reminder source="memory">Remember arbitrary merged hook text.</system-reminder>\n'
+        "</system-reminders>"
+    )
+    bare_plural = (
+        "<system-reminders>\nMerged hook prose without child tags.\n</system-reminders>"
+    )
+    text_blocks = [
+        {"type": "text", "text": " \n\t"},
+        {"type": "text", "text": f"\n  {singular}\t"},
+        {"type": "text", "text": f"  {plural}\n"},
+    ]
+
+    for content in (
+        f"\n  {singular}\t",
+        "<system-reminder>Source is optional.</system-reminder>",
+        plural,
+        bare_plural,
+        text_blocks,
+    ):
+        assert is_displayable_session_message(_persisted_reminder(content)) is False
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        {"role": "user", "content": "<system-reminder>quoted</system-reminder>"},
+        {
+            "role": "user",
+            "content": "<system-reminder>quoted</system-reminder>",
+            "metadata": {},
+        },
+        {
+            "role": "user",
+            "content": "<system-reminder>quoted</system-reminder>",
+            "metadata": {"ephemeral": True},
+        },
+        {
+            "role": "user",
+            "content": "<system-reminder>quoted</system-reminder>",
+            "metadata": {"ephemeral": True, "persisted": False},
+        },
+        {
+            "role": "user",
+            "content": "<system-reminder>quoted</system-reminder>",
+            "metadata": {"ephemeral": True, "persisted": 1},
+        },
+        {
+            "role": "user",
+            "content": "<system-reminder>quoted</system-reminder>",
+            "metadata": {"ephemeral": True, "persisted": "true"},
+        },
+        {
+            "role": "user",
+            "content": "<system-reminder>quoted</system-reminder>",
+            "metadata": {"ephemeral": False, "persisted": True},
+        },
+        {
+            "role": "user",
+            "content": "<system-reminder>quoted</system-reminder>",
+            "metadata": {"ephemeral": "true", "persisted": True},
+        },
+        {
+            "role": "user",
+            "content": "<system-reminder>quoted</system-reminder>",
+            "metadata": ["ephemeral", "persisted"],
+        },
+        _persisted_reminder("Please explain <system-reminder> as literal text."),
+        _persisted_reminder(
+            "<system-reminder>quoted tag</system-reminder> before my question"
+        ),
+        _persisted_reminder(
+            [
+                {"type": "text", "text": "My question is:"},
+                {"type": "text", "text": "<system-reminder>quoted</system-reminder>"},
+            ]
+        ),
+        _persisted_reminder(
+            [
+                {"type": "text", "text": "<system-reminder>only</system-reminder>"},
+                {"type": "tool_use", "name": "not text"},
+            ]
+        ),
+        _persisted_reminder([]),
+        _persisted_reminder(123),
+        _persisted_reminder("<system-reminderish>not a reminder</system-reminderish>"),
+        _persisted_reminder(
+            '<system-reminders source="x">attribute not allowed</system-reminders>'
+        ),
+        _persisted_reminder("<system-reminder>missing close"),
+        _persisted_reminder("<system-reminder>wrong close</system-reminders>"),
+        _persisted_reminder(
+            "<system-reminder>first</system-reminder> human "
+            "<system-reminder>second</system-reminder>"
+        ),
+        _persisted_reminder(
+            "<system-reminder>first</system-reminder>\n\n"
+            "<system-reminder>second</system-reminder>"
+        ),
+        _persisted_reminder(
+            "<system-reminder>outer <system-reminder>nested</system-reminder>"
+            "</system-reminder>"
+        ),
+        _persisted_reminder(
+            "<system-reminders><system-reminders>nested</system-reminders>"
+            "</system-reminders>"
+        ),
+        _persisted_reminder(
+            '<system-reminder source="unterminated>not valid</system-reminder>'
+        ),
+        _persisted_reminder(
+            '<system-reminder source="hook" extra="attribute">not valid</system-reminder>'
+        ),
+    ],
+)
+def test_is_displayable_session_message_fails_open_for_human_or_malformed_content(
+    message,
+):
+    """Anything ambiguous remains visible rather than hiding human content."""
+    from amplifier_app_cli.ui import is_displayable_session_message
+
+    assert is_displayable_session_message(message) is True
+
+
+def test_is_displayable_session_message_always_keeps_assistant_messages():
+    """Assistant content remains visible even if it quotes a reminder tag."""
+    from amplifier_app_cli.ui import is_displayable_session_message
+
+    message = _persisted_reminder(
+        "<system-reminder>assistant quoted this</system-reminder>", role="assistant"
+    )
+    assert is_displayable_session_message(message) is True
+
+
+def test_history_hides_persisted_reminders_before_the_last_ten_and_preserves_transcript():
+    """Rich history renders ten visible rows and reports only visible skipped rows."""
+    reminders = [
+        _persisted_reminder(f"<system-reminder>HIDDEN_{number}</system-reminder>")
+        for number in range(8)
+    ]
+    transcript = (
+        [{"role": "user", "content": f"EARLY_VISIBLE_{number}"} for number in range(3)]
+        + reminders
+        + [
+            {"role": "assistant", "content": f"LATE_VISIBLE_{number}"}
+            for number in range(10)
+        ]
+    )
+    original = copy.deepcopy(transcript)
+
+    output = _capture_history(transcript, max_messages=10)
+
+    assert "... 3 earlier messages" in output
+    assert "EARLY_VISIBLE_0" not in output
+    assert "LATE_VISIBLE_0" in output
+    assert "LATE_VISIBLE_9" in output
+    assert all(f"HIDDEN_{number}" not in output for number in range(8))
+    assert transcript == original
+
+
+@pytest.mark.asyncio
+async def test_replay_skips_reminder_timing_and_interrupted_remainder():
+    """Replay neither delays nor renders reminders, including after Ctrl-C."""
+    import amplifier_app_cli.commands.session as session_commands
+
+    complete_transcript = [
+        {"role": "user", "content": "COMPLETE_FIRST_VISIBLE"},
+        _persisted_reminder("<system-reminder>COMPLETE_REMINDER</system-reminder>"),
+        {"role": "assistant", "content": "COMPLETE_FINAL_VISIBLE"},
+    ]
+    complete_original = copy.deepcopy(complete_transcript)
+    complete_sleeps = 0
+
+    async def count_sleep(_: float) -> None:
+        nonlocal complete_sleeps
+        complete_sleeps += 1
+
+    original_console = session_commands.console
+    complete_console, complete_buffer = _make_console()
+    session_commands.console = complete_console
+    try:
+        with patch.object(session_commands.asyncio, "sleep", new=count_sleep):
+            await session_commands._replay_session_history(
+                complete_transcript,
+                {
+                    "session_id": "test-session",
+                    "created": "2026-09-08T00:00:00+00:00",
+                    "bundle": "test",
+                    "model": "test/model",
+                },
+                speed=1000,
+            )
+    finally:
+        session_commands.console = original_console
+
+    assert complete_sleeps == 2
+    assert "COMPLETE_REMINDER" not in complete_buffer.getvalue()
+    assert complete_transcript == complete_original
+
+    interrupted_transcript = [
+        {"role": "user", "content": "FIRST_VISIBLE"},
+        {"role": "assistant", "content": "INTERRUPTED_ASSISTANT"},
+        _persisted_reminder("<system-reminder>REMAINDER_REMINDER</system-reminder>"),
+        {"role": "user", "content": "REMAINDER_VISIBLE"},
+        {"role": "assistant", "content": "FINAL_VISIBLE"},
+    ]
+    original = copy.deepcopy(interrupted_transcript)
+    console, buffer = _make_console()
+    sleeps = 0
+
+    async def interrupt_second_sleep(_: float) -> None:
+        nonlocal sleeps
+        sleeps += 1
+        if sleeps == 2:
+            raise KeyboardInterrupt
+
+    session_commands.console = console
+    try:
+        with patch.object(
+            session_commands.asyncio, "sleep", new=interrupt_second_sleep
+        ):
+            await session_commands._replay_session_history(
+                interrupted_transcript,
+                {
+                    "session_id": "test-session",
+                    "created": "2026-09-08T00:00:00+00:00",
+                    "bundle": "test",
+                    "model": "test/model",
+                },
+                speed=1000,
+            )
+    finally:
+        session_commands.console = original_console
+
+    output = buffer.getvalue()
+    assert sleeps == 2
+    assert "Skipped to end" in output
+    assert "INTERRUPTED_ASSISTANT" not in output
+    assert "REMAINDER_REMINDER" not in output
+    assert "REMAINDER_VISIBLE" in output
+    assert "FINAL_VISIBLE" in output
+    assert interrupted_transcript == original
+
+
+@pytest.mark.asyncio
+async def test_loaded_transcript_hides_reminders_but_session_runner_restores_them(
+    tmp_path,
+):
+    """Display filtering never removes persisted reminder context from a resumed session."""
+    from amplifier_app_cli.session_runner import (
+        SessionConfig,
+        create_initialized_session,
+    )
+    from amplifier_app_cli.session_store import SessionStore
+
+    reminder = _persisted_reminder(
+        "<system-reminders>\n"
+        "This explanatory preamble was injected by the system.\n"
+        '<system-reminder source="hook">PERSISTED_CONTEXT</system-reminder>\n'
+        "</system-reminders>"
+    )
+    transcript = [
+        {"role": "user", "content": "VISIBLE_CONTEXT"},
+        reminder,
+        {"role": "assistant", "content": "VISIBLE_RESPONSE"},
+    ]
+    store = SessionStore(base_dir=tmp_path / "sessions")
+    store.save("resume-reminder-test", transcript, {"bundle": "test"})
+    loaded_transcript, _ = store.load("resume-reminder-test")
+    original = copy.deepcopy(loaded_transcript)
+
+    history = _capture_history(loaded_transcript, max_messages=10)
+    assert "VISIBLE_CONTEXT" in history
+    assert "VISIBLE_RESPONSE" in history
+    assert "PERSISTED_CONTEXT" not in history
+
+    class RecordingContext:
+        def __init__(self):
+            self.messages = []
+
+        async def get_messages(self):
+            return self.messages
+
+        async def set_messages(self, messages):
+            self.messages = messages
+
+    context = RecordingContext()
+    session = MagicMock()
+    session.config = {}
+    session.coordinator.get.side_effect = lambda name: (
+        context if name == "context" else None
+    )
+    session.coordinator.get_capability.return_value = None
+    config = SessionConfig(
+        config={},
+        search_paths=[],
+        verbose=False,
+        session_id="resume-reminder-test",
+        initial_transcript=loaded_transcript,
+    )
+
+    with (
+        patch(
+            "amplifier_app_cli.session_runner._create_bundle_session",
+            new_callable=AsyncMock,
+            return_value=session,
+        ),
+        patch("amplifier_app_cli.commands.init.check_first_run", return_value=False),
+        patch("amplifier_app_cli.project_utils.get_project_slug", return_value="test"),
+        patch("amplifier_app_cli.ui.CLIApprovalSystem"),
+        patch("amplifier_app_cli.ui.CLIDisplaySystem"),
+        patch("amplifier_app_cli.session_runner.SessionStore", return_value=store),
+        patch("amplifier_app_cli.session_runner.InitializedSession"),
+    ):
+        await create_initialized_session(config, MagicMock())
+
+    assert context.messages == original
+    assert context.messages[1] == reminder
+    assert loaded_transcript == original


### PR DESCRIPTION
## Summary
- Add one shared UI-only classifier for persisted reminder envelopes.
- Apply it to session history, replay timing, and interrupted replay remainder handling.
- Keep transcript storage and resume context unchanged; document the display-only contract.

## Why
Persisted system reminders are needed for resumed context but should not appear as conversation history or consume the visible history window. Human-authored, malformed, mixed, and unflagged content remains visible.

## Verification
- `uv run --with truststore==0.10.4 pytest -q` — 2113 passed, 1 skipped, 13 deselected, 1 xfailed.
- Deterministic DTU verification passed: real PTY `amplifier session resume` and `--replay` exited 0; fixture-backed checks covered hidden identified reminders, visible human/unflagged quotes, default-window behavior, unchanged transcript bytes, and retained resume context. This validates the fixture-shim scope; it does not claim live vendor or full default-bundle coverage.

## Compatibility
No breaking changes. No provider requests, version changes, global CLI behavior, Foundation changes, or workspace-root changes.
