### PR TITLE
feat: make slash completion prefix-first with advisory arguments

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,9 @@ the exact current line, regardless of the automatic-popup setting.
 Keep ambiguous-completion guidance in the inline right prompt: prompt-toolkit
 hides bottom toolbars when a terminal cannot answer cursor-position requests.
 Verify its visible rendering in a CPR-unsupported PTY, not only its callback text.
+Pipe-input Escape tests must allow both VT-parser (`ttimeoutlen`) and key-binding
+(`timeoutlen`) timeouts. Shorten both on the test application, send one Escape,
+and wait for the restored document and closed menu; a second Escape is not a flush.
 
 ## Interactive control-flow exits
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,9 +79,21 @@ normal `prompt_async()` call; prompt-toolkit completion callbacks may read only
 that already-built snapshot.  Do not add discovery, provider, filesystem,
 network, or configurator calls to a keypress path.
 Keep history search enabled: its prompt-toolkit compatibility path uses the
-public buffer insertion hook only for a trailing, whitespace-free leading slash token; arguments stay Tab-only.
-Resolve the slash-popup UI setting once at interactive-session construction,
-outside prompt-toolkit callbacks and the per-prompt refresh loop.
+public buffer insertion hook for safe, end-of-buffer leading-slash documents.
+Known argument candidates may open advisory menus; custom typed arguments must
+remain unchanged on Enter unless the user explicitly selects a candidate.
+Resolve the slash-popup UI setting once at interactive-session construction;
+it gates every automatic command and argument menu, outside prompt-toolkit
+callbacks and the per-prompt refresh loop.
+Unselected `Tab` must only accept a unique candidate or extend the literal
+longest shared candidate prefix; it never cycles choices. `Up`/`Down` and
+`Shift-Tab` create explicit reversible previews, which `Tab`, `Enter`, or
+`Space` may accept without submitting. Unselected command `Enter` accepts
+only an exact or unique command; unselected argument `Enter` always submits
+the exact current line, regardless of the automatic-popup setting.
+Keep ambiguous-completion guidance in the inline right prompt: prompt-toolkit
+hides bottom toolbars when a terminal cannot answer cursor-position requests.
+Verify its visible rendering in a CPR-unsupported PTY, not only its callback text.
 
 ## Interactive control-flow exits
 

--- a/README.md
+++ b/README.md
@@ -276,21 +276,29 @@ amplifier run --<TAB>      # Shows all options
 ## Interactive Slash Completion
 
 Inside an interactive Amplifier session, typing a leading `/` automatically
-opens the top-level command menu; `Tab` completes commands and their currently
-available arguments. The menu includes short descriptions and is based on the
-mounted providers, modes, skills, and live configuration captured before the
-prompt opens.
+opens command menus and known argument-choice menus; `Tab` completes commands
+and their currently available arguments. The menu includes short descriptions
+and is based on the mounted providers, modes, skills, and live configuration
+captured before the prompt opens.
 
-- `Tab` opens the menu and cycles forward; `Shift-Tab` cycles backward.
-- `Up`/`Down` select an open menu item. `Enter` accepts that item; press
-  `Enter` again to run the completed command.
+- `Tab` completes the unambiguous part whether or not a menu is open: one
+  match is accepted with its trailing space; several matches extend their
+  shared prefix and remain unselected. Repeating `Tab` does not cycle choices.
+- `Up`/`Down` and `Shift-Tab` select an open menu item. `Tab`, `Enter`, or
+  `Space` accepts an explicitly selected item without submitting the prompt.
+- `Enter` accepts an exact command name (or one unique command match). For an
+  ambiguous command prefix it keeps the menu open and asks you to type more or
+  choose. An unselected argument menu always submits the exact text you typed.
 - `Esc` cancels an open menu and restores the text from before completion.
-- A unique match is inserted with a trailing space, such as `/pro` + `Tab`
-  becoming `/provider `.
+- For example, with `/product-council`, `/product-council-here`, and
+  `/provider` available, `/p` + `Tab` becomes `/pro`; `/pro` + `Tab` remains
+  `/pro` until you type more or select a choice. `/provider ` + `Tab` opens
+  its known argument choices.
 - `/exit` ends the interactive session; `/quit` is an alias. Neither accepts
   arguments.
 
-Automatic slash menus are on by default. To disable only the automatic popup,
+Automatic slash menus are on by default. To disable all automatic command and
+argument popups,
 add this to `~/.amplifier/settings.yaml`:
 
 ```yaml
@@ -304,8 +312,10 @@ change; restart the interactive session to pick it up.
 
 Completion is available for built-in slash commands, provider and mode
 controls, `/config` verbs/flags, user-invocable skills and their declared
-literal arguments, and `/goal` controls. Free-form prompt text, goal
-conditions, and file/path arguments are intentionally not guessed.
+literal arguments, and `/goal` controls. The catalog is conditional on the
+commands, modes, skills, and providers mounted in the live session. Free-form
+prompt text, goal conditions, and file/path arguments are intentionally not
+guessed.
 
 ## Architecture
 

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -86,7 +86,12 @@ from .ui.dashboard_renderer import _redact_value as _dr_redact_value
 from .ui.error_display import display_llm_error, display_validation_error
 from .ui.item_renderer import ItemRenderer
 from .ui.log_filter import LLMErrorLogFilter
-from .ui.completion import SlashCompleter, build_completion_snapshot
+from .ui.completion import (
+    Candidate,
+    SlashCompleter,
+    build_completion_snapshot,
+    longest_common_prefix,
+)
 from .ui.view_policy import resolve_view
 from .utils.error_format import escape_markup
 from .utils.version import get_core_version, get_version
@@ -3489,7 +3494,8 @@ def _create_prompt_session(
             conversation provider's mount name (see ``_pinned_provider_name``)
         completer: Optional snapshot-backed slash completer for the REPL.
         auto_popup_enabled: Whether typing a leading slash automatically opens
-            the top-level completion menu. Tab completion remains available.
+            completion menus for command names and known argument choices. Tab
+            completion remains available.
 
     Returns:
         Configured PromptSession instance
@@ -3518,6 +3524,98 @@ def _create_prompt_session(
             f"Could not load history from {history_path}: {e}. Using in-memory history for this session."
         )
 
+    ambiguity_hint = False
+
+    def clear_ambiguity_hint() -> None:
+        nonlocal ambiguity_hint
+        ambiguity_hint = False
+
+    def completion_hint() -> str:
+        """Show a short prompt only while its ambiguous menu remains open."""
+        if ambiguity_hint and session.default_buffer.complete_state is not None:
+            return "Type more or choose"
+        return ""
+
+    def start_slash_completion(buffer: Buffer) -> None:
+        """Open an unselected automatic menu only at a safe current position."""
+        if (
+            auto_popup_enabled
+            and completer is not None
+            and SlashCompleter.is_automatic_completion_position(
+                buffer.text, buffer.cursor_position
+            )
+        ):
+            if (
+                buffer.complete_state is not None
+                and buffer.complete_state.current_completion is None
+            ):
+                # Prompt-toolkit keeps the document from when this menu opened
+                # for Esc/cancel. Renew it after filtering typed input so
+                # cancellation preserves the current prefix.
+                typed_document = buffer.document
+                buffer.cancel_completion()
+                buffer.document = typed_document
+            buffer.start_completion(
+                select_first=False, complete_event=CompleteEvent(text_inserted=True)
+            )
+
+    def restore_unselected_document(buffer: Buffer) -> None:
+        """Close an unselected menu without losing the visible typed document."""
+        typed_document = buffer.document
+        buffer.cancel_completion()
+        buffer.document = typed_document
+
+    def insert_candidate(buffer: Buffer, candidate) -> None:
+        """Replace only the token before the cursor and retain later text."""
+        start = buffer.cursor_position
+        while start and not buffer.text[start - 1].isspace():
+            start -= 1
+        has_delimiter_after = (
+            buffer.cursor_position < len(buffer.text)
+            and buffer.text[buffer.cursor_position].isspace()
+        )
+        buffer.delete_before_cursor(count=buffer.cursor_position - start)
+        insertion = candidate.value
+        if candidate.append_space and not has_delimiter_after:
+            insertion += " "
+        buffer.insert_text(insertion)
+
+    def token_before_cursor(buffer: Buffer) -> str:
+        """Return the complete current token, including its leading slash."""
+        start = buffer.cursor_position
+        while start and not buffer.text[start - 1].isspace():
+            start -= 1
+        return buffer.text[start : buffer.cursor_position]
+
+    def extension_for_prefix(prefix: str, shared: str) -> str:
+        """Extend a case-insensitive match without changing typed case."""
+        shared_prefix = shared[: len(prefix)]
+        if (
+            len(prefix.casefold()) != len(prefix)
+            or len(shared_prefix.casefold()) != len(shared_prefix)
+            or prefix.casefold() != shared_prefix.casefold()
+        ):
+            return ""
+        return shared[len(prefix) :]
+
+    def accept_selected_completion(buffer: Buffer, completion) -> None:
+        """Commit an explicit preview, then offer a known next argument."""
+        state = buffer.complete_state
+        if state is not None:
+            # Complete against the original document so accepting a choice
+            # before an existing delimiter retains that later text intact.
+            original_document = state.original_document
+            buffer.cancel_completion()
+            buffer.document = original_document
+        insert_candidate(
+            buffer,
+            Candidate(
+                completion.display_text,
+                append_space=completion.text.endswith(" "),
+            ),
+        )
+        start_slash_completion(buffer)
+
     # Create key bindings for multi-line support
     kb = KeyBindings()
 
@@ -3529,63 +3627,127 @@ def _create_prompt_session(
     @kb.add("enter")  # Enter submits (even in multiline mode)
     def accept_input(event):
         """Accept a completion menu selection, otherwise submit input."""
-        if event.current_buffer.complete_state:
-            state = event.current_buffer.complete_state
-            completion = state.current_completion
-            if completion is None and state.completions:
-                completion = state.completions[0]
-            if completion is not None:
-                event.current_buffer.apply_completion(completion)
-            else:
-                event.current_buffer.cancel_completion()
-            return
-        event.current_buffer.validate_and_handle()
-
-    @kb.add("tab")
-    def complete_next(event):
-        """Open/cycle the explicitly requested slash completion menu."""
+        nonlocal ambiguity_hint
         buffer = event.current_buffer
         if buffer.complete_state:
-            buffer.complete_next()
-        elif completer is not None:
-            candidates = completer.engine.complete(buffer.text, buffer.cursor_position)
-            if len(candidates) == 1:
-                # Prompt-toolkit's native Completion only replaces text before
-                # the cursor.  Replacing the complete token ourselves avoids
-                # duplicating a suffix when a user invokes Tab in its middle.
-                start = buffer.cursor_position
-                while start and not buffer.text[start - 1].isspace():
-                    start -= 1
-                end = buffer.cursor_position
-                while end < len(buffer.text) and not buffer.text[end].isspace():
-                    end += 1
-                buffer.cursor_position = start
-                buffer.delete(count=end - start)
-                buffer.insert_text(candidates[0].insertion)
-            elif candidates:
-                buffer.start_completion(select_first=False)
+            state = buffer.complete_state
+            completion = state.current_completion
+            if completion is not None:
+                clear_ambiguity_hint()
+                accept_selected_completion(buffer, completion)
+                return
+
+            original = state.original_document
+            if SlashCompleter.is_argument_position(
+                original.text, original.cursor_position
+            ):
+                # Argument candidates are always advisory, including menus
+                # opened manually when automatic popups are disabled.
+                restore_unselected_document(buffer)
+                clear_ambiguity_hint()
+                buffer.validate_and_handle()
+                return
+
+            candidates = (
+                completer.engine.complete(buffer.text, buffer.cursor_position)
+                if completer is not None
+                else []
+            )
+            typed_token = token_before_cursor(buffer)
+            exact = next(
+                (
+                    candidate
+                    for candidate in candidates
+                    if candidate.value.lower() == typed_token.lower()
+                ),
+                None,
+            )
+            if exact is not None or len(candidates) == 1:
+                restore_unselected_document(buffer)
+                insert_candidate(buffer, exact or candidates[0])
+                clear_ambiguity_hint()
+                start_slash_completion(buffer)
+                return
+            if candidates:
+                ambiguity_hint = True
+                return
+            restore_unselected_document(buffer)
+        clear_ambiguity_hint()
+        buffer.validate_and_handle()
+
+    @kb.add("tab", eager=True)
+    @kb.add("c-i", eager=True)
+    def complete_next(event):
+        """Complete an unselected prefix or accept an explicit preview."""
+        buffer = event.current_buffer
+        clear_ambiguity_hint()
+        if buffer.complete_state and buffer.complete_state.current_completion is not None:
+            accept_selected_completion(buffer, buffer.complete_state.current_completion)
+            return
+        if completer is None:
+            return
+        candidates = completer.engine.complete(buffer.text, buffer.cursor_position)
+        if len(candidates) == 1:
+            if buffer.complete_state:
+                restore_unselected_document(buffer)
+            insert_candidate(buffer, candidates[0])
+            start_slash_completion(buffer)
+            return
+        if len(candidates) < 2:
+            return
+        prefix = token_before_cursor(buffer)
+        extension = extension_for_prefix(prefix, longest_common_prefix(candidates))
+        if extension:
+            if buffer.complete_state:
+                restore_unselected_document(buffer)
+            buffer.insert_text(extension)
+        if buffer.complete_state is None:
+            buffer.start_completion(select_first=False)
 
     @kb.add("s-tab")
     def complete_previous(event):
         """Cycle backwards when the completion menu is open."""
+        clear_ambiguity_hint()
         if event.current_buffer.complete_state:
             event.current_buffer.complete_previous()
 
     @kb.add("escape")
     def cancel_completion(event):
         """Cancel completion and restore its original input."""
+        clear_ambiguity_hint()
         if event.current_buffer.complete_state:
             event.current_buffer.cancel_completion()
 
     @kb.add("up", filter=has_completions)
     def completion_up(event):
         """Navigate the open completion menu without stealing history keys."""
+        clear_ambiguity_hint()
         event.current_buffer.complete_previous()
 
     @kb.add("down", filter=has_completions)
     def completion_down(event):
         """Navigate the open completion menu without stealing history keys."""
+        clear_ambiguity_hint()
         event.current_buffer.complete_next()
+
+    @kb.add(" ")
+    def insert_space(event):
+        """Insert a literal boundary unless committing an explicit preview."""
+        buffer = event.current_buffer
+        clear_ambiguity_hint()
+        state = buffer.complete_state
+        if state is not None and state.current_completion is not None:
+            completion = state.current_completion
+            accept_selected_completion(buffer, completion)
+            if not (
+                buffer.document.char_before_cursor.isspace()
+                or buffer.document.current_char.isspace()
+            ):
+                buffer.insert_text(" ")
+            return
+        if state is not None:
+            restore_unselected_document(buffer)
+        buffer.insert_text(" ")
 
     # Dynamic prompt that shows [mode] and [pin] indicators when active.
     #
@@ -3624,21 +3786,18 @@ def _create_prompt_session(
         # (prompt_toolkit's own default) whenever a dedicated fd isn't
         # available; see dedicated_tty_input.py for the full mechanism.
         input=get_dedicated_tty_input(),
+        # Unlike a bottom toolbar, the inline hint does not require CPR support.
+        rprompt=completion_hint,
     )
-    if completer is not None and auto_popup_enabled:
+    if completer is not None:
         # History search disables prompt_toolkit's complete_while_typing; keep
-        # Ctrl-R enabled and scope this public event hook to the leading command token.
-        def start_slash_completion(buffer: Buffer) -> None:
-            if (
-                buffer.cursor_position == len(buffer.text)
-                and buffer.text.startswith("/")
-                and not any(character.isspace() for character in buffer.text[1:])
-            ):
-                buffer.start_completion(
-                    select_first=False, complete_event=CompleteEvent(text_inserted=True)
-                )
+        # Ctrl-R enabled. Candidate availability is snapshot-only and the
+        # adapter repeats this check when its deferred callback runs.
+        def on_text_insert(buffer: Buffer) -> None:
+            clear_ambiguity_hint()
+            start_slash_completion(buffer)
 
-        session.default_buffer.on_text_insert += start_slash_completion
+        session.default_buffer.on_text_insert += on_text_insert
 
     return session
 

--- a/amplifier_app_cli/ui/completion.py
+++ b/amplifier_app_cli/ui/completion.py
@@ -65,6 +65,23 @@ class Candidate:
         return self.value + (" " if self.append_space else "")
 
 
+def longest_common_prefix(candidates: Iterable[Candidate]) -> str:
+    """Return the literal prefix shared by every candidate value."""
+    values = [candidate.value for candidate in candidates]
+    if not values:
+        return ""
+    prefix = values[0]
+    for value in values[1:]:
+        limit = min(len(prefix), len(value))
+        index = 0
+        while index < limit and prefix[index] == value[index]:
+            index += 1
+        prefix = prefix[:index]
+        if not prefix:
+            break
+    return prefix
+
+
 @dataclass
 class CompletionSnapshot:
     """All data allowed to be read while completion is active."""
@@ -381,6 +398,33 @@ class SlashCompleter(Completer):
     def __init__(self, engine: SlashCompletionEngine | None = None):
         self.engine = engine or SlashCompletionEngine()
 
+    @staticmethod
+    def is_automatic_completion_position(text: str, cursor_position: int) -> bool:
+        """Return whether an automatic menu can safely inspect this document.
+
+        Candidate availability remains the engine's responsibility: this only
+        excludes unsafe or stale document positions shared by the input hook
+        and its deferred completion callback.
+        """
+        return (
+            cursor_position == len(text)
+            and text.startswith("/")
+            and "\n" not in text
+            and "\r" not in text
+        )
+
+    @classmethod
+    def is_argument_position(cls, text: str, cursor_position: int) -> bool:
+        """Return whether a safely completable source document is in arguments."""
+        before, after = text[:cursor_position], text[cursor_position:]
+        return (
+            text.startswith("/")
+            and "\n" not in before
+            and "\r" not in before
+            and (not after or after[:1].isspace())
+            and any(character.isspace() for character in text[1:cursor_position])
+        )
+
     def refresh(self, snapshot: CompletionSnapshot) -> None:
         """Replace the in-memory completion snapshot at a safe REPL boundary."""
         self.engine.refresh(snapshot)
@@ -388,18 +432,21 @@ class SlashCompleter(Completer):
     def get_completions(self, document: Document, complete_event: Any):
         text = document.text
         cursor = document.cursor_position
-        if getattr(complete_event, "text_inserted", False) and (
-            cursor != len(text)
-            or not text.startswith("/")
-            or any(character.isspace() for character in text[1:])
+        if getattr(complete_event, "text_inserted", False) and not self.is_automatic_completion_position(
+            text, cursor
         ):
             # The public buffer hook schedules this callback, so it can see a
-            # later document; automatic completion remains top-level only.
+            # later document; automatic completion must re-check it here.
             return
         prefix = text[:cursor].split()[-1] if text[:cursor] and not text[:cursor][-1].isspace() else ""
         for candidate in self.engine.complete(text, cursor):
+            insertion = (
+                candidate.value
+                if text[cursor:] and text[cursor].isspace()
+                else candidate.insertion
+            )
             yield Completion(
-                candidate.insertion,
+                insertion,
                 start_position=-len(prefix),
                 display=candidate.value,
                 display_meta=candidate.description,

--- a/docs/INTERACTIVE_MODE.md
+++ b/docs/INTERACTIVE_MODE.md
@@ -38,17 +38,39 @@ amplifier bundle).
 
 ## Slash Completion
 
-Typing a leading `/` opens the top-level command menu automatically. `Tab`
-still opens and cycles command and argument completions, including aliases.
+Typing a leading `/` opens command and known argument-choice menus
+automatically. `Tab` has the same prefix behavior whether a menu is already
+open or not: it accepts one match, or extends every matching value's literal
+shared prefix and leaves the menu unselected. It does not cycle an unselected
+menu. Use `Up`/`Down` or `Shift-Tab` to preview a choice; `Tab`, `Enter`, or
+`Space` then accepts that explicit choice without submitting the prompt.
+
+For command names, unselected `Enter` accepts an exact match (case
+insensitively) or one unique match. An ambiguous prefix remains open with a
+short “Type more or choose” hint. For arguments, suggestions are advisory:
+unselected `Enter` always submits the exact current line, including partial,
+custom, quoted, multiword, or trailing-space arguments. This is also true
+after opening an argument menu manually with automatic popups disabled.
+
+For example, if `/product-council`, `/product-council-here`, and `/provider`
+are available, `/p` then `Tab` becomes `/pro`. A second `Tab` leaves `/pro`
+unselected because the names are still ambiguous. A real `/p` alias is an
+exact shorter command and prevents that extension; `Enter` accepts it with a
+space. The available command catalog is conditional on the built-ins and
+currently mounted modes, skills, and providers.
 To disable only the automatic popup, add this to `~/.amplifier/settings.yaml`:
 
 ```yaml
 ui: {slash_popup: {enabled: false}}
 ```
 
-The default is enabled; `enabled` must be the YAML boolean `false`, not the
+The default is enabled; this disables every automatic command and argument
+popup (manual `Tab` remains available). `enabled` must be the YAML boolean `false`, not the
 string `"false"`. The setting takes effect for fresh and resumed interactive
 sessions started after the change; restart the session to apply it.
+
+This experiment opens menus on text insertion, not deletion: `Backspace`
+closes an open menu until you type again or press `Tab`.
 
 ## Runtime Modes
 

--- a/tests/test_interactive_slash_completion.py
+++ b/tests/test_interactive_slash_completion.py
@@ -15,10 +15,12 @@ import pytest
 from amplifier_app_cli.main import CommandProcessor, _create_prompt_session
 from amplifier_app_cli.lib.settings import AppSettings, SettingsPaths
 from amplifier_app_cli.ui.completion import (
+    Candidate,
     CompletionSnapshot,
     SlashCompleter,
     SlashCompletionEngine,
     build_completion_snapshot,
+    longest_common_prefix,
 )
 from prompt_toolkit import PromptSession
 from prompt_toolkit.input.defaults import create_pipe_input
@@ -163,6 +165,39 @@ def test_engine_never_completes_prose_or_unsafe_cursor_suffix() -> None:
     assert _values(engine, "write /pro") == []
     assert _values(engine, "/proXvider", 4) == []
     assert _values(engine, "/provider", 4) == []
+
+
+def test_longest_common_prefix_keeps_literal_candidate_grammar() -> None:
+    assert longest_common_prefix(
+        [
+            Candidate("/product-council"),
+            Candidate("/product-council-here"),
+            Candidate("/provider"),
+        ]
+    ) == "/pro"
+    assert longest_common_prefix([Candidate("Fast"), Candidate("fast")]) == ""
+    assert longest_common_prefix([]) == ""
+
+
+def test_engine_prefix_fixture_distinguishes_aliases_from_longer_matches() -> None:
+    snapshot = CompletionSnapshot(
+        skill_shortcuts={
+            "product-council": {"name": "product-council"},
+            "product-council-here": {"name": "product-council-here"},
+        },
+        commands={"/provider": "Provider"},
+    )
+    engine = SlashCompletionEngine(snapshot)
+
+    assert longest_common_prefix(engine.complete("/p")) == "/pro"
+    assert _values(engine, "/prov") == ["/provider"]
+    assert _values(engine, "/prod") == [
+        "/product-council",
+        "/product-council-here",
+    ]
+
+    snapshot.mode_shortcuts["p"] = "plan"
+    assert longest_common_prefix(engine.complete("/p")) == "/p"
 
 
 def test_completer_reads_only_the_existing_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -315,14 +350,39 @@ async def _wait_until_completion_closed(session, expected_text: str) -> None:
         else:
             stable_checks = 0
         await asyncio.sleep(0.01)
-    raise AssertionError("completion state did not close")
+    raise AssertionError(
+        f"completion state did not close: text={session.default_buffer.text!r}, "
+        f"state={session.default_buffer.complete_state!r}"
+    )
+
+
+async def _wait_until_buffer_text(session, expected_text: str) -> None:
+    """Wait for a pipe-input key binding to update the public buffer text."""
+    for _ in range(100):
+        if session.default_buffer.text == expected_text:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(
+        f"buffer text did not become {expected_text!r}: "
+        f"{session.default_buffer.text!r}"
+    )
+
+
+async def _wait_until_completion_hint(session, expected_text: str) -> None:
+    for _ in range(100):
+        if session.rprompt() == expected_text:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(
+        f"completion hint did not become {expected_text!r}: {session.rprompt()!r}"
+    )
 
 
 async def _wait_until_selected_completion(session, expected_text: str) -> None:
     for _ in range(100):
         state = session.default_buffer.complete_state
         completion = state.current_completion if state else None
-        if completion is not None and completion.text == f"{expected_text} ":
+        if completion is not None and completion.display_text == expected_text:
             return
         await asyncio.sleep(0.01)
     raise AssertionError(f"{expected_text!r} was not selected")
@@ -361,6 +421,30 @@ async def test_pipe_unique_tab_and_ctrl_j(prompt_factory) -> None:
         assert await asyncio.wait_for(task, 1) == "previous prompt"
     finally:
         await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_pipe_space_inserts_before_existing_whitespace_and_never_guesses(
+    prompt_factory,
+) -> None:
+    session, pipe, context = prompt_factory(
+        CompletionSnapshot(commands={"/clear": "Clear", "/config": "Config"})
+    )
+    task = None
+    try:
+        task = await _start(session)
+        pipe.send_text("a b\x1b[D\x1b[D \r")
+        assert await asyncio.wait_for(task, 1) == "a  b"
+
+        task = await _start(session)
+        pipe.send_text("/c ")
+        await _wait_until_completion_closed(session, "/c ")
+        pipe.send_text("\r")
+        assert await asyncio.wait_for(task, 1) == "/c "
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
         context.__exit__(None, None, None)
 
 
@@ -489,6 +573,10 @@ async def test_pipe_disabled_auto_popup_keeps_tab_commands_arguments_and_aliases
         pipe.send_text("c\t")
         await _wait_until_settled_complete_state(session, ["/clear", "/config"])
         pipe.send_text("\t")
+        state = await _wait_until_settled_complete_state(session, ["/clear", "/config"])
+        assert state.current_completion is None
+        assert session.default_buffer.text == "/c"
+        pipe.send_text("\x1b[B")
         await _wait_until_selected_completion(session, "/clear")
         pipe.send_text("\r")
         await _wait_until_completion_closed(session, "/clear ")
@@ -501,11 +589,13 @@ async def test_pipe_disabled_auto_popup_keeps_tab_commands_arguments_and_aliases
         assert await asyncio.wait_for(task, 1) == "/quit "
 
         task = await _start(session)
-        pipe.send_text("/provider \t")
+        pipe.send_text("/provider ")
+        await _wait_until_completion_closed(session, "/provider ")
+        pipe.send_text("\t")
         await _wait_until_settled_complete_state(
             session, ["auto", "use", "test", "models"]
         )
-        pipe.send_text("\t")
+        pipe.send_text("\x1b[B")
         await _wait_until_selected_completion(session, "auto")
     finally:
         if task is not None:
@@ -514,7 +604,7 @@ async def test_pipe_disabled_auto_popup_keeps_tab_commands_arguments_and_aliases
 
 
 @pytest.mark.asyncio
-async def test_pipe_enter_accepts_auto_provider_completion_without_opening_arguments(
+async def test_pipe_auto_command_acceptance_opens_unselected_argument_menu(
     prompt_factory,
 ) -> None:
     session, pipe, context = prompt_factory(
@@ -528,11 +618,251 @@ async def test_pipe_enter_accepts_auto_provider_completion_without_opening_argum
         assert state.current_completion is None
 
         pipe.send_text("\r")
-        await _wait_until_completion_closed(session, "/provider ")
+        state = await _wait_until_settled_complete_state(
+            session, ["auto", "use", "test", "models"]
+        )
+        assert state.current_completion is None
+        assert session.default_buffer.text == "/provider "
         assert not task.done(), "first Enter must only accept the menu selection"
 
         pipe.send_text("\r")
         assert await asyncio.wait_for(task, 1) == "/provider "
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_pipe_tab_extends_shared_prefix_without_selecting_or_cycling(
+    prompt_factory,
+) -> None:
+    snapshot = CompletionSnapshot(
+        commands={"/provider": "Provider"},
+        skill_shortcuts={
+            "product-council": {"name": "product-council"},
+            "product-council-here": {"name": "product-council-here"},
+        },
+    )
+    session, pipe, context = prompt_factory(snapshot)
+    task = None
+    try:
+        task = await _start(session)
+        pipe.send_text("/p")
+        await _wait_until_settled_complete_state(
+            session, ["/product-council", "/product-council-here", "/provider"]
+        )
+        assert session.default_buffer.cursor_position == 2
+        assert longest_common_prefix(
+            session.completer.engine.complete(
+                session.default_buffer.text, session.default_buffer.cursor_position
+            )
+        ) == "/pro"
+        pipe.send_text("\t")
+        await _wait_until_buffer_text(session, "/pro")
+        state = await _wait_until_settled_complete_state(
+            session, ["/product-council", "/product-council-here", "/provider"]
+        )
+        assert state.current_completion is None
+        assert session.default_buffer.text == "/pro"
+
+        pipe.send_text("\t")
+        await _wait_until_buffer_text(session, "/pro")
+        state = await _wait_until_settled_complete_state(
+            session, ["/product-council", "/product-council-here", "/provider"]
+        )
+        assert state.current_completion is None
+        assert session.default_buffer.text == "/pro"
+
+        pipe.send_text("\r")
+        await _wait_until_completion_hint(session, "Type more or choose")
+        assert not task.done()
+        pipe.send_text("\t")
+        await _wait_until_completion_hint(session, "")
+        pipe.send_text("\x1b[B")
+        await _wait_until_selected_completion(session, "/product-council")
+        pipe.send_text("\t")
+        await _wait_until_buffer_text(session, "/product-council ")
+        pipe.send_text("\r")
+        assert await asyncio.wait_for(task, 1) == "/product-council "
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("auto_popup_enabled", [False, True])
+async def test_pipe_inline_ambiguity_hint_clears_on_edit(
+    prompt_factory, auto_popup_enabled: bool
+) -> None:
+    session, pipe, context = prompt_factory(
+        CompletionSnapshot(
+            commands={
+                "/product-council": "Product council",
+                "/product-council-here": "Product council here",
+                "/provider": "Provider",
+            }
+        ),
+        auto_popup_enabled=auto_popup_enabled,
+    )
+    task = None
+    try:
+        # Bottom toolbars are hidden when the terminal cannot answer CPR.
+        # Inline right prompts do not require that renderer capability.
+        assert session.bottom_toolbar is None
+        assert callable(session.rprompt)
+        task = await _start(session)
+        pipe.send_text("/pro\t")
+        await _wait_until_settled_complete_state(
+            session, ["/product-council", "/product-council-here", "/provider"]
+        )
+        pipe.send_text("\r")
+        await _wait_until_completion_hint(session, "Type more or choose")
+        assert not task.done()
+        pipe.send_text("v")
+        await _wait_until_buffer_text(session, "/prov")
+        await _wait_until_completion_hint(session, "")
+        assert not task.done()
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_pipe_exact_short_alias_enter_and_space_do_not_guess(
+    prompt_factory,
+) -> None:
+    aliases = CompletionSnapshot(
+        commands={"/provider": "Provider"},
+        mode_shortcuts={"p": "plan"},
+    )
+    session, pipe, context = prompt_factory(aliases)
+    task = None
+    try:
+        task = await _start(session)
+        pipe.send_text("/p\t")
+        state = await _wait_until_settled_complete_state(session, ["/p", "/provider"])
+        assert state.current_completion is None
+        assert session.default_buffer.text == "/p"
+        pipe.send_text("\r")
+        await _wait_until_buffer_text(session, "/p ")
+        assert not task.done()
+        pipe.send_text("\r")
+        assert await asyncio.wait_for(task, 1) == "/p "
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+    ambiguous = CompletionSnapshot(
+        commands={
+            "/provider": "Provider",
+            "/product-council": "Product council",
+            "/product-council-here": "Product council here",
+        }
+    )
+    session, pipe, context = prompt_factory(ambiguous)
+    try:
+        task = await _start(session)
+        pipe.send_text("/pro ")
+        await _wait_until_completion_closed(session, "/pro ")
+        pipe.send_text("\r")
+        assert await asyncio.wait_for(task, 1) == "/pro "
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_pipe_manual_argument_menu_enter_preserves_current_line_when_disabled(
+    prompt_factory,
+) -> None:
+    session, pipe, context = prompt_factory(
+        CompletionSnapshot(commands={"/provider": "Provider"}),
+        auto_popup_enabled=False,
+    )
+    task = None
+    try:
+        task = await _start(session)
+        pipe.send_text("/provider \t")
+        await _wait_until_settled_complete_state(
+            session, ["auto", "use", "test", "models"]
+        )
+        pipe.send_text('u custom "quoted value"  \r')
+        assert await asyncio.wait_for(task, 1) == '/provider u custom "quoted value"  '
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("auto_popup_enabled", [False, True])
+async def test_pipe_midline_manual_argument_menu_submits_original_line(
+    prompt_factory, auto_popup_enabled: bool
+) -> None:
+    session, pipe, context = prompt_factory(
+        CompletionSnapshot(commands={"/provider": "Provider"}),
+        auto_popup_enabled=auto_popup_enabled,
+    )
+    task = None
+    try:
+        task = await _start(session)
+        pipe.send_text("/provider  rest\x1b[D\x1b[D\x1b[D\x1b[D\x1b[D\t")
+        await _wait_until_settled_complete_state(
+            session, ["auto", "use", "test", "models"]
+        )
+        assert session.default_buffer.text == "/provider  rest"
+        pipe.send_text("\r")
+        assert await asyncio.wait_for(task, 1) == "/provider  rest"
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("auto_popup_enabled", [False, True])
+@pytest.mark.parametrize("selected_key", ["\r", "\t", " "])
+@pytest.mark.parametrize("suffix", ["", " rest"])
+async def test_pipe_preview_delimiters_escape_and_accept_without_doubling(
+    prompt_factory,
+    auto_popup_enabled: bool,
+    selected_key: str,
+    suffix: str,
+) -> None:
+    session, pipe, context = prompt_factory(
+        CompletionSnapshot(commands={"/provider": "Provider"}),
+        auto_popup_enabled=auto_popup_enabled,
+    )
+    task = None
+    original_text = "/provider " + suffix
+    expected_text = "/provider auto" + (suffix or " ")
+    try:
+        task = await _start(session)
+        pipe.send_text(original_text + "\x1b[D" * len(suffix) + "\t")
+        await _wait_until_settled_complete_state(
+            session, ["auto", "use", "test", "models"]
+        )
+        pipe.send_text("\x1b[B")
+        await _wait_until_selected_completion(session, "auto")
+        assert session.default_buffer.text == expected_text
+        # A second Escape flushes the first through pipe input's parser.
+        pipe.send_text("\x1b\x1b")
+        await _wait_until_buffer_text(session, original_text)
+
+        pipe.send_text("\t")
+        await _wait_until_settled_complete_state(
+            session, ["auto", "use", "test", "models"]
+        )
+        pipe.send_text(f"\x1b[B{selected_key}")
+        await _wait_until_buffer_text(session, expected_text)
+        assert not task.done()
+        pipe.send_text("\r")
+        assert await asyncio.wait_for(task, 1) == expected_text
     finally:
         if task is not None:
             await _cancel_pending_prompt(task)
@@ -743,7 +1073,7 @@ async def test_pipe_midtoken_edits_do_not_reopen_and_tab_still_completes_argumen
 
 
 @pytest.mark.asyncio
-async def test_pipe_automatic_completion_does_not_race_into_arguments(
+async def test_pipe_auto_argument_menu_filters_without_changing_typed_text(
     prompt_factory,
 ) -> None:
     session, pipe, context = prompt_factory(
@@ -753,19 +1083,19 @@ async def test_pipe_automatic_completion_does_not_race_into_arguments(
     try:
         task = await _start(session)
         pipe.send_text("/provider ")
-        await _wait_until_completion_closed(session, "/provider ")
-
-        pipe.send_text("\t")
         state = await _wait_until_settled_complete_state(
             session, ["auto", "use", "test", "models"]
         )
         assert state.current_completion is None
-        pipe.send_text("\t")
-        await _wait_until_selected_completion(session, "auto")
-        pipe.send_text("\t")
-        await _wait_until_selected_completion(session, "use")
-        pipe.send_text("\x1b[Z")
-        await _wait_until_selected_completion(session, "auto")
+        assert session.default_buffer.text == "/provider "
+
+        pipe.send_text("u")
+        state = await _wait_until_settled_complete_state(session, ["use"])
+        assert state.current_completion is None
+        assert session.default_buffer.text == "/provider u"
+
+        pipe.send_text("\r")
+        assert await asyncio.wait_for(task, 1) == "/provider u"
     finally:
         if task is not None:
             await _cancel_pending_prompt(task)
@@ -773,7 +1103,85 @@ async def test_pipe_automatic_completion_does_not_race_into_arguments(
 
 
 @pytest.mark.asyncio
-async def test_pipe_rapid_provider_argument_text_does_not_open_a_menu(
+async def test_pipe_argument_enter_preserves_custom_and_skill_values(
+    prompt_factory,
+) -> None:
+    snapshot = CompletionSnapshot(
+        commands={"/provider": "Provider controls"},
+        skill_shortcuts={"rvw": {"name": "review", "description": "Review"}},
+        skills=[
+            {
+                "name": "review",
+                "aliases": ["rvw"],
+                "description": "Review",
+                "argument_hint": None,
+                "arguments": [
+                    {"after": [], "values": ["Fast", "thorough"]},
+                    {"after": ["thorough"], "values": ["security"]},
+                ],
+            }
+        ],
+    )
+    session, pipe, context = prompt_factory(
+        snapshot
+    )
+    task = None
+    try:
+        for typed in (
+            "/provider u",
+            "/rvw th",
+            "/rvw thorough custom-value",
+            '/provider "a quoted multi word value"',
+        ):
+            task = await _start(session)
+            pipe.send_text(f"{typed}\r")
+            assert await asyncio.wait_for(task, 1) == typed
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_pipe_selected_argument_accepts_only_then_next_menu_is_advisory(
+    prompt_factory,
+) -> None:
+    snapshot = CompletionSnapshot(
+        skill_shortcuts={"rvw": {"name": "review", "description": "Review"}},
+        skills=[
+            {
+                "name": "review",
+                "aliases": ["rvw"],
+                "description": "Review",
+                "argument_hint": None,
+                "arguments": [
+                    {"after": [], "values": ["Fast", "thorough"]},
+                    {"after": ["thorough"], "values": ["security"]},
+                ],
+            }
+        ],
+    )
+    session, pipe, context = prompt_factory(snapshot)
+    task = None
+    try:
+        task = await _start(session)
+        pipe.send_text("/rvw th")
+        await _wait_until_settled_complete_state(session, ["thorough"])
+        pipe.send_text("\x1b[B\r")
+        state = await _wait_until_settled_complete_state(session, ["security"])
+        assert state.current_completion is None
+        assert session.default_buffer.text == "/rvw thorough "
+        assert not task.done(), "Enter must only accept an explicit argument choice"
+        pipe.send_text("\r")
+        assert await asyncio.wait_for(task, 1) == "/rvw thorough "
+    finally:
+        if task is not None:
+            await _cancel_pending_prompt(task)
+        context.__exit__(None, None, None)
+
+
+@pytest.mark.asyncio
+async def test_pipe_escape_and_backspace_restore_selected_argument_prefix(
     prompt_factory,
 ) -> None:
     session, pipe, context = prompt_factory(
@@ -783,11 +1191,31 @@ async def test_pipe_rapid_provider_argument_text_does_not_open_a_menu(
     try:
         task = await _start(session)
         pipe.send_text("/provider u")
-        await _wait_until_completion_closed(session, "/provider u")
+        await _wait_until_settled_complete_state(session, ["use"])
+        pipe.send_text("\x1b[B")
+        await _wait_until_selected_completion(session, "use")
+        # The pipe parser resolves an Escape prefix with the next key. Escape
+        # restores `/provider u`; Backspace then removes its `u`.
+        pipe.send_text("\x1b\x7fcustom\r")
+        assert await asyncio.wait_for(task, 1) == "/provider custom"
     finally:
         if task is not None:
             await _cancel_pending_prompt(task)
         context.__exit__(None, None, None)
+
+
+def test_automatic_completion_position_rejects_unsafe_stale_documents() -> None:
+    completer = SlashCompleter(_engine())
+
+    assert SlashCompleter.is_automatic_completion_position("/provider ", 10)
+    assert not SlashCompleter.is_automatic_completion_position("/provider\n", 10)
+    assert not SlashCompleter.is_automatic_completion_position("/provider\r", 10)
+    assert list(
+        completer.get_completions(
+            __import__("prompt_toolkit").document.Document("/provider\n"),
+            __import__("prompt_toolkit").completion.CompleteEvent(text_inserted=True),
+        )
+    ) == []
 
 
 def test_exit_commands_are_static_and_cannot_be_shadowed() -> None:

--- a/tests/test_interactive_slash_completion.py
+++ b/tests/test_interactive_slash_completion.py
@@ -850,9 +850,12 @@ async def test_pipe_preview_delimiters_escape_and_accept_without_doubling(
         pipe.send_text("\x1b[B")
         await _wait_until_selected_completion(session, "auto")
         assert session.default_buffer.text == expected_text
-        # A second Escape flushes the first through pipe input's parser.
-        pipe.send_text("\x1b\x1b")
-        await _wait_until_buffer_text(session, original_text)
+        # A single Escape waits for both VT parsing and key-binding ambiguity.
+        # Shorten those test-only timers instead of injecting a second key.
+        session.app.ttimeoutlen = 0.01
+        session.app.timeoutlen = 0.01
+        pipe.send_text("\x1b")
+        await _wait_until_completion_closed(session, original_text)
 
         pipe.send_text("\t")
         await _wait_until_settled_complete_state(


### PR DESCRIPTION
## Summary

Make interactive slash completion prefix-first while keeping argument suggestions optional.

- Open unselected menus for known arguments as well as slash-command names.
- Make unselected Tab accept one unique match or extend only the longest common prefix. Repeated Tab does not cycle, and an exact short name remains ambiguous when a longer name also matches.
- Keep explicit arrow/Shift-Tab selection separate from acceptance. Tab, Enter, or Space accepts a selected item without executing the command.
- Prefer an exact typed command on unselected command-menu Enter, then a unique match; otherwise keep the menu open with a visible “Type more or choose” hint. Unselected argument-menu Enter submits the typed line unchanged, including with automatic popups disabled.
- Preserve literal Space editing, avoid duplicate completion delimiters, retain later text during midline completion, and render the ambiguity hint without requiring terminal cursor-position-request support.

The existing `ui.slash_popup.enabled` setting still defaults to true. Setting it to false disables automatic command and argument menus, not manual Tab completion or advisory argument submission. Command validation, completion metadata, and snapshot-only keypress callbacks are unchanged.

## Verification

- `uv run --with truststore pytest -q` — **2,183 passed**, 1 skipped, 13 deselected, 1 xfailed.
- `uv run --with truststore pytest -q -m integration` — **13 passed**.
- `uv run --with truststore pytest -q tests/test_interactive_slash_completion.py tests/test_interactive_chat_tty_teardown.py` — **74 passed**.
- Ruff checks on the changed Python files passed.
- Independent source and pre-publication reviews passed.
- Live DTU keyboard checks passed at **120×40 and 80×24**: common-prefix completion, exact short-name acceptance, visible ambiguity guidance in CPR-unsupported terminals, separately paced selection/acceptance, advisory argument submission, popup-disabled manual completion, and clean exits.

The corrected live report retains an overall **PARTIAL** label because two text-readiness probes timed out. Fresh screenshots immediately afterward confirmed the live session title and prompt before the tested flows; all four corrected keyboard cases passed. The initial failure report is preserved separately. Exact trailing-space counts are covered by real PromptSession pipe tests rather than whitespace-trimming screen captures.

## Scope and limitations

- Updates the implementation, regression tests, and interactive documentation only.
- No new settings schema, in-app UI controls, shell-completion changes, provider behavior changes, or new skill metadata.
- Backspace still closes the menu until another character or Tab; that existing limitation is unchanged.
- Private DTU artifacts, logs, screenshots, fixtures, and local verification directories are not included.