### PR TITLE
fix(cli): keep JSON session output clean and persist first saves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,8 @@ transcript and its source metadata intact so resume context restores the reminde
 Save paths preserving metadata from an earlier hook must use
 `SessionStore.get_metadata_if_exists()`; strict `get_metadata()` remains for
 user-requested lookups and must still fail for a missing session.
+JSON output paths must restore the console's configured backing stream, not a
+dynamic temporary stdout capture.
 
 ## Interactive slash completion
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,12 @@ only persisted transcript entries marked `ephemeral is True` and
 transcript and its source metadata intact so resume context restores the reminders;
 `reminder_placement` controls ordering, not display eligibility.
 
+## Session metadata preservation
+
+Save paths preserving metadata from an earlier hook must use
+`SessionStore.get_metadata_if_exists()`; strict `get_metadata()` remains for
+user-requested lookups and must still fail for a missing session.
+
 ## Interactive slash completion
 
 Keep completion candidate generation in `ui/completion.py`.  Its live-session

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ Save paths preserving metadata from an earlier hook must use
 user-requested lookups and must still fail for a missing session.
 JSON output paths must restore the console's configured backing stream, not a
 dynamic temporary stdout capture.
+Run-command diagnostics before headless execution belong on stderr so JSON
+stdout remains one parseable payload.
 
 ## Interactive slash completion
 

--- a/amplifier_app_cli/commands/run.py
+++ b/amplifier_app_cli/commands/run.py
@@ -359,6 +359,12 @@ def register_run_command(
         # GAP-027: wrapped for scoped SIGINT handling + a clean cancellation
         # message instead of a raw traceback landing wherever an interrupt
         # happens to surface (see _resolve_config_interruptibly docstring).
+        diagnostics_to_stderr = output_format in ["json", "json-trace"]
+        original_stdout = sys.stdout
+        original_console_file = console._file
+        if diagnostics_to_stderr:
+            sys.stdout = sys.stderr
+            console.file = sys.stderr
         try:
             config_data, prepared_bundle = _resolve_config_interruptibly(
                 bundle_name=bundle,
@@ -411,6 +417,10 @@ def register_run_command(
                 )
             )
             sys.exit(1)
+        finally:
+            if diagnostics_to_stderr:
+                sys.stdout = original_stdout
+                console.file = original_console_file
 
         search_paths = get_module_search_paths()
 

--- a/amplifier_app_cli/commands/run.py
+++ b/amplifier_app_cli/commands/run.py
@@ -273,6 +273,20 @@ def register_run_command(
         """Execute a prompt or start an interactive session."""
         from ..session_store import SessionStore
 
+        diagnostics_to_stderr = output_format in ["json", "json-trace"]
+        original_stdout = sys.stdout
+        original_console_file = console._file
+
+        def restore_diagnostic_streams() -> None:
+            if diagnostics_to_stderr:
+                sys.stdout = original_stdout
+                console.file = original_console_file
+
+        if diagnostics_to_stderr:
+            sys.stdout = sys.stderr
+            console.file = sys.stderr
+            click.get_current_context().call_on_close(restore_diagnostic_streams)
+
         # Handle --resume flag
         if resume:
             store = SessionStore()
@@ -359,12 +373,6 @@ def register_run_command(
         # GAP-027: wrapped for scoped SIGINT handling + a clean cancellation
         # message instead of a raw traceback landing wherever an interrupt
         # happens to surface (see _resolve_config_interruptibly docstring).
-        diagnostics_to_stderr = output_format in ["json", "json-trace"]
-        original_stdout = sys.stdout
-        original_console_file = console._file
-        if diagnostics_to_stderr:
-            sys.stdout = sys.stderr
-            console.file = sys.stderr
         try:
             config_data, prepared_bundle = _resolve_config_interruptibly(
                 bundle_name=bundle,
@@ -417,10 +425,6 @@ def register_run_command(
                 )
             )
             sys.exit(1)
-        finally:
-            if diagnostics_to_stderr:
-                sys.stdout = original_stdout
-                console.file = original_console_file
 
         search_paths = get_module_search_paths()
 
@@ -557,6 +561,7 @@ def register_run_command(
 
         # Run update check (uses unified startup_checker with settings.yaml)
         _run_startup_update_check()
+        restore_diagnostic_streams()
 
         if mode == "chat":
             # Interactive mode - supports optional initial_prompt for auto-execution

--- a/amplifier_app_cli/incremental_save.py
+++ b/amplifier_app_cli/incremental_save.py
@@ -100,7 +100,7 @@ class IncrementalSaveHook:
 
             # Load existing metadata to preserve fields like name, description
             # that may have been set by other hooks (e.g., session-naming)
-            existing_metadata = self.store.get_metadata(self.session_id) or {}
+            existing_metadata = self.store.get_metadata_if_exists(self.session_id)
 
             # Build metadata, preserving existing fields while updating dynamic ones
             metadata = {

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -4352,7 +4352,7 @@ async def execute_single(
     # In JSON mode, redirect all output to stderr so only JSON goes to stdout
     if output_format in ["json", "json-trace"]:
         original_stdout = sys.stdout
-        original_console_file = console.file
+        original_console_file = console._file
         sys.stdout = sys.stderr
         console.file = sys.stderr
     else:
@@ -4732,7 +4732,7 @@ async def execute_single(
             sys.stdout.flush()
         elif original_stdout is not None:
             sys.stdout = original_stdout
-        if original_console_file is not None:
+        if original_stdout is not None:
             console.file = original_console_file
 
 

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -3793,7 +3793,7 @@ async def interactive_chat(
             messages = await context.get_messages()
             # Load existing metadata to preserve fields like name, description
             # that may have been set by other hooks (e.g., session-naming)
-            existing_metadata = store.get_metadata(actual_session_id) or {}
+            existing_metadata = store.get_metadata_if_exists(actual_session_id)
             metadata = {
                 **existing_metadata,  # Preserve name, description, etc.
                 "session_id": actual_session_id,
@@ -4621,7 +4621,7 @@ async def execute_single(
             store = SessionStore()
             # Load existing metadata to preserve fields like name, description
             # that may have been set by other hooks (e.g., session-naming)
-            existing_metadata = store.get_metadata(actual_session_id) or {}
+            existing_metadata = store.get_metadata_if_exists(actual_session_id)
             metadata = {
                 **existing_metadata,  # Preserve name, description, etc.
                 "session_id": actual_session_id,
@@ -4647,6 +4647,7 @@ async def execute_single(
 
     except ModuleValidationError as e:
         if output_format in ["json", "json-trace"]:
+            json_output_data = None
             # Restore stdout before writing error JSON
             if original_stdout is not None:
                 sys.stdout = original_stdout
@@ -4667,6 +4668,7 @@ async def execute_single(
 
     except LLMError as e:
         if output_format in ["json", "json-trace"]:
+            json_output_data = None
             if original_stdout is not None:
                 sys.stdout = original_stdout
             error_output = {
@@ -4683,6 +4685,7 @@ async def execute_single(
 
     except Exception as e:
         if output_format in ["json", "json-trace"]:
+            json_output_data = None
             # Restore stdout before writing error JSON
             if original_stdout is not None:
                 sys.stdout = original_stdout

--- a/amplifier_app_cli/session_store.py
+++ b/amplifier_app_cli/session_store.py
@@ -355,6 +355,22 @@ class SessionStore:
 
         return self._load_metadata(session_dir)
 
+    def get_metadata_if_exists(self, session_id: str) -> dict:
+        """Return existing metadata, or an empty dict for a new session.
+
+        Save paths use this to preserve metadata written by an earlier hook
+        without treating the first save of a new session as a failed lookup.
+        ``get_metadata()`` remains strict for callers that require a saved
+        session to exist.
+        """
+        if not session_id or not session_id.strip():
+            raise ValueError("session_id cannot be empty")
+        if "/" in session_id or "\\" in session_id or session_id in (".", ".."):
+            raise ValueError(f"Invalid session_id: {session_id}")
+        if not self.exists(session_id):
+            return {}
+        return self.get_metadata(session_id)
+
     def exists(self, session_id: str) -> bool:
         """Check if session exists.
 

--- a/tests/test_headless_session_persistence.py
+++ b/tests/test_headless_session_persistence.py
@@ -264,6 +264,12 @@ def test_run_routes_preparation_output_away_from_json_payload(
         test_console.print("PREPARATION CONSOLE MARKER")
         return {}, prepared_bundle
 
+    startup_console = Console()
+
+    def _startup_check() -> None:
+        print("STARTUP MARKER")
+        startup_console.print("STARTUP CONSOLE MARKER")
+
     register_run_command(
         cli,
         interactive_chat=AsyncMock(),
@@ -282,7 +288,10 @@ def test_run_routes_preparation_output_away_from_json_payload(
             "amplifier_app_cli.commands.run.create_config_manager",
             return_value=MagicMock(get_merged_settings=dict),
         ),
-        patch("amplifier_app_cli.commands.run._run_startup_update_check"),
+        patch(
+            "amplifier_app_cli.commands.run._run_startup_update_check",
+            side_effect=_startup_check,
+        ),
         patch(
             f"{_MAIN}.create_initialized_session",
             new=AsyncMock(return_value=initialized),
@@ -298,10 +307,14 @@ def test_run_routes_preparation_output_away_from_json_payload(
     stream = result.stderr if marker_stream == "stderr" else result.stdout
     assert "PREPARATION MARKER" in stream
     assert "PREPARATION CONSOLE MARKER" in stream
+    assert "STARTUP MARKER" in stream
+    assert "STARTUP CONSOLE MARKER" in stream
 
     if output_format in {"json", "json-trace"}:
         assert "PREPARATION MARKER" not in result.stdout
         assert "PREPARATION CONSOLE MARKER" not in result.stdout
+        assert "STARTUP MARKER" not in result.stdout
+        assert "STARTUP CONSOLE MARKER" not in result.stdout
         payload = json.loads(result.stdout)
         assert payload["status"] == "success"
         assert payload["session_id"] == _SESSION_ID

--- a/tests/test_headless_session_persistence.py
+++ b/tests/test_headless_session_persistence.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from click.testing import CliRunner
 from rich.console import Console
 
 from amplifier_app_cli.session_store import SessionStore
@@ -235,3 +236,167 @@ async def test_headless_json_reports_one_error_when_final_session_save_fails(
     output = json.loads(stdout)
     assert output["status"] == "error"
     assert output["error"] == "session save failed"
+
+
+@pytest.mark.parametrize(
+    ("output_format", "marker_stream"),
+    [("json", "stderr"), ("json-trace", "stderr"), ("text", "stdout")],
+)
+def test_run_routes_preparation_output_away_from_json_payload(
+    split_homes: tuple[Path, Path],
+    output_format: str,
+    marker_stream: str,
+) -> None:
+    """Preparation diagnostics precede execute_single but not JSON stdout."""
+    import click
+
+    from amplifier_app_cli.commands.run import register_run_command
+    from amplifier_app_cli.main import execute_single
+
+    cli = click.Group()
+    initialized = _initialized_session()
+    prepared_bundle = MagicMock()
+    prepared_bundle.mount_plan = {}
+    test_console = Console()
+
+    def _prepare(**_kwargs):
+        print("PREPARATION MARKER")
+        test_console.print("PREPARATION CONSOLE MARKER")
+        return {}, prepared_bundle
+
+    register_run_command(
+        cli,
+        interactive_chat=AsyncMock(),
+        execute_single=execute_single,
+        get_module_search_paths=list,
+        check_first_run=lambda: False,
+        prompt_first_run_init=lambda _console: False,
+    )
+
+    with (
+        patch(
+            "amplifier_app_cli.commands.run._resolve_config_interruptibly",
+            side_effect=_prepare,
+        ),
+        patch(
+            "amplifier_app_cli.commands.run.create_config_manager",
+            return_value=MagicMock(get_merged_settings=dict),
+        ),
+        patch("amplifier_app_cli.commands.run._run_startup_update_check"),
+        patch(
+            f"{_MAIN}.create_initialized_session",
+            new=AsyncMock(return_value=initialized),
+        ),
+        patch("amplifier_app_cli.commands.run.console", new=test_console),
+        patch(f"{_MAIN}.console", new=test_console),
+    ):
+        result = CliRunner().invoke(
+            cli, ["run", "--output-format", output_format, "persist this"]
+        )
+
+    assert result.exit_code == 0, result.output
+    stream = result.stderr if marker_stream == "stderr" else result.stdout
+    assert "PREPARATION MARKER" in stream
+    assert "PREPARATION CONSOLE MARKER" in stream
+
+    if output_format in {"json", "json-trace"}:
+        assert "PREPARATION MARKER" not in result.stdout
+        assert "PREPARATION CONSOLE MARKER" not in result.stdout
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "success"
+        assert payload["session_id"] == _SESSION_ID
+    else:
+        assert "saved response" in result.stdout
+
+    assert SessionStore().load(_SESSION_ID)[1]["session_id"] == _SESSION_ID
+
+
+def test_run_json_preparation_failure_remains_nonzero(
+    split_homes: tuple[Path, Path],
+) -> None:
+    """Redirecting diagnostics must not convert a failed preparation to success."""
+    import click
+
+    from amplifier_app_cli.commands.run import register_run_command
+
+    cli = click.Group()
+    test_console = Console()
+    register_run_command(
+        cli,
+        interactive_chat=AsyncMock(),
+        execute_single=AsyncMock(),
+        get_module_search_paths=list,
+        check_first_run=lambda: False,
+        prompt_first_run_init=lambda _console: False,
+    )
+
+    with (
+        patch(
+            "amplifier_app_cli.commands.run._resolve_config_interruptibly",
+            side_effect=FileNotFoundError("bundle missing"),
+        ),
+        patch(
+            "amplifier_app_cli.commands.run.create_config_manager",
+            return_value=MagicMock(get_merged_settings=dict),
+        ),
+        patch("amplifier_app_cli.commands.run.console", new=test_console),
+    ):
+        result = CliRunner().invoke(
+            cli, ["run", "--output-format", "json", "persist this"]
+        )
+
+    assert result.exit_code == 1
+    assert result.stdout == ""
+    assert "bundle missing" in result.stderr
+
+
+@pytest.mark.parametrize("output_format", ["json", "json-trace"])
+def test_run_json_restores_dynamic_console_file_after_execution(
+    split_homes: tuple[Path, Path],
+    tmp_path: Path,
+    output_format: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Headless output must not retain CliRunner's closed stream in the console."""
+    import asyncio
+
+    import click
+
+    from amplifier_app_cli.console import console
+    from amplifier_app_cli.main import execute_single
+
+    monkeypatch.setattr(console, "_file", None)
+    cli = click.Group()
+
+    @cli.command()
+    def run_headless() -> None:
+        asyncio.run(
+            execute_single(
+                prompt="persist this",
+                config={},
+                search_paths=[tmp_path],
+                verbose=False,
+                session_id=_SESSION_ID,
+                bundle_name="test-bundle",
+                output_format=output_format,
+            )
+        )
+
+    @cli.command()
+    def print_again() -> None:
+        console.print("SECOND INVOCATION")
+
+    assert console._file is None
+    with patch(
+        f"{_MAIN}.create_initialized_session",
+        new=AsyncMock(return_value=_initialized_session()),
+    ):
+        first = CliRunner().invoke(cli, ["run-headless"])
+
+    assert first.exit_code == 0, first.output
+    assert json.loads(first.stdout)["status"] == "success"
+    assert console._file is None
+
+    second = CliRunner().invoke(cli, ["print-again"])
+    assert second.exit_code == 0, second.output
+    assert "SECOND INVOCATION" in second.stdout

--- a/tests/test_headless_session_persistence.py
+++ b/tests/test_headless_session_persistence.py
@@ -1,0 +1,237 @@
+"""Regression coverage for headless JSON session persistence.
+
+The final headless save must create a new session before it tries to preserve
+metadata from an earlier save.  JSON output is particularly important here:
+missing prior metadata must not turn a successfully saved request into a
+non-zero CLI result.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from rich.console import Console
+
+from amplifier_app_cli.session_store import SessionStore
+
+_MAIN = "amplifier_app_cli.main"
+_SESSION_ID = "headless-json-session"
+
+
+def _private_console() -> Console:
+    """Keep JSON redirection from retaining pytest's per-test capture stream."""
+    return Console(file=io.StringIO())
+
+
+def _initialized_session(*, response: str = "saved response") -> MagicMock:
+    """Return the smallest session double that exercises the final save path."""
+    context = MagicMock()
+    context.get_messages = AsyncMock(
+        return_value=[
+            {"role": "user", "content": "persist this"},
+            {"role": "assistant", "content": response},
+        ]
+    )
+
+    def get_capability(name: str):
+        if name == "context":
+            return context
+        if name == "providers":
+            return {}
+        return None
+
+    session = MagicMock()
+    session.session_id = _SESSION_ID
+    session.execute = AsyncMock(return_value=response)
+    session.coordinator = MagicMock()
+    session.coordinator.get = get_capability
+    session.coordinator.cancellation = MagicMock()
+    session.coordinator.cancellation.is_cancelled = False
+
+    initialized = MagicMock()
+    initialized.session = session
+    initialized.session_id = _SESSION_ID
+    initialized.cleanup = AsyncMock()
+    return initialized
+
+
+@pytest.fixture
+def split_homes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> tuple[Path, Path]:
+    """Make a HOME decoy so the assertion proves AMPLIFIER_HOME won."""
+    default_home = tmp_path / "default-home"
+    isolated_home = tmp_path / "isolated-amplifier-home"
+    monkeypatch.setenv("HOME", str(default_home))
+    monkeypatch.setenv("USERPROFILE", str(default_home))
+    monkeypatch.setenv("AMPLIFIER_HOME", str(isolated_home))
+    return default_home, isolated_home
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("output_format", ["json", "json-trace"])
+async def test_headless_json_output_creates_and_loads_new_session_from_amplifier_home(
+    split_homes: tuple[Path, Path],
+    tmp_path: Path,
+    capfd: pytest.CaptureFixture[str],
+    output_format: str,
+) -> None:
+    """A successful response persists and is loadable from AMPLIFIER_HOME.
+
+    This deliberately starts with no session directory.  Before the fix,
+    execute_single() called get_metadata() first, which raised
+    FileNotFoundError and exited 1 after the model response had completed.
+    """
+    from amplifier_app_cli.main import execute_single
+
+    default_home, isolated_home = split_homes
+    initialized = _initialized_session()
+
+    with (
+        patch(
+            f"{_MAIN}.create_initialized_session",
+            new=AsyncMock(return_value=initialized),
+        ),
+        patch(f"{_MAIN}.console", new=_private_console()),
+    ):
+        await execute_single(
+            prompt="persist this",
+            config={},
+            search_paths=[tmp_path],
+            verbose=False,
+            session_id=_SESSION_ID,
+            bundle_name="test-bundle",
+            output_format=output_format,
+        )
+
+    output = json.loads(capfd.readouterr().out)
+    assert output["status"] == "success"
+    assert output["session_id"] == _SESSION_ID
+    if output_format == "json-trace":
+        assert output["execution_trace"] == []
+
+    # This is a real second lookup, not an assertion about a mocked constructor.
+    transcript, metadata = SessionStore().load(_SESSION_ID)
+    assert transcript[0]["content"] == "persist this"
+    assert metadata["session_id"] == _SESSION_ID
+    assert SessionStore().base_dir.is_relative_to(isolated_home)
+    assert not (default_home / ".amplifier").exists()
+
+
+def test_session_store_default_home_fallback_and_explicit_base_precedence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The resolver honors AMPLIFIER_HOME, falls back to HOME, and never wins over base_dir."""
+    default_home = tmp_path / "default-home"
+    isolated_home = tmp_path / "isolated-home"
+    explicit_base = tmp_path / "explicit-sessions"
+    monkeypatch.setenv("HOME", str(default_home))
+    monkeypatch.setenv("USERPROFILE", str(default_home))
+
+    monkeypatch.delenv("AMPLIFIER_HOME", raising=False)
+    fallback_store = SessionStore()
+    assert fallback_store.base_dir.is_relative_to(default_home / ".amplifier")
+
+    monkeypatch.setenv("AMPLIFIER_HOME", str(isolated_home))
+    configured_store = SessionStore()
+    configured_store.save("configured-session", [], {"source": "configured"})
+    assert configured_store.load("configured-session")[1]["source"] == "configured"
+    assert configured_store.base_dir.is_relative_to(isolated_home)
+    configured_store.save("named-session", [], {"name": "preserved"})
+    assert configured_store.get_metadata_if_exists("named-session") == {
+        "name": "preserved"
+    }
+    with pytest.raises(FileNotFoundError, match="Session 'missing' not found"):
+        configured_store.get_metadata("missing")
+    assert configured_store.get_metadata_if_exists("missing") == {}
+    with pytest.raises(ValueError, match="Invalid session_id"):
+        configured_store.get_metadata_if_exists("../invalid")
+    corrupt_dir = configured_store.base_dir / "corrupt-session"
+    corrupt_dir.mkdir()
+    (corrupt_dir / "metadata.json").write_text("{not json", encoding="utf-8")
+    assert (
+        configured_store.get_metadata_if_exists("corrupt-session")["recovered"] is True
+    )
+
+    explicit_store = SessionStore(base_dir=explicit_base)
+    explicit_store.save("explicit-session", [], {"source": "explicit"})
+    assert explicit_store.load("explicit-session")[1]["source"] == "explicit"
+    assert explicit_store.base_dir == explicit_base
+
+
+@pytest.mark.asyncio
+async def test_headless_json_trace_still_exits_nonzero_for_execution_failure(
+    split_homes: tuple[Path, Path],
+    tmp_path: Path,
+    capfd: pytest.CaptureFixture[str],
+) -> None:
+    """The new-session case is narrow: genuine execution failures still fail loud."""
+    from amplifier_app_cli.main import execute_single
+
+    initialized = _initialized_session()
+    initialized.session.execute = AsyncMock(side_effect=RuntimeError("provider failed"))
+
+    with (
+        patch(
+            f"{_MAIN}.create_initialized_session",
+            new=AsyncMock(return_value=initialized),
+        ),
+        patch(f"{_MAIN}.console", new=_private_console()),
+        pytest.raises(SystemExit) as exit_info,
+    ):
+        await execute_single(
+            prompt="persist this",
+            config={},
+            search_paths=[tmp_path],
+            verbose=False,
+            session_id=_SESSION_ID,
+            bundle_name="test-bundle",
+            output_format="json-trace",
+        )
+
+    assert exit_info.value.code == 1
+    output = json.loads(capfd.readouterr().out)
+    assert output["status"] == "error"
+    assert output["error"] == "provider failed"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("output_format", ["json", "json-trace"])
+async def test_headless_json_reports_one_error_when_final_session_save_fails(
+    split_homes: tuple[Path, Path],
+    tmp_path: Path,
+    capfd: pytest.CaptureFixture[str],
+    output_format: str,
+) -> None:
+    """A failed final save fails loud without appending stale success JSON."""
+    from amplifier_app_cli.main import execute_single
+
+    initialized = _initialized_session()
+
+    with (
+        patch(
+            f"{_MAIN}.create_initialized_session",
+            new=AsyncMock(return_value=initialized),
+        ),
+        patch(f"{_MAIN}.console", new=_private_console()),
+        patch.object(SessionStore, "save", side_effect=OSError("session save failed")),
+        pytest.raises(SystemExit) as exit_info,
+    ):
+        await execute_single(
+            prompt="persist this",
+            config={},
+            search_paths=[tmp_path],
+            verbose=False,
+            session_id=_SESSION_ID,
+            bundle_name="test-bundle",
+            output_format=output_format,
+        )
+
+    assert exit_info.value.code == 1
+    stdout = capfd.readouterr().out
+    assert stdout.count('"status"') == 1
+    output = json.loads(stdout)
+    assert output["status"] == "error"
+    assert output["error"] == "session save failed"


### PR DESCRIPTION
## What changed

- Persist new sessions without requiring strict metadata lookup before the first save.
- Preserve metadata written by earlier hooks while keeping strict metadata lookup behavior for callers that require an existing session.
- Keep `json` and `json-trace` stdout as one parseable JSON payload by routing run-command preparation/startup diagnostics to stderr and restoring the configured console stream before execution.
- Clear stale JSON output on post-response save failures so only one error object is emitted.
- Add focused regression coverage for first-save persistence, metadata preservation/corrupt recovery, `AMPLIFIER_HOME`, preparation/startup diagnostics, console restoration, execution failures, and final-save failures.

## Why

Headless JSON sessions could fail after a successful response when prior metadata did not exist, and preparation/startup output could contaminate JSON stdout. These fixes keep successful persistence reliable and make JSON output deterministic without weakening genuine failure behavior.

## How tested

- Focused regression tests: 12 passed.
- Full suite: 2170 passed, 1 skipped, 13 deselected, 1 xfailed.
- Ruff check and format check for the new regression test: passed.
- `git diff --check`: passed.
- Independent runtime validation: passed across four fresh first-save runs using both supported provider families, both JSON output formats, two bundles, resume persistence, and the missing-resume negative path. The validator confirmed exact single-object JSON stdout, persisted transcript/metadata reload, resumed transcript growth, nonzero missing-session exit, empty stdout on that error, no false success marker, and no traceback.

## Breaking changes

None.

## Additional notes

No controlled performance improvement is claimed. Existing full-suite skip, deselection, and expected-failure counts are reported unchanged.
