### PR TITLE
feat(cli): add slash completion and exit commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,16 @@ only persisted transcript entries marked `ephemeral is True` and
 `persisted is True` whose content is a reminder envelope. Keep the original
 transcript and its source metadata intact so resume context restores the reminders;
 `reminder_placement` controls ordering, not display eligibility.
+
+## Interactive slash completion
+
+Keep completion candidate generation in `ui/completion.py`.  Its live-session
+snapshot is rebuilt only at REPL construction and immediately before each
+normal `prompt_async()` call; prompt-toolkit completion callbacks may read only
+that already-built snapshot.  Do not add discovery, provider, filesystem,
+network, or configurator calls to a keypress path.
+
+## Interactive control-flow exits
+
+REPL exit commands return an action from `CommandProcessor`; only the normal
+REPL loop may terminate so its shared `finally` runs cleanup and closes TTY input once.

--- a/README.md
+++ b/README.md
@@ -273,6 +273,27 @@ amplifier bundle use <TAB> # Shows available bundles
 amplifier run --<TAB>      # Shows all options
 ```
 
+## Interactive Slash Completion
+
+Inside an interactive Amplifier session, press `Tab` after a leading `/` to
+complete commands and their currently available arguments. The menu includes
+short descriptions and is based on the mounted providers, modes, skills, and
+live configuration captured before the prompt opens.
+
+- `Tab` opens the menu and cycles forward; `Shift-Tab` cycles backward.
+- `Up`/`Down` select an open menu item. `Enter` accepts that item; press
+  `Enter` again to run the completed command.
+- `Esc` cancels an open menu and restores the text from before completion.
+- A unique match is inserted with a trailing space, such as `/pro` + `Tab`
+  becoming `/provider `.
+- `/exit` ends the interactive session; `/quit` is an alias. Neither accepts
+  arguments.
+
+Completion is available for built-in slash commands, provider and mode
+controls, `/config` verbs/flags, user-invocable skills and their declared
+literal arguments, and `/goal` controls. Free-form prompt text, goal
+conditions, and file/path arguments are intentionally not guessed.
+
 ## Architecture
 
 This CLI is built on top of amplifier-core and provides:

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -25,9 +25,11 @@ from amplifier_core import (
 from amplifier_core.llm_errors import LLMError
 from amplifier_foundation import sanitize_message
 from prompt_toolkit import PromptSession
+from prompt_toolkit.filters import has_completions
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.history import FileHistory, InMemoryHistory
 from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.shortcuts import CompleteStyle
 from rich.panel import Panel
 
 # Errors that mean the terminal can never satisfy the REPL, so retrying is
@@ -81,6 +83,7 @@ from .ui.dashboard_renderer import _redact_value as _dr_redact_value
 from .ui.error_display import display_llm_error, display_validation_error
 from .ui.item_renderer import ItemRenderer
 from .ui.log_filter import LLMErrorLogFilter
+from .ui.completion import SlashCompleter, build_completion_snapshot
 from .ui.view_policy import resolve_view
 from .utils.error_format import escape_markup
 from .utils.version import get_core_version, get_version
@@ -542,6 +545,8 @@ class CommandProcessor:
             "description": "Clear conversation context",
         },
         "/help": {"action": "show_help", "description": "Show available commands"},
+        "/exit": {"action": "exit", "description": "Exit this session"},
+        "/quit": {"action": "exit", "description": "Alias for /exit"},
         "/config": {
             "action": "show_config",
             "description": "Live session config \u2014 /config [category] [disable|enable name]",
@@ -698,6 +703,11 @@ class CommandProcessor:
         self.session = session
         self.bundle_name = bundle_name
         self.configurator: Any = None
+        # These are session-scoped dispatch snapshots.  The class attributes
+        # remain a backwards-compatible, additive cache for older callers, but
+        # command dispatch must never inherit another session's shortcuts.
+        self._mode_shortcuts: dict[str, str] = {}
+        self._skill_shortcuts: dict[str, dict] = {}
         # Initialize session_state if not present
         if not hasattr(self.session.coordinator, "session_state"):
             self.session.coordinator.session_state = {}
@@ -714,7 +724,12 @@ class CommandProcessor:
         """Populate MODE_SHORTCUTS from mode discovery."""
         discovery = self.session.coordinator.session_state.get("mode_discovery")
         if discovery and hasattr(discovery, "get_shortcuts"):
-            shortcuts = discovery.get_shortcuts()
+            shortcuts = dict(discovery.get_shortcuts())
+            # Direct canonical mode commands must dispatch just like their
+            # aliases.  setdefault preserves an explicit discovery mapping.
+            for canonical in tuple(shortcuts.values()):
+                shortcuts.setdefault(canonical, canonical)
+            self._mode_shortcuts = shortcuts
             # Update class-level shortcuts dict
             CommandProcessor.MODE_SHORTCUTS.update(shortcuts)
 
@@ -731,7 +746,8 @@ class CommandProcessor:
         """
         discovery = self.session.coordinator.get_capability("skills_discovery")
         if discovery and hasattr(discovery, "get_shortcuts"):
-            shortcuts = discovery.get_shortcuts()
+            shortcuts = dict(discovery.get_shortcuts())
+            self._skill_shortcuts = shortcuts
             # Update class-level shortcuts dict
             CommandProcessor.SKILL_SHORTCUTS.update(shortcuts)
 
@@ -759,7 +775,17 @@ class CommandProcessor:
                         data["trailing_prompt"] = trailing
                 elif cmd_info["action"] == "load_skill":
                     skill_parts = args.strip().split(maxsplit=1)
-                    data["skill_name"] = skill_parts[0] if skill_parts else ""
+                    selected_name = skill_parts[0] if skill_parts else ""
+                    # `/skill <alias>` follows the same dispatch rule as a
+                    # direct `/alias`.  Keep the user's command text intact
+                    # in data["command"]; only the internal lookup is
+                    # canonicalized.
+                    shortcut = self._skill_shortcuts.get(selected_name)
+                    data["skill_name"] = (
+                        shortcut.get("name", selected_name)
+                        if isinstance(shortcut, dict)
+                        else selected_name
+                    )
                     data["arguments"] = skill_parts[1] if len(skill_parts) > 1 else ""
                 elif cmd_info["action"] == "handle_goal" and args.strip():
                     # Setting a condition (not a clear alias) runs it as a turn
@@ -782,16 +808,17 @@ class CommandProcessor:
 
             # Check for mode shortcuts (e.g., /plan -> /mode plan)
             shortcut_name = command[1:]  # Remove leading /
-            if shortcut_name in self.MODE_SHORTCUTS:
-                data = {"args": shortcut_name, "command": command}
+            if shortcut_name in self._mode_shortcuts:
+                canonical_name = self._mode_shortcuts[shortcut_name]
+                data = {"args": canonical_name, "command": command}
                 trailing = args.strip()
                 if trailing:
                     if trailing.lower() in ("on", "off"):
                         # Exact "on"/"off" → mode control, not trailing prompt
-                        data["args"] = f"{shortcut_name} {trailing}"
+                        data["args"] = f"{canonical_name} {trailing}"
                     else:
                         # Trailing text → force activation + queue as prompt
-                        data["args"] = f"{shortcut_name} on"
+                        data["args"] = f"{canonical_name} on"
                         data["trailing_prompt"] = trailing
                 return "handle_mode", data
 
@@ -801,7 +828,7 @@ class CommandProcessor:
             # skill's `shortcut:` frontmatter field). Older skills bundles
             # don't populate "name" — fall back to the lookup key.
             def _dispatch_skill_shortcut(name: str) -> tuple[str, dict[str, Any]]:
-                entry = self.SKILL_SHORTCUTS[name]
+                entry = self._skill_shortcuts[name]
                 canonical = (
                     entry.get("name", name) if isinstance(entry, dict) else name
                 )
@@ -814,7 +841,7 @@ class CommandProcessor:
                     },
                 )
 
-            if shortcut_name in self.SKILL_SHORTCUTS:
+            if shortcut_name in self._skill_shortcuts:
                 return _dispatch_skill_shortcut(shortcut_name)
 
             # Defense-in-depth: SKILL_SHORTCUTS is populated once, additively,
@@ -827,7 +854,7 @@ class CommandProcessor:
             # already-resolved capability) and fails soft if the capability
             # is absent, exactly like the initial population.
             self._populate_skill_shortcuts()
-            if shortcut_name in self.SKILL_SHORTCUTS:
+            if shortcut_name in self._skill_shortcuts:
                 return _dispatch_skill_shortcut(shortcut_name)
 
             return "unknown_command", {"command": command}
@@ -2053,7 +2080,11 @@ class CommandProcessor:
         # startup snapshot -- then use SKILL_SHORTCUTS (same source as
         # process_input) for consistency.
         self._populate_skill_shortcuts()
-        shortcuts = self.SKILL_SHORTCUTS
+        # Keep the legacy public class cache visible to callers that populated
+        # it directly before per-session snapshots existed.  Completion and
+        # dispatch deliberately use only _skill_shortcuts, so this compatibility
+        # display path cannot offer a shortcut the dispatcher would reject.
+        shortcuts = self._skill_shortcuts or self.SKILL_SHORTCUTS
         if shortcuts:
             lines.append("")
             lines.append("Skill Commands:")
@@ -3436,6 +3467,7 @@ def _build_prompt_message(
 def _create_prompt_session(
     get_active_mode: Callable | None = None,
     get_pinned_provider: Callable | None = None,
+    completer: SlashCompleter | None = None,
 ) -> PromptSession:
     """Create configured PromptSession for REPL.
 
@@ -3451,6 +3483,7 @@ def _create_prompt_session(
         get_active_mode: Optional callable that returns the current active mode name
         get_pinned_provider: Optional callable that returns the pinned
             conversation provider's mount name (see ``_pinned_provider_name``)
+        completer: Optional snapshot-backed slash completer for the REPL.
 
     Returns:
         Configured PromptSession instance
@@ -3489,8 +3522,64 @@ def _create_prompt_session(
 
     @kb.add("enter")  # Enter submits (even in multiline mode)
     def accept_input(event):
-        """Submit input on Enter."""
+        """Accept a completion menu selection, otherwise submit input."""
+        if event.current_buffer.complete_state:
+            state = event.current_buffer.complete_state
+            completion = state.current_completion
+            if completion is None and state.completions:
+                completion = state.completions[0]
+            if completion is not None:
+                event.current_buffer.apply_completion(completion)
+            else:
+                event.current_buffer.cancel_completion()
+            return
         event.current_buffer.validate_and_handle()
+
+    @kb.add("tab")
+    def complete_next(event):
+        """Open/cycle the explicitly requested slash completion menu."""
+        buffer = event.current_buffer
+        if buffer.complete_state:
+            buffer.complete_next()
+        elif completer is not None:
+            candidates = completer.engine.complete(buffer.text, buffer.cursor_position)
+            if len(candidates) == 1:
+                # Prompt-toolkit's native Completion only replaces text before
+                # the cursor.  Replacing the complete token ourselves avoids
+                # duplicating a suffix when a user invokes Tab in its middle.
+                start = buffer.cursor_position
+                while start and not buffer.text[start - 1].isspace():
+                    start -= 1
+                end = buffer.cursor_position
+                while end < len(buffer.text) and not buffer.text[end].isspace():
+                    end += 1
+                buffer.cursor_position = start
+                buffer.delete(count=end - start)
+                buffer.insert_text(candidates[0].insertion)
+            elif candidates:
+                buffer.start_completion(select_first=False)
+
+    @kb.add("s-tab")
+    def complete_previous(event):
+        """Cycle backwards when the completion menu is open."""
+        if event.current_buffer.complete_state:
+            event.current_buffer.complete_previous()
+
+    @kb.add("escape")
+    def cancel_completion(event):
+        """Cancel completion and restore its original input."""
+        if event.current_buffer.complete_state:
+            event.current_buffer.cancel_completion()
+
+    @kb.add("up", filter=has_completions)
+    def completion_up(event):
+        """Navigate the open completion menu without stealing history keys."""
+        event.current_buffer.complete_previous()
+
+    @kb.add("down", filter=has_completions)
+    def completion_down(event):
+        """Navigate the open completion menu without stealing history keys."""
+        event.current_buffer.complete_next()
 
     # Dynamic prompt that shows [mode] and [pin] indicators when active.
     #
@@ -3509,6 +3598,10 @@ def _create_prompt_session(
         message=get_prompt,  # Callable for dynamic prompt
         history=history,
         key_bindings=kb,
+        completer=completer,
+        complete_while_typing=False,
+        complete_style=CompleteStyle.COLUMN,
+        reserve_space_for_menu=8,
         multiline=True,  # Enable multi-line display
         # Empty continuation prefix -- NOT "  " or "... ". A non-empty prefix
         # is prepended to every wrapped/continuation line by prompt_toolkit,
@@ -3636,6 +3729,11 @@ async def interactive_chat(
     # prompt_toolkit traceback out of this call, never reaching the loop. Unit
     # tests miss it because they mock _create_prompt_session.
     try:
+        slash_completer = SlashCompleter()
+        # Completion data is captured here and refreshed before every normal
+        # prompt.  Keypresses read only this snapshot, never discovery,
+        # configurator, filesystem, network, or mounted providers.
+        slash_completer.refresh(build_completion_snapshot(command_processor))
         prompt_session = _create_prompt_session(
             get_active_mode=lambda: (
                 command_processor.session.coordinator.session_state.get("active_mode")
@@ -3643,6 +3741,7 @@ async def interactive_chat(
             get_pinned_provider=lambda: _pinned_provider_name(
                 command_processor.session
             ),
+            completer=slash_completer,
         )
     except _TERMINAL_UNUSABLE_ERRORS as e:
         _report_terminal_unusable(e, verbose=verbose)
@@ -4018,6 +4117,7 @@ async def interactive_chat(
 
         while True:
             try:
+                slash_completer.refresh(build_completion_snapshot(command_processor))
                 # Get user input with history, editing, and paste support.
                 # patch_stdout here is the thread-offloaded
                 # patch_stdout_offloaded (see stdout_offload.py) -- same
@@ -4032,6 +4132,12 @@ async def interactive_chat(
                 if user_input.strip():
                     # Process input for commands
                     action, data = command_processor.process_input(user_input)
+
+                    if action == "exit":
+                        if data["args"].strip():
+                            console.print(f"[cyan]Usage: {data['command']}[/cyan]")
+                            continue
+                        break
 
                     if action == "prompt":
                         console.print("\n[dim]Processing... (Ctrl+C to cancel)[/dim]")

--- a/amplifier_app_cli/ui/completion.py
+++ b/amplifier_app_cli/ui/completion.py
@@ -1,0 +1,486 @@
+"""Slash-command completion for the interactive REPL.
+
+The candidate engine is deliberately independent of prompt_toolkit.  A snapshot
+is assembled between prompts, then the completer only reads that in-memory
+snapshot while the user presses keys.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any, Iterable
+
+from prompt_toolkit.completion import Completer, Completion
+from prompt_toolkit.document import Document
+
+
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+_CONFIG_CATEGORIES = (
+    "context",
+    "tools",
+    "hooks",
+    "providers",
+    "agents",
+    "behaviors",
+)
+_CONFIG_LIST_METHODS = {
+    "context": "context_list",
+    "tools": "tools_list",
+    "hooks": "hooks_list",
+    "providers": "providers_list",
+    "agents": "agents_list",
+    "behaviors": "behaviors_list",
+}
+
+
+def _description(value: Any) -> str:
+    """Return prompt-safe, single-line metadata for a completion menu."""
+    text = _CONTROL_CHARS.sub(" ", str(value or "")).replace("\n", " ").strip()
+    return text[:80]
+
+
+def _item_name(item: Any) -> str | None:
+    """Extract an ItemRecord-compatible name without importing foundation."""
+    value = item.get("name") if isinstance(item, dict) else getattr(item, "name", None)
+    return str(value) if value else None
+
+
+def _item_enabled(item: Any) -> bool:
+    return bool(item.get("enabled")) if isinstance(item, dict) else bool(
+        getattr(item, "enabled", False)
+    )
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """A display value and text to insert for one completion."""
+
+    value: str
+    description: str = ""
+    append_space: bool = True
+
+    @property
+    def insertion(self) -> str:
+        return self.value + (" " if self.append_space else "")
+
+
+@dataclass
+class CompletionSnapshot:
+    """All data allowed to be read while completion is active."""
+
+    commands: dict[str, str] = field(default_factory=dict)
+    mode_shortcuts: dict[str, str] = field(default_factory=dict)
+    modes: dict[str, str] = field(default_factory=dict)
+    skills: list[dict[str, Any]] = field(default_factory=list)
+    skill_shortcuts: dict[str, dict[str, Any]] = field(default_factory=dict)
+    providers: tuple[str, ...] = ()
+    config_items: dict[str, tuple[tuple[str, bool], ...]] = field(default_factory=dict)
+
+
+class SlashCompletionEngine:
+    """Pure, snapshot-backed slash completion candidate engine."""
+
+    def __init__(self, snapshot: CompletionSnapshot | None = None):
+        self.snapshot = snapshot or CompletionSnapshot()
+
+    def refresh(self, snapshot: CompletionSnapshot) -> None:
+        self.snapshot = snapshot
+
+    @staticmethod
+    def _tokens(before_cursor: str) -> tuple[list[str], str]:
+        """Return complete words and the word currently being edited."""
+        if not before_cursor or before_cursor[-1].isspace():
+            return before_cursor.split(), ""
+        words = before_cursor.split()
+        return words[:-1], words[-1] if words else ""
+
+    @staticmethod
+    def _matching(
+        values: Iterable[Candidate], prefix: str, *, case_sensitive: bool = False
+    ) -> list[Candidate]:
+        """Filter candidates, preserving grammar-specific matching rules."""
+        if case_sensitive:
+            return [candidate for candidate in values if candidate.value.startswith(prefix)]
+        return [
+            candidate
+            for candidate in values
+            if candidate.value.lower().startswith(prefix.lower())
+        ]
+
+    def complete(self, text: str, cursor_position: int | None = None) -> list[Candidate]:
+        """Return candidates for text before *cursor_position*, never doing I/O."""
+        cursor = len(text) if cursor_position is None else cursor_position
+        before, after = text[:cursor], text[cursor:]
+        if not text.startswith("/") or "\n" in before or (after and not after[:1].isspace()):
+            # A native Completion cannot safely replace a token suffix.  The
+            # adapter only exposes end-of-token candidates, avoiding duplicate
+            # text such as ``/providervider``.
+            return []
+        complete_words, current = self._tokens(before)
+        if not complete_words and not current:
+            return []
+        command = (complete_words[0] if complete_words else current).lower()
+        if len(complete_words) == 0:
+            return self._top_level(current)
+        args = complete_words[1:]
+        return self._arguments(command, args, current)
+
+    def _top_level(self, prefix: str) -> list[Candidate]:
+        candidates: dict[str, Candidate] = {
+            command: Candidate(command, description)
+            for command, description in self.snapshot.commands.items()
+        }
+        # Dispatcher precedence is built-in > mode > skill.
+        for alias, canonical in self.snapshot.mode_shortcuts.items():
+            value = f"/{alias}"
+            candidates.setdefault(value, Candidate(value, self.snapshot.modes.get(canonical, "")))
+        for alias, entry in self.snapshot.skill_shortcuts.items():
+            value = f"/{alias}"
+            candidates.setdefault(
+                value,
+                Candidate(value, self._skill_description(alias, entry)),
+            )
+        return self._matching(
+            (candidates[name] for name in sorted(candidates)), prefix
+        )
+
+    def _arguments(self, command: str, args: list[str], current: str) -> list[Candidate]:
+        if command == "/provider":
+            return self._provider(args, current)
+        if command == "/mode":
+            return self._mode(args, current)
+        if command == "/config":
+            return self._config(args, current)
+        if command == "/goal":
+            return self._goal(args, current)
+        if command in {"/allowed-dirs", "/denied-dirs"}:
+            return self._directory_command(args, current)
+        if command == "/skill":
+            return self._skill_command(args, current)
+        # Built-in commands always win over dynamic mode or skill names, even
+        # when this built-in has no argument completion grammar of its own.
+        if command in self.snapshot.commands:
+            return []
+        direct_mode = command[1:]
+        if direct_mode in self.snapshot.mode_shortcuts:
+            return self._direct_mode(args, current)
+        if command.startswith("/"):
+            skill_name = command[1:]
+            if skill_name in self.snapshot.skill_shortcuts:
+                return self._skill_arguments(skill_name, args, current)
+        return []
+
+    def _directory_command(self, args: list[str], current: str) -> list[Candidate]:
+        """Complete only the bounded verbs; directory paths remain free-form."""
+        if not args:
+            return self._matching(
+                [
+                    Candidate("list", "List configured directories"),
+                    Candidate("add", "Add a directory"),
+                    Candidate("remove", "Remove a directory"),
+                ],
+                current,
+            )
+        return []
+
+    def _provider(self, args: list[str], current: str) -> list[Candidate]:
+        if not args:
+            return self._matching(
+                [
+                    Candidate("auto", "Use automatic provider selection"),
+                    Candidate("use", "Pin a mounted provider"),
+                    Candidate("test", "Test mounted provider connectivity"),
+                    Candidate("models", "List models for a mounted provider"),
+                ],
+                current,
+            )
+        if args[0].lower() in {"use", "test", "models"} and len(args) == 1:
+            return self._matching((Candidate(name) for name in self.snapshot.providers), current)
+        return []
+
+    def _mode(self, args: list[str], current: str) -> list[Candidate]:
+        names = [
+            Candidate(name, description)
+            for name, description in sorted(self.snapshot.modes.items())
+        ]
+        if not args:
+            return self._matching([Candidate("off"), Candidate("info"), *names], current)
+        if args[0].lower() == "info" and len(args) == 1:
+            return self._matching(names, current)
+        if len(args) == 1 and args[0].lower() in self.snapshot.modes:
+            return self._matching([Candidate("on"), Candidate("off")], current)
+        return []
+
+    def _direct_mode(self, args: list[str], current: str) -> list[Candidate]:
+        """Complete direct mode shortcuts after dispatcher precedence wins."""
+        if not args:
+            return self._matching([Candidate("on"), Candidate("off")], current)
+        return []
+
+    def _goal(self, args: list[str], current: str) -> list[Candidate]:
+        if not args:
+            return self._matching(
+                [
+                    Candidate("clear"),
+                    Candidate("stop"),
+                    Candidate("off"),
+                    Candidate("reset"),
+                    Candidate("none"),
+                    Candidate("cancel"),
+                    Candidate("--max-turns"),
+                ],
+                current,
+            )
+        # A cap's numeric value and every condition are user free-form text.
+        return []
+
+    def _config_flags(self, args: list[str], current: str) -> list[Candidate]:
+        if args and args[-1] == "--format":
+            return self._matching([Candidate("text"), Candidate("json")], current)
+        used = set(args)
+        choices: list[Candidate] = []
+        if "--compact" not in used:
+            choices.append(Candidate("--compact"))
+        if "--detailed" not in used and "--trees" not in used:
+            choices.append(Candidate("--detailed"))
+            choices.append(Candidate("--trees"))
+        if "--format" not in used:
+            choices.append(Candidate("--format"))
+        return self._matching(choices, current)
+
+    def _config(self, args: list[str], current: str) -> list[Candidate]:
+        if args and args[0] == "set":
+            return []  # value is free-form; never complete it as a command.
+        positional = self._strip_config_flags(args)
+        if positional and positional[0] == "save":
+            if args and args[-1] == "--scope":
+                return self._matching([Candidate("project"), Candidate("global")], current)
+            if len(positional) == 1:
+                return self._matching([Candidate("--scope")], current)
+            return []
+        # --scope belongs only to `/config save`; it is not a display flag and
+        # must never be swallowed before the save verb has been entered.
+        if "--scope" in args or current.startswith("--scope"):
+            return []
+        flag_matches = self._config_flags(args, current)
+        if args and args[-1] == "--format":
+            return flag_matches
+        if current.startswith("-"):
+            return flag_matches
+        if not positional:
+            return self._matching(
+                [
+                    Candidate("show"),
+                    Candidate("diff"),
+                    Candidate("save"),
+                    Candidate("set"),
+                    *(Candidate(name) for name in _CONFIG_CATEGORIES),
+                    *flag_matches,
+                ],
+                current,
+            )
+        head = positional[0]
+        if head == "show":
+            if len(positional) == 1:
+                return self._matching(
+                    [*(Candidate(name) for name in _CONFIG_CATEGORIES), *flag_matches],
+                    current,
+                )
+            if len(positional) == 2 and positional[1] in _CONFIG_CATEGORIES:
+                return self._matching(
+                    [*self._config_names(positional[1]), *flag_matches], current
+                )
+            return []
+        if head in _CONFIG_CATEGORIES:
+            if len(positional) == 1:
+                controls = (
+                    []
+                    if head == "hooks"
+                    else [Candidate("enable"), Candidate("disable")]
+                )
+                return self._matching(
+                    [
+                        *controls,
+                        *self._config_names(head),
+                        *flag_matches,
+                    ],
+                    current,
+                )
+            if len(positional) == 2 and positional[1] in {"enable", "disable"}:
+                enabled = positional[1] == "disable"
+                return self._matching(self._config_names(head, enabled=enabled), current)
+        return []
+
+    @staticmethod
+    def _strip_config_flags(args: list[str]) -> list[str]:
+        remaining: list[str] = []
+        index = 0
+        while index < len(args):
+            value = args[index]
+            if value in {"--compact", "--detailed", "--trees"}:
+                index += 1
+                continue
+            if value == "--format":
+                index += 2
+                continue
+            remaining.append(value)
+            index += 1
+        return remaining
+
+    def _config_names(self, category: str, enabled: bool | None = None) -> list[Candidate]:
+        return [
+            Candidate(name)
+            for name, is_enabled in self.snapshot.config_items.get(category, ())
+            if enabled is None or is_enabled is enabled
+        ]
+
+    def _skill_command(self, args: list[str], current: str) -> list[Candidate]:
+        if not args:
+            candidates: list[Candidate] = []
+            for record in self.snapshot.skills:
+                description = self._skill_description(str(record["name"]), record)
+                candidates.append(Candidate(str(record["name"]), description))
+                candidates.extend(Candidate(str(alias), description) for alias in record.get("aliases", []))
+            return self._matching(candidates, current)
+        return self._skill_arguments(args[0], args[1:], current)
+
+    def _skill_description(self, selected_name: str, entry: dict[str, Any]) -> str:
+        """Keep display-only hints visible even beside long descriptions."""
+        record = self._find_skill(selected_name) or entry
+        hint = record.get("argument_hint")
+        description = _description(record.get("description", entry.get("description", "")))
+        return _description(f"{hint} — {description}") if hint else description
+
+    def _skill_arguments(self, selected_name: str, args: list[str], current: str) -> list[Candidate]:
+        record = self._find_skill(selected_name)
+        if record is None:
+            return []
+        completed = args
+        result: list[Candidate] = []
+        for rule in record.get("arguments", []):
+            if rule.get("after", []) == completed:
+                result.extend(Candidate(str(value)) for value in rule.get("values", []))
+        # Skill completion specs define literal values. Their matching remains
+        # case-sensitive so the displayed grammar and accepted values agree.
+        return self._matching(result, current, case_sensitive=True)
+
+    def _find_skill(self, selected_name: str) -> dict[str, Any] | None:
+        canonical = self.snapshot.skill_shortcuts.get(selected_name, {}).get(
+            "name", selected_name
+        )
+        for record in self.snapshot.skills:
+            if record.get("name") == canonical:
+                return record
+        return None
+
+
+class SlashCompleter(Completer):
+    """Thin prompt_toolkit adapter around :class:`SlashCompletionEngine`."""
+
+    def __init__(self, engine: SlashCompletionEngine | None = None):
+        self.engine = engine or SlashCompletionEngine()
+
+    def refresh(self, snapshot: CompletionSnapshot) -> None:
+        """Replace the in-memory completion snapshot at a safe REPL boundary."""
+        self.engine.refresh(snapshot)
+
+    def get_completions(self, document: Document, complete_event: Any):
+        text = document.text
+        cursor = document.cursor_position
+        prefix = text[:cursor].split()[-1] if text[:cursor] and not text[:cursor][-1].isspace() else ""
+        for candidate in self.engine.complete(text, cursor):
+            yield Completion(
+                candidate.insertion,
+                start_position=-len(prefix),
+                display=candidate.value,
+                display_meta=candidate.description,
+            )
+
+
+def build_completion_snapshot(command_processor: Any) -> CompletionSnapshot:
+    """Read cached session state once, immediately before prompting.
+
+    This is intentionally the only bridge from the live session to completion.
+    It may call discovery/configurator cache APIs, but completion keypresses do
+    not invoke this function.
+    """
+    commands = {
+        command: _description(info.get("description", ""))
+        for command, info in command_processor.COMMANDS.items()
+    }
+    command_processor._populate_mode_shortcuts()
+    command_processor._populate_skill_shortcuts()
+    mode_shortcuts = dict(getattr(command_processor, "_mode_shortcuts", {}))
+    skill_shortcuts = dict(getattr(command_processor, "_skill_shortcuts", {}))
+    modes: dict[str, str] = {}
+    discovery = command_processor.session.coordinator.session_state.get("mode_discovery")
+    if discovery and hasattr(discovery, "list_modes"):
+        for item in discovery.list_modes():
+            # ModeDiscovery returns ModeListing(name, description, source,
+            # advertised), a NamedTuple.  Attribute access keeps that public
+            # shape explicit while retaining old tuple compatibility.
+            name = getattr(item, "name", None)
+            description = getattr(item, "description", None)
+            if name is None:
+                name = item[0]
+            if description is None:
+                description = item[1] if len(item) > 1 else ""
+            name = str(name)
+            modes[name] = _description(description)
+    for canonical in mode_shortcuts.values():
+        modes.setdefault(canonical, "")
+
+    skills: list[dict[str, Any]] = []
+    discovery = command_processor.session.coordinator.get_capability("skills_discovery")
+    if discovery and hasattr(discovery, "get_completion_catalog"):
+        skills = list(discovery.get_completion_catalog())
+    elif discovery:
+        listed = discovery.list_skills() if hasattr(discovery, "list_skills") else []
+        descriptions = {name: description for name, description in listed}
+        seen: set[str] = set()
+        for alias, entry in skill_shortcuts.items():
+            canonical = entry.get("name", alias) if isinstance(entry, dict) else alias
+            if canonical in seen:
+                continue
+            seen.add(canonical)
+            aliases = [
+                candidate
+                for candidate, candidate_entry in skill_shortcuts.items()
+                if (candidate_entry.get("name", candidate) if isinstance(candidate_entry, dict) else candidate)
+                == canonical
+                and candidate != canonical
+            ]
+            skills.append(
+                {
+                    "name": canonical,
+                    "aliases": aliases,
+                    "description": descriptions.get(canonical, entry.get("description", "") if isinstance(entry, dict) else ""),
+                    "argument_hint": None,
+                    "arguments": [],
+                }
+            )
+
+    providers = tuple(
+        sorted((command_processor.session.coordinator.get("providers") or {}).keys())
+    )
+    config_items: dict[str, tuple[tuple[str, bool], ...]] = {}
+    configurator = getattr(command_processor, "configurator", None)
+    if configurator is not None:
+        for category, method_name in _CONFIG_LIST_METHODS.items():
+            method = getattr(configurator, method_name, None)
+            if method is not None:
+                config_items[category] = tuple(
+                    (name, _item_enabled(item))
+                    for item in method()
+                    if (name := _item_name(item)) is not None
+                )
+    return CompletionSnapshot(
+        commands=commands,
+        mode_shortcuts=mode_shortcuts,
+        modes=modes,
+        skills=skills,
+        skill_shortcuts=skill_shortcuts,
+        providers=providers,
+        config_items=config_items,
+    )

--- a/docs/INTERACTIVE_MODE.md
+++ b/docs/INTERACTIVE_MODE.md
@@ -24,12 +24,17 @@ Within an interactive session, you compose prompts and issue slash commands. Run
 | `/tools` | List tools | Shows loaded capabilities |
 | `/config` | Show configuration | Full mount plan |
 | `/help` | List commands | Quick reference |
-| `/stop` | Interrupt execution | Or use Ctrl+C |
+| `/exit` | Exit this session | No arguments |
+| `/quit` | Exit this session | Alias for `/exit`; no arguments |
+| Ctrl-C | Interrupt execution | During an active turn |
 | `/modes` | List available modes (from `amplifier-bundle-modes`) | |
 | `/mode <name>` | Activate a runtime mode | Mode name or shortcut |
 | `/mode off` | Deactivate the current mode | |
 
-The first eight are app-CLI built-ins. The `/mode*` commands come from `amplifier-bundle-modes` when that bundle is composed into your active configuration (which is the case for every standard amplifier bundle).
+The app-CLI built-ins shown above are available in every interactive session.
+The `/mode*` commands come from `amplifier-bundle-modes` when that bundle is
+composed into your active configuration (which is the case for every standard
+amplifier bundle).
 
 ## Runtime Modes
 
@@ -132,7 +137,7 @@ Mode: off | Messages: 15 | ...
 
 > /save api_migration_plan.json
 ✓ Transcript saved
-> exit
+> /exit
 ```
 
 **Session 2: Resume and Implement**

--- a/tests/test_interactive_chat_tty_teardown.py
+++ b/tests/test_interactive_chat_tty_teardown.py
@@ -171,6 +171,145 @@ class TestInteractiveChatClosesDedicatedTtyOnTeardown:
         mock_close.assert_called_once()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("command", ["/exit", "/exit ", "/quit", "/quit "])
+    async def test_slash_exit_commands_teardown_without_executing_a_turn(
+        self, tmp_path: Path, command: str
+    ):
+        """A slash exit leaves through the REPL's normal cleanup path."""
+        from amplifier_app_cli.main import interactive_chat
+
+        session = _make_mock_session()
+        initialized = _make_initialized(session)
+        mock_ps = MagicMock()
+        mock_ps.prompt_async = AsyncMock(side_effect=[command])
+        mock_close = MagicMock()
+        runtime_mentions = AsyncMock(side_effect=lambda s, t: t)
+
+        with (
+            patch(
+                f"{_MODULE}.create_initialized_session",
+                new=AsyncMock(return_value=initialized),
+            ),
+            patch(f"{_MODULE}._create_prompt_session", return_value=mock_ps),
+            patch("amplifier_app_cli.incremental_save.register_incremental_save"),
+            patch(f"{_MODULE}.SessionStore") as MockStore,
+            patch(f"{_MODULE}.console"),
+            patch(f"{_MODULE}.process_runtime_mentions", new=runtime_mentions),
+            patch(f"{_MODULE}.get_effective_config_summary"),
+            patch(f"{_MODULE}.close_dedicated_tty_input", new=mock_close),
+        ):
+            store_instance = MockStore.return_value
+            store_instance.get_metadata.return_value = {}
+            store_instance.save.return_value = None
+
+            await interactive_chat(
+                config={},
+                search_paths=[tmp_path],
+                verbose=False,
+                bundle_name="test-bundle",
+            )
+
+        mock_ps.prompt_async.assert_awaited_once()
+        session.execute.assert_not_awaited()
+        runtime_mentions.assert_not_awaited()
+        initialized.cleanup.assert_awaited_once()
+        mock_close.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("command", ["exit", "quit"])
+    async def test_bare_exit_commands_remain_compatible(
+        self, tmp_path: Path, command: str
+    ):
+        """The pre-existing bare exit aliases continue to leave the REPL."""
+        from amplifier_app_cli.main import interactive_chat
+
+        session = _make_mock_session()
+        initialized = _make_initialized(session)
+        mock_ps = MagicMock()
+        mock_ps.prompt_async = AsyncMock(side_effect=[command])
+        mock_close = MagicMock()
+        runtime_mentions = AsyncMock(side_effect=lambda s, t: t)
+
+        with (
+            patch(
+                f"{_MODULE}.create_initialized_session",
+                new=AsyncMock(return_value=initialized),
+            ),
+            patch(f"{_MODULE}._create_prompt_session", return_value=mock_ps),
+            patch("amplifier_app_cli.incremental_save.register_incremental_save"),
+            patch(f"{_MODULE}.SessionStore") as MockStore,
+            patch(f"{_MODULE}.console"),
+            patch(f"{_MODULE}.process_runtime_mentions", new=runtime_mentions),
+            patch(f"{_MODULE}.get_effective_config_summary"),
+            patch(f"{_MODULE}.close_dedicated_tty_input", new=mock_close),
+        ):
+            store_instance = MockStore.return_value
+            store_instance.get_metadata.return_value = {}
+            store_instance.save.return_value = None
+
+            await interactive_chat(
+                config={},
+                search_paths=[tmp_path],
+                verbose=False,
+                bundle_name="test-bundle",
+            )
+
+        mock_ps.prompt_async.assert_awaited_once()
+        session.execute.assert_not_awaited()
+        runtime_mentions.assert_not_awaited()
+        initialized.cleanup.assert_awaited_once()
+        mock_close.assert_called_once()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("command", ["/exit later", "/quit later"])
+    async def test_slash_exit_with_arguments_prints_usage_and_keeps_prompting(
+        self, tmp_path: Path, command: str
+    ):
+        """Exit arguments are rejected without sending a model turn."""
+        from amplifier_app_cli.main import interactive_chat
+
+        session = _make_mock_session()
+        initialized = _make_initialized(session)
+        mock_ps = MagicMock()
+        mock_ps.prompt_async = AsyncMock(side_effect=[command, EOFError])
+        mock_close = MagicMock()
+        runtime_mentions = AsyncMock(side_effect=lambda s, t: t)
+        mock_console = MagicMock()
+
+        with (
+            patch(
+                f"{_MODULE}.create_initialized_session",
+                new=AsyncMock(return_value=initialized),
+            ),
+            patch(f"{_MODULE}._create_prompt_session", return_value=mock_ps),
+            patch("amplifier_app_cli.incremental_save.register_incremental_save"),
+            patch(f"{_MODULE}.SessionStore") as MockStore,
+            patch(f"{_MODULE}.console", new=mock_console),
+            patch(f"{_MODULE}.process_runtime_mentions", new=runtime_mentions),
+            patch(f"{_MODULE}.get_effective_config_summary"),
+            patch(f"{_MODULE}.close_dedicated_tty_input", new=mock_close),
+        ):
+            store_instance = MockStore.return_value
+            store_instance.get_metadata.return_value = {}
+            store_instance.save.return_value = None
+
+            await interactive_chat(
+                config={},
+                search_paths=[tmp_path],
+                verbose=False,
+                bundle_name="test-bundle",
+            )
+
+        assert mock_ps.prompt_async.await_count == 2
+        mock_console.print.assert_any_call(
+            f"[cyan]Usage: {command.split()[0]}[/cyan]"
+        )
+        session.execute.assert_not_awaited()
+        runtime_mentions.assert_not_awaited()
+        initialized.cleanup.assert_awaited_once()
+        mock_close.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_close_dedicated_tty_input_called_even_after_initial_prompt(
         self, tmp_path: Path
     ):

--- a/tests/test_interactive_chat_tty_teardown.py
+++ b/tests/test_interactive_chat_tty_teardown.py
@@ -29,12 +29,25 @@ tests pass.
 
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 _MODULE = "amplifier_app_cli.main"
+
+
+@pytest.fixture(autouse=True, scope="module")
+def _use_headless_patch_stdout():
+    """Keep mocked REPL tests from opening a real Windows console preflight."""
+    # These tests already fake PromptSession and its console. Patch only main's
+    # imported alias so a headless CI console cannot mask their startup contract.
+    with patch(
+        f"{_MODULE}.patch_stdout",
+        new=lambda *_args, **_kwargs: contextlib.nullcontext(),
+    ):
+        yield
 
 
 # ---------------------------------------------------------------------------
@@ -168,6 +181,7 @@ class TestInteractiveChatClosesDedicatedTtyOnTeardown:
                 bundle_name="test-bundle",
             )
 
+        mock_ps.prompt_async.assert_awaited_once()
         mock_close.assert_called_once()
 
     @pytest.mark.asyncio
@@ -430,4 +444,5 @@ class TestCloseDedicatedTtyTeardownIsRobust:
 
         # cleanup() (session teardown) still ran despite no dedicated fd
         # having been opened -- the close call didn't short-circuit anything.
+        mock_ps.prompt_async.assert_awaited_once()
         initialized.cleanup.assert_awaited_once()

--- a/tests/test_interactive_chat_tty_teardown.py
+++ b/tests/test_interactive_chat_tty_teardown.py
@@ -34,6 +34,8 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from prompt_toolkit import PromptSession
+from prompt_toolkit.output import DummyOutput
 
 _MODULE = "amplifier_app_cli.main"
 
@@ -43,11 +45,18 @@ def _use_headless_patch_stdout():
     """Keep mocked REPL tests from opening a real Windows console preflight."""
     # These tests already fake PromptSession and its console. Patch only main's
     # imported alias so a headless CI console cannot mask their startup contract.
+    original_init = PromptSession.__init__
+
+    def _headless_init(self, *args, **kwargs):
+        kwargs["output"] = DummyOutput()
+        return original_init(self, *args, **kwargs)
+
     with patch(
         f"{_MODULE}.patch_stdout",
         new=lambda *_args, **_kwargs: contextlib.nullcontext(),
     ):
-        yield
+        with patch.object(PromptSession, "__init__", new=_headless_init):
+            yield
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_interactive_slash_completion.py
+++ b/tests/test_interactive_slash_completion.py
@@ -1,0 +1,414 @@
+"""End-to-end and pure-engine coverage for interactive slash completion."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+from collections import namedtuple
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from amplifier_app_cli.main import CommandProcessor, _create_prompt_session
+from amplifier_app_cli.ui.completion import (
+    CompletionSnapshot,
+    SlashCompleter,
+    SlashCompletionEngine,
+    build_completion_snapshot,
+)
+from prompt_toolkit import PromptSession
+from prompt_toolkit.input.defaults import create_pipe_input
+from prompt_toolkit.output import DummyOutput
+
+
+def _engine() -> SlashCompletionEngine:
+    return SlashCompletionEngine(
+        CompletionSnapshot(
+            commands={
+                "/provider": "Provider controls\nunsafe",
+                "/config": "Live configuration",
+                "/clear": "Clear context",
+                "/goal": "Set a goal",
+                "/status": "Show session status",
+                "/exit": "Exit this session",
+                "/quit": "Alias for /exit",
+            },
+            mode_shortcuts={"p": "plan"},
+            modes={"plan": "Plan work"},
+            skill_shortcuts={
+                "review": {"name": "review", "description": "Review a result"},
+                "rvw": {"name": "review", "description": "Review a result"},
+                "memory": {"name": "memory", "description": "Persistent preferences"},
+                "p": {"name": "review", "description": "Colliding review skill"},
+                "status": {"name": "review", "description": "Colliding status skill"},
+            },
+            skills=[
+                {
+                    "name": "review",
+                    "aliases": ["rvw"],
+                    "description": "Review a result",
+                    "argument_hint": "[target]",
+                    "arguments": [
+                        {"after": [], "values": ["Fast", "thorough"]},
+                        {"after": ["thorough"], "values": ["security"]},
+                    ],
+                },
+                {
+                    "name": "memory",
+                    "aliases": [],
+                    "description": "Persistent preferences",
+                    "argument_hint": None,
+                    "arguments": [
+                        {
+                            "after": [],
+                            "values": [
+                                "list",
+                                "review",
+                                "forget",
+                                "edit",
+                                "remember",
+                                "help",
+                            ],
+                        },
+                        {"after": ["review"], "values": ["accept", "decline", "skip"]},
+                    ],
+                },
+            ],
+            providers=("alpha", "beta"),
+            config_items={
+                "tools": (("bash", True), ("browser", False)),
+                "providers": (("alpha", True),),
+            },
+        )
+    )
+
+
+def _values(engine: SlashCompletionEngine, text: str, cursor: int | None = None) -> list[str]:
+    return [candidate.value for candidate in engine.complete(text, cursor)]
+
+
+def test_engine_completes_commands_provider_modes_and_goal() -> None:
+    engine = _engine()
+
+    assert _values(engine, "/pro") == ["/provider"]
+    assert _values(engine, "/exit ") == []
+    assert _values(engine, "/quit ") == []
+    assert {"/clear", "/config"}.issubset(_values(engine, "/c"))
+    assert _values(engine, "/provider ") == ["auto", "use", "test", "models"]
+    assert _values(engine, "/provider use ") == ["alpha", "beta"]
+    assert _values(engine, "/mode ") == ["off", "info", "plan"]
+    assert _values(engine, "/mode plan ") == ["on", "off"]
+    assert _values(engine, "/mode info ") == ["plan"]
+    assert _values(engine, "/p ") == ["on", "off"]
+    assert "--max-turns" in _values(engine, "/goal ")
+    assert _values(engine, "/goal --max-turns ") == []
+    assert _values(engine, "/goal finish the task ") == []
+    assert _values(engine, "/allowed-dirs ") == ["list", "add", "remove"]
+    assert _values(engine, "/denied-dirs add ") == []
+    assert _values(engine, "/status ") == []
+
+
+def test_engine_completes_config_only_in_parser_valid_positions() -> None:
+    engine = _engine()
+
+    assert {"show", "diff", "save", "tools", "--format"}.issubset(
+        _values(engine, "/config ")
+    )
+    assert _values(engine, "/config --format ") == ["text", "json"]
+    assert _values(engine, "/config save --sc") == ["--scope"]
+    assert _values(engine, "/config save --scope ") == ["project", "global"]
+    assert _values(engine, "/config --scope ") == []
+    assert "--compact" in _values(engine, "/config show tools ")
+    assert "--trees" not in _values(engine, "/config --detailed ")
+    assert _values(engine, "/config tools disable ") == ["bash"]
+    assert _values(engine, "/config tools enable ") == ["browser"]
+    assert _values(engine, "/config set path ") == []
+    assert "enable" not in _values(engine, "/config hooks ")
+    assert "disable" not in _values(engine, "/config hooks ")
+
+
+def test_engine_skill_catalog_aliases_hints_and_memory_sidecar() -> None:
+    engine = _engine()
+
+    names = engine.complete("/skill ")
+    assert {candidate.value for candidate in names} == {"review", "rvw", "memory"}
+    assert next(candidate for candidate in names if candidate.value == "review").description.startswith(
+        "[target]"
+    )
+    assert _values(engine, "/skill rvw ") == ["Fast", "thorough"]
+    assert _values(engine, "/skill rvw f") == []
+    assert _values(engine, "/skill rvw F") == ["Fast"]
+    assert _values(engine, "/rvw thorough ") == ["security"]
+    direct = next(candidate for candidate in engine.complete("/rvw") if candidate.value == "/rvw")
+    assert direct.description.endswith("Review a result")
+    assert direct.description.startswith("[target]")
+    assert _values(engine, "/skill memory ") == [
+        "list",
+        "review",
+        "forget",
+        "edit",
+        "remember",
+        "help",
+    ]
+    assert _values(engine, "/memory review ") == ["accept", "decline", "skip"]
+
+
+def test_engine_never_completes_prose_or_unsafe_cursor_suffix() -> None:
+    engine = _engine()
+
+    assert _values(engine, "write /pro") == []
+    assert _values(engine, "/proXvider", 4) == []
+    assert _values(engine, "/provider", 4) == []
+
+
+def test_completer_reads_only_the_existing_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    engine = _engine()
+    completer = SlashCompleter(engine)
+    monkeypatch.setattr(
+        engine,
+        "refresh",
+        lambda snapshot: (_ for _ in ()).throw(AssertionError("keypress refresh")),
+    )
+
+    completions = list(completer.get_completions(__import__("prompt_toolkit").document.Document("/pro"), None))
+    assert [completion.text for completion in completions] == ["/provider "]
+
+
+class _Discovery:
+    def __init__(self) -> None:
+        self.shortcuts = {"rvw": {"name": "review", "description": "Review"}}
+
+    def get_shortcuts(self):
+        return self.shortcuts
+
+    def list_skills(self):
+        return [("review", "Review")]
+
+
+def test_snapshot_refreshes_live_cached_values_and_old_skill_fallback() -> None:
+    discovery = _Discovery()
+    coordinator = MagicMock()
+    coordinator.session_state = {"active_mode": None}
+    coordinator.get_capability.side_effect = lambda name: discovery if name == "skills_discovery" else None
+    providers = {"one": object()}
+    coordinator.get.side_effect = lambda name: providers if name == "providers" else None
+    session = SimpleNamespace(coordinator=coordinator)
+    processor = CommandProcessor(session)
+
+    first = build_completion_snapshot(processor)
+    assert first.providers == ("one",)
+    assert first.skills[0]["name"] == "review"
+    assert first.skills[0]["aliases"] == ["rvw"]
+    assert first.skills[0]["arguments"] == []
+
+    providers["two"] = object()
+    discovery.shortcuts["audit"] = {"name": "audit", "description": "Audit"}
+    second = build_completion_snapshot(processor)
+    assert second.providers == ("one", "two")
+    assert "audit" in second.skill_shortcuts
+
+
+def test_snapshot_reads_actual_modelisting_shape() -> None:
+    ModeListing = namedtuple("ModeListing", ["name", "description", "source", "advertised"])
+    discovery = _Discovery()
+    modes = MagicMock()
+    modes.get_shortcuts.return_value = {"p": "plan"}
+    modes.list_modes.return_value = [ModeListing("plan", "Think first", "modes", True)]
+    coordinator = MagicMock()
+    coordinator.session_state = {"active_mode": None, "mode_discovery": modes}
+    coordinator.get_capability.side_effect = lambda name: discovery if name == "skills_discovery" else None
+    coordinator.get.return_value = {}
+    snapshot = build_completion_snapshot(CommandProcessor(SimpleNamespace(coordinator=coordinator)))
+
+    assert snapshot.modes == {"plan": "Think first"}
+    assert snapshot.mode_shortcuts == {"p": "plan", "plan": "plan"}
+
+
+@pytest.mark.asyncio
+async def test_config_save_completion_round_trips_handler_syntax() -> None:
+    coordinator = MagicMock()
+    coordinator.session_state = {"active_mode": None}
+    coordinator.get_capability.return_value = None
+    processor = CommandProcessor(SimpleNamespace(coordinator=coordinator))
+    processor.configurator = MagicMock()
+    processor._handle_config_save = AsyncMock(return_value="saved")
+
+    assert await processor._get_config_display("save --scope project") == "saved"
+    processor._handle_config_save.assert_awaited_once_with("project")
+
+
+@pytest.fixture
+def prompt_factory(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """Create real PromptSessions with a pipe input and DummyOutput."""
+    main_module = importlib.import_module("amplifier_app_cli.main")
+
+    original_init = PromptSession.__init__
+
+    def dummy_output_init(self, *args, **kwargs):
+        kwargs["output"] = DummyOutput()
+        return original_init(self, *args, **kwargs)
+
+    monkeypatch.setattr(PromptSession, "__init__", dummy_output_init)
+    monkeypatch.setattr(main_module, "get_amplifier_home", lambda: tmp_path / ".amplifier")
+
+    def build(snapshot: CompletionSnapshot):
+        pipe_context = create_pipe_input()
+        pipe = pipe_context.__enter__()
+        monkeypatch.setattr(main_module, "get_dedicated_tty_input", lambda: pipe)
+        completer = SlashCompleter()
+        completer.refresh(snapshot)
+        return _create_prompt_session(completer=completer), pipe, pipe_context
+
+    return build
+
+
+async def _start(session):
+    task = asyncio.create_task(session.prompt_async())
+    await asyncio.sleep(0.03)
+    return task
+
+
+@pytest.mark.asyncio
+async def test_pipe_unique_tab_and_ctrl_j(prompt_factory) -> None:
+    session, pipe, context = prompt_factory(
+        CompletionSnapshot(commands={"/provider": "Provider", "/quit": "Alias for /exit"})
+    )
+    try:
+        task = await _start(session)
+        pipe.send_text("/pro\t\r")
+        assert await asyncio.wait_for(task, 1) == "/provider "
+
+        task = await _start(session)
+        pipe.send_text("/qui\t\r")
+        assert await asyncio.wait_for(task, 1) == "/quit "
+
+        task = await _start(session)
+        pipe.send_text("first\x0asecond\r")
+        assert await asyncio.wait_for(task, 1) == "first\nsecond"
+
+        session.history.append_string("previous prompt")
+        task = await _start(session)
+        pipe.send_text("\x1b[A\r")
+        assert await asyncio.wait_for(task, 1) == "previous prompt"
+    finally:
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_pipe_menu_navigation_escape_and_enter_does_not_submit(prompt_factory) -> None:
+    snapshot = CompletionSnapshot(
+        commands={"/clear": "Clear", "/config": "Config", "/context": "Context"}
+    )
+    session, pipe, context = prompt_factory(snapshot)
+    try:
+        task = await _start(session)
+        pipe.send_text("/c\t")
+        await asyncio.sleep(0.08)
+        pipe.send_text("\x1b[B\r")  # Down chooses the first candidate.
+        await asyncio.sleep(0.03)
+        assert not task.done(), "first Enter must only accept the menu selection"
+        pipe.send_text("\r")
+        assert await asyncio.wait_for(task, 1) == "/clear "
+
+        task = await _start(session)
+        pipe.send_text("/c\t")
+        await asyncio.sleep(0.08)
+        pipe.send_text("\x1b[Z\r")  # Shift-Tab chooses the last candidate.
+        await asyncio.sleep(0.03)
+        pipe.send_text("\r")
+        assert await asyncio.wait_for(task, 1) == "/context "
+
+        task = await _start(session)
+        pipe.send_text("/c\t")
+        await asyncio.sleep(0.08)
+        pipe.send_text("\x1b\r")
+        assert await asyncio.wait_for(task, 1) == "/c"
+
+        task = await _start(session)
+        pipe.send_text("/c\t")
+        await asyncio.sleep(0.08)
+        pipe.send_text("l\t\r")
+        assert await asyncio.wait_for(task, 1) == "/clear "
+    finally:
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_pipe_menu_accepts_quit_before_second_enter_submits(prompt_factory) -> None:
+    session, pipe, context = prompt_factory(
+        CompletionSnapshot(commands={"/query": "Query", "/quit": "Exit this session"})
+    )
+    try:
+        task = await _start(session)
+        pipe.send_text("/q\t")
+        await asyncio.sleep(0.08)
+        pipe.send_text("\x1b[B\x1b[B\r")
+        await asyncio.sleep(0.03)
+        assert not task.done(), "first Enter must only accept /quit from the menu"
+        pipe.send_text("\r")
+        assert await asyncio.wait_for(task, 1) == "/quit "
+    finally:
+        context.__exit__(None, None, None)
+
+
+def test_exit_commands_are_static_and_cannot_be_shadowed() -> None:
+    modes = MagicMock()
+    modes.get_shortcuts.return_value = {"exit": "mode-exit", "quit": "mode-quit"}
+    skills = MagicMock()
+    skills.get_shortcuts.return_value = {
+        "exit": {"name": "exit-skill", "description": "Shadow exit"},
+        "quit": {"name": "quit-skill", "description": "Shadow quit"},
+    }
+    coordinator = MagicMock()
+    coordinator.session_state = {"active_mode": None, "mode_discovery": modes}
+    coordinator.get_capability.side_effect = (
+        lambda name: skills if name == "skills_discovery" else None
+    )
+    coordinator.get.return_value = {}
+    processor = CommandProcessor(SimpleNamespace(coordinator=coordinator))
+
+    assert processor.process_input("/EXIT") == (
+        "exit",
+        {"args": "", "command": "/exit"},
+    )
+    assert processor.process_input("/quit later") == (
+        "exit",
+        {"args": "later", "command": "/quit"},
+    )
+    assert CommandProcessor.COMMANDS["/exit"]["description"] == "Exit this session"
+    assert CommandProcessor.COMMANDS["/quit"]["description"] == "Alias for /exit"
+
+    help_text = processor._format_help()
+    assert "  /exit        - Exit this session" in help_text
+    assert "  /quit        - Alias for /exit" in help_text
+
+    snapshot = build_completion_snapshot(processor)
+    assert snapshot.commands["/exit"] == "Exit this session"
+    assert snapshot.commands["/quit"] == "Alias for /exit"
+    engine = SlashCompletionEngine(snapshot)
+    assert _values(engine, "/e") == ["/exit"]
+    assert _values(engine, "/q") == ["/quit"]
+
+
+def test_command_processor_aliases_are_session_scoped_and_canonical() -> None:
+    skills = _Discovery()
+    first = MagicMock()
+    first.coordinator.session_state = {
+        "active_mode": None,
+        "mode_discovery": MagicMock(get_shortcuts=lambda: {"p": "plan"}),
+    }
+    first.coordinator.get_capability.side_effect = (
+        lambda key: skills if key == "skills_discovery" else None
+    )
+    processor = CommandProcessor(first)
+
+    assert processor.process_input("/p")[1]["args"] == "plan"
+    assert processor.process_input("/plan")[1]["args"] == "plan"
+    assert processor.process_input("/rvw")[1]["skill_name"] == "review"
+    assert processor.process_input("/skill rvw")[1]["skill_name"] == "review"
+
+    second = MagicMock()
+    second.coordinator.session_state = {"active_mode": None}
+    second.coordinator.get_capability.return_value = None
+    isolated = CommandProcessor(second)
+    assert isolated.process_input("/rvw")[0] == "unknown_command"


### PR DESCRIPTION
## What changed
- Add snapshot-backed interactive slash completion for built-ins, provider/mode/config controls, user-invocable skills, and bounded `/goal`/directory verbs.
- Add explicit `/exit` and `/quit` commands with usage validation, preserving bare `exit`/`quit` compatibility and shared TTY cleanup.
- Derive help and completion from the static command registry, with built-in precedence over dynamic mode/skill aliases.

## Why
Interactive users can discover valid command syntax without keypress-time discovery or provider/filesystem/network work, and can leave the REPL through an explicitly authorized command path that always reaches normal cleanup.

## Verification
- Local full suite: 2134 passed, 1 skipped, 1 xfailed, 13 deselected.
- Local integration suite: 13 passed.
- Targeted Windows teardown fixture tests: 12 passed.
- `uv run ruff check` on all changed Python files: passed.
- `git diff --check` and staged secret-pattern scan: clean.
- Terminal evidence: actual DTU report passed exit/quit clean exit, usage rejection with continued prompting, menu Enter selection with second Enter submission, and cleanup. The report is PARTIAL only because the 120x40 viewport could not show every help row and did not visually confirm the trailing separator; static/runtime registry and unit coverage verify those behaviors.

## Breaking changes
None.

## Notes
No host paths, DTU identifiers, internal model names, or private captures are included. The optional memory adopter PR remains independent and is not a dependency of this CLI change.

### Fixture repair
- The initial CI run failed only in the two Windows test jobs because interactive teardown tests reached the native-console preflight before the mocked prompt.
- This push corrects that test fixture only: it keeps the fake REPL headless; no production code or platform skip was added.