### PR TITLE
feat: open slash command menu automatically with settings opt-out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,10 @@ snapshot is rebuilt only at REPL construction and immediately before each
 normal `prompt_async()` call; prompt-toolkit completion callbacks may read only
 that already-built snapshot.  Do not add discovery, provider, filesystem,
 network, or configurator calls to a keypress path.
+Keep history search enabled: its prompt-toolkit compatibility path uses the
+public buffer insertion hook only for a trailing, whitespace-free leading slash token; arguments stay Tab-only.
+Resolve the slash-popup UI setting once at interactive-session construction,
+outside prompt-toolkit callbacks and the per-prompt refresh loop.
 
 ## Interactive control-flow exits
 

--- a/README.md
+++ b/README.md
@@ -275,10 +275,11 @@ amplifier run --<TAB>      # Shows all options
 
 ## Interactive Slash Completion
 
-Inside an interactive Amplifier session, press `Tab` after a leading `/` to
-complete commands and their currently available arguments. The menu includes
-short descriptions and is based on the mounted providers, modes, skills, and
-live configuration captured before the prompt opens.
+Inside an interactive Amplifier session, typing a leading `/` automatically
+opens the top-level command menu; `Tab` completes commands and their currently
+available arguments. The menu includes short descriptions and is based on the
+mounted providers, modes, skills, and live configuration captured before the
+prompt opens.
 
 - `Tab` opens the menu and cycles forward; `Shift-Tab` cycles backward.
 - `Up`/`Down` select an open menu item. `Enter` accepts that item; press
@@ -288,6 +289,18 @@ live configuration captured before the prompt opens.
   becoming `/provider `.
 - `/exit` ends the interactive session; `/quit` is an alias. Neither accepts
   arguments.
+
+Automatic slash menus are on by default. To disable only the automatic popup,
+add this to `~/.amplifier/settings.yaml`:
+
+```yaml
+ui: {slash_popup: {enabled: false}}
+```
+
+`Tab` completion, including command arguments and aliases, remains available.
+`enabled` must be the YAML boolean `false`, not the string `"false"`. The
+setting applies to fresh and resumed interactive sessions started after the
+change; restart the interactive session to pick it up.
 
 Completion is available for built-in slash commands, provider and mode
 controls, `/config` verbs/flags, user-invocable skills and their declared

--- a/amplifier_app_cli/lib/settings.py
+++ b/amplifier_app_cli/lib/settings.py
@@ -136,6 +136,25 @@ class AppSettings:
                     pass  # Skip malformed files
         return result
 
+    # ----- UI settings -----
+
+    def get_slash_popup_enabled(self) -> bool:
+        """Return whether typing a leading slash automatically opens its menu.
+
+        This is a client preference, not bundle runtime configuration. Only a
+        YAML boolean overrides the default so malformed values safely retain
+        the default enabled behavior.
+        """
+        settings = self.get_merged_settings()
+        ui_settings = settings.get("ui")
+        if not isinstance(ui_settings, dict):
+            return True
+        slash_popup_settings = ui_settings.get("slash_popup")
+        if not isinstance(slash_popup_settings, dict):
+            return True
+        enabled = slash_popup_settings.get("enabled")
+        return enabled if isinstance(enabled, bool) else True
+
     # ----- Bundle settings -----
 
     def get_active_bundle(self) -> str | None:

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -25,6 +25,8 @@ from amplifier_core import (
 from amplifier_core.llm_errors import LLMError
 from amplifier_foundation import sanitize_message
 from prompt_toolkit import PromptSession
+from prompt_toolkit.buffer import Buffer
+from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.filters import has_completions
 from prompt_toolkit.formatted_text import HTML
 from prompt_toolkit.history import FileHistory, InMemoryHistory
@@ -71,6 +73,7 @@ from .console import Markdown, console
 from .dedicated_tty_input import close_dedicated_tty_input, get_dedicated_tty_input
 from .effective_config import get_effective_config_summary
 from .key_manager import KeyManager
+from .lib.settings import AppSettings
 from .provider_diagnostics import DEFAULT_TIMEOUT_S as _PROVIDER_DIAGNOSTIC_TIMEOUT_S
 from .provider_diagnostics import format_model_line
 from .provider_diagnostics import invoke_list_models
@@ -3468,6 +3471,7 @@ def _create_prompt_session(
     get_active_mode: Callable | None = None,
     get_pinned_provider: Callable | None = None,
     completer: SlashCompleter | None = None,
+    auto_popup_enabled: bool = True,
 ) -> PromptSession:
     """Create configured PromptSession for REPL.
 
@@ -3484,6 +3488,8 @@ def _create_prompt_session(
         get_pinned_provider: Optional callable that returns the pinned
             conversation provider's mount name (see ``_pinned_provider_name``)
         completer: Optional snapshot-backed slash completer for the REPL.
+        auto_popup_enabled: Whether typing a leading slash automatically opens
+            the top-level completion menu. Tab completion remains available.
 
     Returns:
         Configured PromptSession instance
@@ -3594,7 +3600,7 @@ def _create_prompt_session(
     def get_prompt():
         return _build_prompt_message(get_active_mode, get_pinned_provider)
 
-    return PromptSession(
+    session = PromptSession(
         message=get_prompt,  # Callable for dynamic prompt
         history=history,
         key_bindings=kb,
@@ -3619,6 +3625,22 @@ def _create_prompt_session(
         # available; see dedicated_tty_input.py for the full mechanism.
         input=get_dedicated_tty_input(),
     )
+    if completer is not None and auto_popup_enabled:
+        # History search disables prompt_toolkit's complete_while_typing; keep
+        # Ctrl-R enabled and scope this public event hook to the leading command token.
+        def start_slash_completion(buffer: Buffer) -> None:
+            if (
+                buffer.cursor_position == len(buffer.text)
+                and buffer.text.startswith("/")
+                and not any(character.isspace() for character in buffer.text[1:])
+            ):
+                buffer.start_completion(
+                    select_first=False, complete_event=CompleteEvent(text_inserted=True)
+                )
+
+        session.default_buffer.on_text_insert += start_slash_completion
+
+    return session
 
 
 async def interactive_chat(
@@ -3734,6 +3756,9 @@ async def interactive_chat(
         # prompt.  Keypresses read only this snapshot, never discovery,
         # configurator, filesystem, network, or mounted providers.
         slash_completer.refresh(build_completion_snapshot(command_processor))
+        # Resolve the client preference once per interactive session, outside
+        # prompt-toolkit callbacks and the per-prompt refresh loop.
+        auto_popup_enabled = AppSettings().get_slash_popup_enabled()
         prompt_session = _create_prompt_session(
             get_active_mode=lambda: (
                 command_processor.session.coordinator.session_state.get("active_mode")
@@ -3742,6 +3767,7 @@ async def interactive_chat(
                 command_processor.session
             ),
             completer=slash_completer,
+            auto_popup_enabled=auto_popup_enabled,
         )
     except _TERMINAL_UNUSABLE_ERRORS as e:
         _report_terminal_unusable(e, verbose=verbose)

--- a/amplifier_app_cli/ui/completion.py
+++ b/amplifier_app_cli/ui/completion.py
@@ -388,6 +388,14 @@ class SlashCompleter(Completer):
     def get_completions(self, document: Document, complete_event: Any):
         text = document.text
         cursor = document.cursor_position
+        if getattr(complete_event, "text_inserted", False) and (
+            cursor != len(text)
+            or not text.startswith("/")
+            or any(character.isspace() for character in text[1:])
+        ):
+            # The public buffer hook schedules this callback, so it can see a
+            # later document; automatic completion remains top-level only.
+            return
         prefix = text[:cursor].split()[-1] if text[:cursor] and not text[:cursor][-1].isspace() else ""
         for candidate in self.engine.complete(text, cursor):
             yield Completion(

--- a/docs/INTERACTIVE_MODE.md
+++ b/docs/INTERACTIVE_MODE.md
@@ -36,6 +36,20 @@ The `/mode*` commands come from `amplifier-bundle-modes` when that bundle is
 composed into your active configuration (which is the case for every standard
 amplifier bundle).
 
+## Slash Completion
+
+Typing a leading `/` opens the top-level command menu automatically. `Tab`
+still opens and cycles command and argument completions, including aliases.
+To disable only the automatic popup, add this to `~/.amplifier/settings.yaml`:
+
+```yaml
+ui: {slash_popup: {enabled: false}}
+```
+
+The default is enabled; `enabled` must be the YAML boolean `false`, not the
+string `"false"`. The setting takes effect for fresh and resumed interactive
+sessions started after the change; restart the session to apply it.
+
 ## Runtime Modes
 
 Runtime modes are runtime behavior overlays that modify how the assistant operates — restricting tools, contributing context, agents, or skills, and gating destructive actions. Plan mode is a common built-in:

--- a/tests/test_interactive_slash_completion.py
+++ b/tests/test_interactive_slash_completion.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import importlib
 from collections import namedtuple
+from contextlib import suppress
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from amplifier_app_cli.main import CommandProcessor, _create_prompt_session
+from amplifier_app_cli.lib.settings import AppSettings, SettingsPaths
 from amplifier_app_cli.ui.completion import (
     CompletionSnapshot,
     SlashCompleter,
@@ -251,27 +255,92 @@ def prompt_factory(monkeypatch: pytest.MonkeyPatch, tmp_path):
     monkeypatch.setattr(PromptSession, "__init__", dummy_output_init)
     monkeypatch.setattr(main_module, "get_amplifier_home", lambda: tmp_path / ".amplifier")
 
-    def build(snapshot: CompletionSnapshot):
+    def build(snapshot: CompletionSnapshot, *, auto_popup_enabled: bool = True):
         pipe_context = create_pipe_input()
         pipe = pipe_context.__enter__()
         monkeypatch.setattr(main_module, "get_dedicated_tty_input", lambda: pipe)
         completer = SlashCompleter()
         completer.refresh(snapshot)
-        return _create_prompt_session(completer=completer), pipe, pipe_context
+        return (
+            _create_prompt_session(
+                completer=completer, auto_popup_enabled=auto_popup_enabled
+            ),
+            pipe,
+            pipe_context,
+        )
 
     return build
 
 
 async def _start(session):
     task = asyncio.create_task(session.prompt_async())
-    await asyncio.sleep(0.03)
+    await asyncio.sleep(0)
     return task
+
+
+async def _wait_until_settled_complete_state(
+    session, expected: list[str] | None = None
+):
+    """Wait for the public completion state to settle without fixed test delays."""
+    for _ in range(100):
+        state = session.default_buffer.complete_state
+        values = (
+            [completion.display_text for completion in state.completions]
+            if state
+            else []
+        )
+        if state is not None and values and (expected is None or values == expected):
+            await asyncio.sleep(0)
+            settled = session.default_buffer.complete_state
+            settled_values = (
+                [completion.display_text for completion in settled.completions]
+                if settled
+                else []
+            )
+            if settled is not None and settled_values == values:
+                return settled
+        await asyncio.sleep(0.01)
+    raise AssertionError("completion state did not settle")
+
+
+async def _wait_until_completion_closed(session, expected_text: str) -> None:
+    """Wait until the menu is closed after the buffer has received an edit."""
+    stable_checks = 0
+    for _ in range(100):
+        buffer = session.default_buffer
+        if buffer.text == expected_text and buffer.complete_state is None:
+            stable_checks += 1
+            if stable_checks == 3:
+                return
+        else:
+            stable_checks = 0
+        await asyncio.sleep(0.01)
+    raise AssertionError("completion state did not close")
+
+
+async def _wait_until_selected_completion(session, expected_text: str) -> None:
+    for _ in range(100):
+        state = session.default_buffer.complete_state
+        completion = state.current_completion if state else None
+        if completion is not None and completion.text == f"{expected_text} ":
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(f"{expected_text!r} was not selected")
+
+
+async def _cancel_pending_prompt(task) -> None:
+    if not task.done():
+        task.cancel()
+    with suppress(asyncio.CancelledError):
+        await task
 
 
 @pytest.mark.asyncio
 async def test_pipe_unique_tab_and_ctrl_j(prompt_factory) -> None:
     session, pipe, context = prompt_factory(
-        CompletionSnapshot(commands={"/provider": "Provider", "/quit": "Alias for /exit"})
+        CompletionSnapshot(
+            commands={"/provider": "Provider", "/quit": "Alias for /exit"}
+        )
     )
     try:
         task = await _start(session)
@@ -291,11 +360,14 @@ async def test_pipe_unique_tab_and_ctrl_j(prompt_factory) -> None:
         pipe.send_text("\x1b[A\r")
         assert await asyncio.wait_for(task, 1) == "previous prompt"
     finally:
+        await _cancel_pending_prompt(task)
         context.__exit__(None, None, None)
 
 
 @pytest.mark.asyncio
-async def test_pipe_menu_navigation_escape_and_enter_does_not_submit(prompt_factory) -> None:
+async def test_pipe_menu_navigation_escape_and_enter_does_not_submit(
+    prompt_factory,
+) -> None:
     snapshot = CompletionSnapshot(
         commands={"/clear": "Clear", "/config": "Config", "/context": "Context"}
     )
@@ -330,11 +402,14 @@ async def test_pipe_menu_navigation_escape_and_enter_does_not_submit(prompt_fact
         pipe.send_text("l\t\r")
         assert await asyncio.wait_for(task, 1) == "/clear "
     finally:
+        await _cancel_pending_prompt(task)
         context.__exit__(None, None, None)
 
 
 @pytest.mark.asyncio
-async def test_pipe_menu_accepts_quit_before_second_enter_submits(prompt_factory) -> None:
+async def test_pipe_menu_accepts_quit_before_second_enter_submits(
+    prompt_factory,
+) -> None:
     session, pipe, context = prompt_factory(
         CompletionSnapshot(commands={"/query": "Query", "/quit": "Exit this session"})
     )
@@ -348,6 +423,370 @@ async def test_pipe_menu_accepts_quit_before_second_enter_submits(prompt_factory
         pipe.send_text("\r")
         assert await asyncio.wait_for(task, 1) == "/quit "
     finally:
+        await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_pipe_typing_slash_opens_and_refilters_top_level_menu(
+    prompt_factory,
+) -> None:
+    session, pipe, context = prompt_factory(
+        CompletionSnapshot(
+            commands={
+                "/clear": "Clear",
+                "/config": "Config",
+                "/provider": "Provider",
+            }
+        )
+    )
+    task = None
+    try:
+        task = await _start(session)
+        pipe.send_text("/")
+        state = await _wait_until_settled_complete_state(
+            session, ["/clear", "/config", "/provider"]
+        )
+        assert state.current_completion is None
+        assert session.default_buffer.text == "/"
+
+        pipe.send_text("c")
+        state = await _wait_until_settled_complete_state(session, ["/clear", "/config"])
+        assert state.current_completion is None
+        assert session.default_buffer.text == "/c"
+
+        pipe.send_text("l")
+        state = await _wait_until_settled_complete_state(session, ["/clear"])
+        assert state.current_completion is None
+        assert session.default_buffer.text == "/cl"
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_pipe_disabled_auto_popup_keeps_tab_commands_arguments_and_aliases(
+    prompt_factory,
+) -> None:
+    session, pipe, context = prompt_factory(
+        CompletionSnapshot(
+            commands={
+                "/clear": "Clear",
+                "/config": "Config",
+                "/provider": "Provider controls",
+                "/quit": "Alias for /exit",
+            }
+        ),
+        auto_popup_enabled=False,
+    )
+    task = None
+    try:
+        task = await _start(session)
+        pipe.send_text("/")
+        await _wait_until_completion_closed(session, "/")
+
+        pipe.send_text("c\t")
+        await _wait_until_settled_complete_state(session, ["/clear", "/config"])
+        pipe.send_text("\t")
+        await _wait_until_selected_completion(session, "/clear")
+        pipe.send_text("\r")
+        await _wait_until_completion_closed(session, "/clear ")
+        assert not task.done(), "first Enter must only accept the menu selection"
+        pipe.send_text("\r")
+        assert await asyncio.wait_for(task, 1) == "/clear "
+
+        task = await _start(session)
+        pipe.send_text("/qui\t\r")
+        assert await asyncio.wait_for(task, 1) == "/quit "
+
+        task = await _start(session)
+        pipe.send_text("/provider \t")
+        await _wait_until_settled_complete_state(
+            session, ["auto", "use", "test", "models"]
+        )
+        pipe.send_text("\t")
+        await _wait_until_selected_completion(session, "auto")
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_pipe_enter_accepts_auto_provider_completion_without_opening_arguments(
+    prompt_factory,
+) -> None:
+    session, pipe, context = prompt_factory(
+        CompletionSnapshot(commands={"/provider": "Provider controls"})
+    )
+    task = None
+    try:
+        task = await _start(session)
+        pipe.send_text("/pro")
+        state = await _wait_until_settled_complete_state(session, ["/provider"])
+        assert state.current_completion is None
+
+        pipe.send_text("\r")
+        await _wait_until_completion_closed(session, "/provider ")
+        assert not task.done(), "first Enter must only accept the menu selection"
+
+        pipe.send_text("\r")
+        assert await asyncio.wait_for(task, 1) == "/provider "
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.parametrize(
+    ("settings_yaml", "expected"),
+    [
+        (None, True),
+        ("{}", True),
+        ("ui: {slash_popup: {enabled: false}}", False),
+        ("ui: {slash_popup: {enabled: true}}", True),
+        ("ui: false", True),
+        ("ui: []", True),
+        ("ui: {slash_popup: false}", True),
+        ("ui: {slash_popup: []}", True),
+        ("ui: {slash_popup: {enabled: 'false'}}", True),
+        ("ui: {slash_popup: {enabled: null}}", True),
+        ("ui: {slash_popup: {enabled: 0}}", True),
+    ],
+)
+def test_slash_popup_setting_defaults_except_for_yaml_booleans(
+    tmp_path: Path, settings_yaml: str | None, expected: bool
+) -> None:
+    global_settings = tmp_path / "global" / "settings.yaml"
+    if settings_yaml is not None:
+        global_settings.parent.mkdir()
+        global_settings.write_text(settings_yaml, encoding="utf-8")
+    settings = AppSettings(
+        SettingsPaths(
+            global_settings=global_settings,
+            project_settings=tmp_path / "project" / "settings.yaml",
+            local_settings=tmp_path / "project" / "settings.local.yaml",
+        )
+    )
+
+    assert settings.get_slash_popup_enabled() is expected
+
+
+def test_slash_popup_setting_uses_global_project_local_precedence(tmp_path: Path) -> None:
+    paths = SettingsPaths(
+        global_settings=tmp_path / "global" / "settings.yaml",
+        project_settings=tmp_path / "project" / ".amplifier" / "settings.yaml",
+        local_settings=tmp_path / "project" / ".amplifier" / "settings.local.yaml",
+    )
+    for path, enabled in (
+        (paths.global_settings, False),
+        (paths.project_settings, True),
+        (paths.local_settings, False),
+    ):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            f"ui: {{slash_popup: {{enabled: {'true' if enabled else 'false'}}}}}",
+            encoding="utf-8",
+        )
+
+    assert AppSettings(paths).get_slash_popup_enabled() is False
+    paths.local_settings.unlink()
+    assert AppSettings(paths).get_slash_popup_enabled() is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("settings_yaml", "initial_transcript", "expected"),
+    [
+        (None, None, True),
+        ("ui: {slash_popup: {enabled: false}}", None, False),
+        ("ui: {slash_popup: {enabled: true}}", [{"role": "user", "content": "old"}], True),
+    ],
+)
+async def test_interactive_chat_resolves_slash_popup_once_before_prompt_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    settings_yaml: str | None,
+    initial_transcript: list[dict] | None,
+    expected: bool,
+) -> None:
+    main_module = importlib.import_module("amplifier_app_cli.main")
+    settings_module = importlib.import_module("amplifier_app_cli.lib.settings")
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    monkeypatch.chdir(project_dir)
+    app_home = tmp_path / "home" / ".amplifier"
+    if settings_yaml is not None:
+        app_home.mkdir(parents=True)
+        (app_home / "settings.yaml").write_text(settings_yaml, encoding="utf-8")
+    monkeypatch.setattr(settings_module, "get_amplifier_home", lambda: app_home)
+
+    context = MagicMock()
+    context.get_messages = AsyncMock(return_value=[])
+    coordinator = MagicMock()
+    coordinator.session_state = {}
+    coordinator.get.side_effect = (
+        lambda key: context if key == "context" else {} if key == "providers" else None
+    )
+    coordinator.get_capability.return_value = None
+    session = SimpleNamespace(
+        coordinator=coordinator,
+        config={},
+        execute=AsyncMock(),
+    )
+    initialized = SimpleNamespace(
+        session=session,
+        session_id="test-session-id",
+        configurator=None,
+        cleanup=AsyncMock(),
+    )
+    prompt_session = MagicMock()
+    prompt_session.prompt_async = AsyncMock(side_effect=EOFError)
+    create_prompt_session = MagicMock(return_value=prompt_session)
+    settings_reads = 0
+    real_get_merged_settings = settings_module.AppSettings.get_merged_settings
+
+    def count_settings_reads(instance):
+        nonlocal settings_reads
+        settings_reads += 1
+        return real_get_merged_settings(instance)
+
+    monkeypatch.setattr(
+        settings_module.AppSettings, "get_merged_settings", count_settings_reads
+    )
+    monkeypatch.setattr(
+        main_module,
+        "create_initialized_session",
+        AsyncMock(return_value=initialized),
+    )
+    monkeypatch.setattr(main_module, "_create_prompt_session", create_prompt_session)
+    monkeypatch.setattr(main_module, "SessionStore", MagicMock())
+    monkeypatch.setattr(main_module, "console", MagicMock())
+    monkeypatch.setattr(
+        main_module, "patch_stdout", lambda *_args, **_kwargs: contextlib.nullcontext()
+    )
+    monkeypatch.setattr(main_module, "close_dedicated_tty_input", MagicMock())
+    monkeypatch.setattr(main_module, "get_effective_config_summary", MagicMock())
+    monkeypatch.setattr(
+        importlib.import_module("amplifier_app_cli.incremental_save"),
+        "register_incremental_save",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        importlib.import_module("amplifier_app_cli.goal_progress_hook"),
+        "register_goal_progress_hook",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        importlib.import_module("amplifier_app_cli.goal_circuit_breaker"),
+        "register_goal_circuit_breaker",
+        MagicMock(),
+    )
+
+    await main_module.interactive_chat(
+        config={},
+        search_paths=[tmp_path],
+        verbose=False,
+        bundle_name="test-bundle",
+        initial_transcript=initial_transcript,
+    )
+
+    assert create_prompt_session.call_args.kwargs["auto_popup_enabled"] is expected
+    assert settings_reads == 1
+    prompt_session.prompt_async.assert_awaited_once()
+    session.execute.assert_not_awaited()
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("input_text", "expected_text"),
+    [
+        ("write /provider", "write /provider"),
+        ("https://example.test/", "https://example.test/"),
+        ("first\x0a/provider", "first\n/provider"),
+    ],
+)
+async def test_pipe_auto_completion_ignores_non_top_level_slash_text(
+    prompt_factory, input_text, expected_text
+) -> None:
+    session, pipe, context = prompt_factory(
+        CompletionSnapshot(commands={"/provider": "Provider controls"})
+    )
+    task = None
+    try:
+        task = await _start(session)
+        pipe.send_text(input_text)
+        await _wait_until_completion_closed(session, expected_text)
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_pipe_midtoken_edits_do_not_reopen_and_tab_still_completes_arguments(
+    prompt_factory,
+) -> None:
+    session, pipe, context = prompt_factory(
+        CompletionSnapshot(commands={"/provider": "Provider controls"})
+    )
+    task = None
+    try:
+        task = await _start(session)
+        pipe.send_text("/provider")
+        await _wait_until_settled_complete_state(session, ["/provider"])
+        pipe.send_text("\x1b[Dx")
+        await _wait_until_completion_closed(session, "/providexr")
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_pipe_automatic_completion_does_not_race_into_arguments(
+    prompt_factory,
+) -> None:
+    session, pipe, context = prompt_factory(
+        CompletionSnapshot(commands={"/provider": "Provider controls"})
+    )
+    task = None
+    try:
+        task = await _start(session)
+        pipe.send_text("/provider ")
+        await _wait_until_completion_closed(session, "/provider ")
+
+        pipe.send_text("\t")
+        state = await _wait_until_settled_complete_state(
+            session, ["auto", "use", "test", "models"]
+        )
+        assert state.current_completion is None
+        pipe.send_text("\t")
+        await _wait_until_selected_completion(session, "auto")
+        pipe.send_text("\t")
+        await _wait_until_selected_completion(session, "use")
+        pipe.send_text("\x1b[Z")
+        await _wait_until_selected_completion(session, "auto")
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_pipe_rapid_provider_argument_text_does_not_open_a_menu(
+    prompt_factory,
+) -> None:
+    session, pipe, context = prompt_factory(
+        CompletionSnapshot(commands={"/provider": "Provider controls"})
+    )
+    task = None
+    try:
+        task = await _start(session)
+        pipe.send_text("/provider u")
+        await _wait_until_completion_closed(session, "/provider u")
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
         context.__exit__(None, None, None)
 
 


### PR DESCRIPTION
## What changed

- Open the top-level slash-command menu automatically when the user types a leading `/`.
- Keep the behavior on by default; absent or malformed settings retain the enabled default.
- Add the `ui.slash_popup.enabled` opt-out in `~/.amplifier/settings.yaml`:

  ```yaml
  ui: {slash_popup: {enabled: false}}
  ```

- With `enabled: false`, only the automatic popup is disabled. `Tab` completion, command arguments, aliases, and history search remain available.
- Resolve the setting once when each interactive session is constructed, including resumed sessions; no discovery or I/O is added to keypress handling.

## Why

Slash commands are easier to discover without requiring a first `Tab`, while users who prefer the prior quieter interaction can restore Tab-only behavior with one explicit setting.

## Verification

- Full suite: 2,158 passed, 1 skipped, 13 deselected, 1 expected failure.
- Integration suite: 13 passed.
- Targeted slash-completion tests: 37 passed.
- Configured Ruff, `git diff --check`, and production-source hash checks passed.
- Final live terminal gate passed for all three settings states: missing setting (default enabled), `ui.slash_popup.enabled: false`, and `ui.slash_popup.enabled: true`.
- The isolated fixture-environment setup corrected the earlier guard/setup failure; the source was unchanged. Disabled and enabled sessions passed automatic-popup, Tab-only completion, navigation, argument cycling, and Enter/Esc behavior. No prose, provider command, model prompt, or memory call was submitted.

## Breaking changes

None. Automatic popup is additive and can be disabled without changing command or argument completion behavior.