### PR TITLE
feat(cli): add local-value shell completions and safe installation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,15 @@ Pipe-input Escape tests must allow both VT-parser (`ttimeoutlen`) and key-bindin
 (`timeoutlen`) timeouts. Shorten both on the test application, send one Escape,
 and wait for the restored document and closed menu; a second Escape is not a flush.
 
+## Shell completion
+
+Click shell-completion callbacks may use only read-only local settings,
+registry metadata, and directory names/stats. They must not initialize keys or
+providers, migrate registries, construct `SessionStore`, read session content,
+or emit anything except Click's native completion protocol records.
+Keep lock-library imports at locking operations, not read-only module import:
+dependencies can run temporary-file capability probes when imported.
+
 ## Interactive control-flow exits
 
 REPL exit commands return an action from `CommandProcessor`; only the normal

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,9 @@ providers, migrate registries, construct `SessionStore`, read session content,
 or emit anything except Click's native completion protocol records.
 Keep lock-library imports at locking operations, not read-only module import:
 dependencies can run temporary-file capability probes when imported.
+Seed byte-preservation installer tests with explicit LF and CRLF bytes, not
+text-mode writes that translate newlines. Assert the original prefix survives
+the first install and the entire file is identical after a repeat install.
 
 ## Interactive control-flow exits
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ amplifier --install-completion
 **What happens**:
 1. Detects your shell (bash, zsh, or fish) from `$SHELL`
 2. **Automatically appends** the completion line to your shell config:
-   - Bash: `~/.bashrc`
+   - Bash: `~/.bashrc`; an existing profile-only setup keeps `~/.bash_profile`
    - Zsh: `~/.zshrc`
    - Fish: `~/.config/fish/completions/amplifier.fish`
 3. Checks if already installed (safe to run multiple times)
@@ -262,16 +262,36 @@ Detected shell: bash
 ✓ Completion already configured in /home/user/.bashrc
 ```
 
-### Tab Completion Works Everywhere
+### Command and Local Value Completion
 
 Once active, tab completion works throughout the CLI:
 
 ```bash
 amplifier bun<TAB>         # Completes to "bundle"
 amplifier bundle u<TAB>    # Completes to "use"
-amplifier bundle use <TAB> # Shows available bundles
+amplifier bundle use <TAB> # Shows local available bundles
 amplifier run --<TAB>      # Shows all options
 ```
+
+Amplifier supports Bash, Zsh, and Fish, not PowerShell. In addition to command
+names, flags, and fixed choices, it suggests locally known top-level bundle
+names, configured provider instance names, and the newest 100 matching
+top-level sessions for the current project. Lookup is
+read-only and local: it does not fetch bundles, initialize providers, call
+model/provider APIs, or inspect session transcript/event content. Suggestions
+are advisory; unknown bundle, provider, and session values remain valid command
+input where the command normally accepts them.
+
+Your shell controls the completion menu and key behavior. This is separate from
+the interactive `ui.slash_popup.enabled` setting below. Zsh users must enable
+the standard `compinit` setup in `.zshrc`; the installer does not add it.
+Use the printed `source` command for the current terminal. Automatic loading
+in a new Bash terminal depends on that terminal reading the selected startup
+file; login-shell setups may need to source `.bashrc` from their profile.
+Nested bundle names, URIs, and names containing shell-special characters can
+still be entered manually. The installer preserves user-written Fish
+completion files and offers a temporary `| source` command instead of
+overwriting them.
 
 ## Interactive Slash Completion
 

--- a/amplifier_app_cli/commands/agents.py
+++ b/amplifier_app_cli/commands/agents.py
@@ -9,6 +9,7 @@ import click
 from ..console import console
 from ..ui.item_renderer import ItemRenderer
 from ..ui.view_policy import resolve_view, view_flags
+from ..utils.shell_completion import complete_bundle_names
 
 
 @click.group(invoke_without_command=True)
@@ -21,7 +22,13 @@ def agents(ctx: click.Context):
 
 
 @agents.command("list")
-@click.option("--bundle", "-b", default=None, help="Bundle to list agents from")
+@click.option(
+    "--bundle",
+    "-b",
+    default=None,
+    help="Bundle to list agents from",
+    shell_complete=complete_bundle_names,
+)
 @view_flags
 def list_agents(bundle: str | None, compact: bool, detailed: bool, fmt: str):
     """List available agents from bundles.

--- a/amplifier_app_cli/commands/bundle.py
+++ b/amplifier_app_cli/commands/bundle.py
@@ -29,6 +29,10 @@ from ..utils.display import create_sha_text
 from ..utils.display import create_status_symbol
 from ..utils.display import print_legend
 from ..utils.error_format import escape_markup
+from ..utils.shell_completion import (
+    complete_bundle_names,
+    complete_removable_bundle_names,
+)
 
 if TYPE_CHECKING:
     from amplifier_foundation import BundleStatus
@@ -445,7 +449,7 @@ def _extract_bundle_name_from_uri(uri: str) -> str:
 
 
 @bundle.command(name="show")
-@click.argument("name")
+@click.argument("name", shell_complete=complete_bundle_names)
 @view_flags
 def bundle_show(name: str, compact: bool, detailed: bool, fmt: str):
     """Show details of a specific bundle.
@@ -665,7 +669,7 @@ def _render_bundle_show_text(
 
 
 @bundle.command(name="use")
-@click.argument("name")
+@click.argument("name", shell_complete=complete_bundle_names)
 @click.option(
     "--local", "scope_flag", flag_value="local", help="Set locally (just you)"
 )
@@ -1023,7 +1027,7 @@ def bundle_add(uri: str, name_override: str | None, app: bool):
 
 
 @bundle.command(name="remove")
-@click.argument("name")
+@click.argument("name", shell_complete=complete_removable_bundle_names)
 @click.option(
     "--app",
     is_flag=True,
@@ -1158,7 +1162,7 @@ def bundle_remove(name: str, app: bool):
 
 
 @bundle.command(name="update")
-@click.argument("name", required=False)
+@click.argument("name", required=False, shell_complete=complete_bundle_names)
 @click.option("--all", "update_all", is_flag=True, help="Update all discovered bundles")
 @click.option(
     "--check", "check_only", is_flag=True, help="Only check for updates, don't apply"

--- a/amplifier_app_cli/commands/provider.py
+++ b/amplifier_app_cli/commands/provider.py
@@ -44,6 +44,7 @@ from ..ui.scope import (
 )
 from ..ui.view_policy import resolve_view, view_flags
 from ..utils.error_format import escape_markup
+from ..utils.shell_completion import complete_configured_provider_names
 
 console = Console()
 
@@ -831,7 +832,7 @@ def provider_list(scope: str | None, compact: bool, detailed: bool, fmt: str) ->
 
 
 @provider.command("remove")
-@click.argument("name")
+@click.argument("name", shell_complete=complete_configured_provider_names)
 def provider_remove(name: str) -> None:
     """Remove a configured provider.
 
@@ -895,7 +896,7 @@ def provider_remove(name: str) -> None:
 
 
 @provider.command("edit")
-@click.argument("name")
+@click.argument("name", shell_complete=complete_configured_provider_names)
 @click.option(
     "--scope",
     default="global",
@@ -1029,7 +1030,7 @@ def provider_edit(name: str, scope: str) -> None:
 
 
 @provider.command("test")
-@click.argument("name", required=False)
+@click.argument("name", required=False, shell_complete=complete_configured_provider_names)
 def provider_test(name: str | None) -> None:
     """Test provider connectivity.
 
@@ -1104,7 +1105,9 @@ def provider_test(name: str | None) -> None:
 
 
 @provider.command("models")
-@click.argument("provider_id", required=False)
+@click.argument(
+    "provider_id", required=False, shell_complete=complete_configured_provider_names
+)
 @click.pass_context
 def provider_models(ctx: click.Context, provider_id: str | None) -> None:
     """List available models for a provider.

--- a/amplifier_app_cli/commands/run.py
+++ b/amplifier_app_cli/commands/run.py
@@ -238,11 +238,27 @@ def register_run_command(
     prompt_first_run_init: Callable[[Any], bool],
 ):
     """Register the run command on the root CLI group."""
+    from ..utils.shell_completion import (
+        complete_bundle_names,
+        complete_configured_provider_names,
+        complete_current_project_session_ids,
+    )
 
     @cli.command()
     @click.argument("prompt", required=False)
-    @click.option("--bundle", "-B", help="Bundle to use for this session")
-    @click.option("--provider", "-p", default=None, help="LLM provider to use")
+    @click.option(
+        "--bundle",
+        "-B",
+        help="Bundle to use for this session",
+        shell_complete=complete_bundle_names,
+    )
+    @click.option(
+        "--provider",
+        "-p",
+        default=None,
+        help="LLM provider to use",
+        shell_complete=complete_configured_provider_names,
+    )
     @click.option("--model", "-m", help="Model to use (provider-specific)")
     @click.option("--max-tokens", type=int, help="Maximum output tokens")
     @click.option(
@@ -251,7 +267,11 @@ def register_run_command(
         default="single",
         help="Execution mode",
     )
-    @click.option("--resume", help="Resume specific session with new prompt")
+    @click.option(
+        "--resume",
+        help="Resume specific session with new prompt",
+        shell_complete=complete_current_project_session_ids,
+    )
     @click.option("--verbose", "-v", is_flag=True, help="Verbose output")
     @click.option(
         "--output-format",

--- a/amplifier_app_cli/commands/session.py
+++ b/amplifier_app_cli/commands/session.py
@@ -26,6 +26,10 @@ from ..console import console
 from ..ui.item_renderer import ItemRenderer
 from ..ui.view_policy import resolve_view, view_flags
 from ..utils.error_format import escape_markup
+from ..utils.shell_completion import (
+    complete_bundle_names,
+    complete_current_project_session_ids,
+)
 from ..lib.settings import AppSettings
 from ..project_utils import get_project_slug
 from ..runtime.config import resolve_config
@@ -391,6 +395,7 @@ def register_session_commands(
         "-B",
         help="[Experimental] Force a different bundle for this session. "
         "May cause instability if the bundle differs significantly from the original.",
+        shell_complete=complete_bundle_names,
     )
     @click.option(
         "--no-history", is_flag=True, help="Skip displaying conversation history"
@@ -541,7 +546,11 @@ def register_session_commands(
         "--project", type=click.Path(), help="Show sessions for specific project path"
     )
     @click.option(
-        "--tree", "-t", "tree_session", help="Show lineage tree for a session"
+        "--tree",
+        "-t",
+        "tree_session",
+        help="Show lineage tree for a session",
+        shell_complete=complete_current_project_session_ids,
     )
     @view_flags
     def sessions_list(
@@ -747,7 +756,7 @@ def register_session_commands(
         )
 
     @session.command(name="show")
-    @click.argument("session_id")
+    @click.argument("session_id", shell_complete=complete_current_project_session_ids)
     @click.option(
         "--with-transcript",
         "-T",
@@ -804,7 +813,7 @@ def register_session_commands(
                 console.print(json.dumps(turn, indent=2))
 
     @session.command(name="fork")
-    @click.argument("session_id")
+    @click.argument("session_id", shell_complete=complete_current_project_session_ids)
     @click.option(
         "--at-turn",
         "-t",
@@ -992,7 +1001,7 @@ def register_session_commands(
             sys.exit(1)
 
     @session.command(name="delete")
-    @click.argument("session_id")
+    @click.argument("session_id", shell_complete=complete_current_project_session_ids)
     @click.option("--force", "-f", is_flag=True, help="Skip confirmation")
     def sessions_delete(session_id: str, force: bool):
         """Delete a stored session."""
@@ -1024,12 +1033,13 @@ def register_session_commands(
             sys.exit(1)
 
     @session.command(name="resume")
-    @click.argument("session_id")
+    @click.argument("session_id", shell_complete=complete_current_project_session_ids)
     @click.option(
         "--force-bundle",
         "-B",
         help="[Experimental] Force a different bundle for this session. "
         "May cause instability if the bundle differs significantly from the original.",
+        shell_complete=complete_bundle_names,
     )
     @click.option(
         "--no-history", is_flag=True, help="Skip displaying conversation history"
@@ -1151,7 +1161,12 @@ def register_session_commands(
 
     # Register interactive resume on root CLI (not session subgroup)
     @cli.command(name="resume")
-    @click.argument("session_id", required=False, default=None)
+    @click.argument(
+        "session_id",
+        required=False,
+        default=None,
+        shell_complete=complete_current_project_session_ids,
+    )
     @click.option(
         "--limit", "-n", default=10, type=int, help="Number of sessions per page"
     )
@@ -1160,6 +1175,7 @@ def register_session_commands(
         "-B",
         help="[Experimental] Force a different bundle for this session. "
         "May cause instability if the bundle differs significantly from the original.",
+        shell_complete=complete_bundle_names,
     )
     @click.pass_context
     def interactive_resume(

--- a/amplifier_app_cli/commands/tool.py
+++ b/amplifier_app_cli/commands/tool.py
@@ -27,6 +27,7 @@ from ..ui.item_renderer import ItemRenderer
 from ..ui.view_policy import resolve_view
 from ..ui.view_policy import view_flags
 from ..utils.error_format import escape_markup
+from ..utils.shell_completion import complete_bundle_names
 from ..runtime.config import inject_user_providers
 
 logger = logging.getLogger(__name__)
@@ -499,7 +500,12 @@ def tool(ctx: click.Context):
 
 
 @tool.command(name="list")
-@click.option("--bundle", "-b", help="Bundle to use (default: active bundle)")
+@click.option(
+    "--bundle",
+    "-b",
+    help="Bundle to use (default: active bundle)",
+    shell_complete=complete_bundle_names,
+)
 @click.option(
     "--modules", "-m", is_flag=True, help="Show module names instead of mounted tools"
 )
@@ -576,7 +582,12 @@ def tool_list(
 
 @tool.command(name="info")
 @click.argument("tool_name")
-@click.option("--bundle", "-b", help="Bundle to use (default: active bundle)")
+@click.option(
+    "--bundle",
+    "-b",
+    help="Bundle to use (default: active bundle)",
+    shell_complete=complete_bundle_names,
+)
 @click.option(
     "--module",
     "-m",
@@ -665,7 +676,12 @@ def tool_info(
 @tool.command(name="invoke")
 @click.argument("tool_name")
 @click.argument("args", nargs=-1)
-@click.option("--bundle", "-b", help="Bundle to use (default: auto-detect)")
+@click.option(
+    "--bundle",
+    "-b",
+    help="Bundle to use (default: auto-detect)",
+    shell_complete=complete_bundle_names,
+)
 @click.option(
     "--output",
     "-o",

--- a/amplifier_app_cli/key_manager.py
+++ b/amplifier_app_cli/key_manager.py
@@ -3,8 +3,6 @@
 import os
 import platform
 
-from filelock import FileLock
-
 from amplifier_foundation.paths.resolution import get_amplifier_home
 from .utils.atomic_write import atomic_write_text
 
@@ -13,6 +11,8 @@ class KeyManager:
     """Manage API keys in ~/.amplifier/keys.env file."""
 
     def __init__(self):
+        from filelock import FileLock
+
         self.keys_file = get_amplifier_home() / "keys.env"
         # Advisory lock guarding the read-modify-write critical section in
         # save_key()/has_stored_key() -- two ordinary concurrent CLI

--- a/amplifier_app_cli/lib/settings.py
+++ b/amplifier_app_cli/lib/settings.py
@@ -9,10 +9,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from typing import Literal
+from typing import TYPE_CHECKING
 
 import yaml
-from filelock import BaseFileLock
-from filelock import FileLock
+
+if TYPE_CHECKING:
+    from filelock import BaseFileLock
 
 from amplifier_foundation.paths.resolution import get_amplifier_home
 from ..utils.atomic_write import atomic_write_yaml
@@ -1271,6 +1273,8 @@ class AppSettings:
         and not the read that precedes it does not close the race. See
         docs/designs/provider-instance-credentials.md §5.5.
         """
+        from filelock import FileLock
+
         path = self._get_scope_path(scope)
         path.parent.mkdir(parents=True, exist_ok=True)
         return FileLock(str(path) + ".lock", timeout=10)

--- a/amplifier_app_cli/main.py
+++ b/amplifier_app_cli/main.py
@@ -5,6 +5,7 @@ import html
 import json
 import logging
 import os
+import shlex
 import signal
 import sys
 from collections.abc import Callable
@@ -94,6 +95,15 @@ from .ui.completion import (
 )
 from .ui.view_policy import resolve_view
 from .utils.error_format import escape_markup
+from .utils.shell_completion import (
+    can_safely_modify as _completion_can_safely_modify,
+    detect_shell as _completion_detect_shell,
+    get_shell_config_file as _completion_config_file,
+    install_completion_to_config as _install_completion,
+    is_click_completion_instruction,
+    is_completion_installed as _completion_is_installed,
+    manual_installation_instruction,
+)
 from .utils.version import get_core_version, get_version
 
 
@@ -278,7 +288,8 @@ def _attach_llm_error_filter() -> None:
 
 # Load API keys from ~/.amplifier/keys.env on startup
 # This allows keys saved by 'amplifier init' or 'amplifier provider use' to be available
-KeyManager()
+if not os.environ.get("_AMPLIFIER_COMPLETE"):
+    KeyManager()
 
 
 # Placeholder for the run command; assigned after registration below
@@ -291,21 +302,7 @@ def _detect_shell() -> str | None:
     Returns:
         Shell name ('bash', 'zsh', or 'fish') or None if detection fails
     """
-    shell_path = os.environ.get("SHELL", "")
-    if not shell_path:
-        return None
-
-    shell_name = Path(shell_path).name.lower()
-
-    # Check for known shells
-    if "bash" in shell_name:
-        return "bash"
-    if "zsh" in shell_name:
-        return "zsh"
-    if "fish" in shell_name:
-        return "fish"
-
-    return None
+    return _completion_detect_shell()
 
 
 def _get_shell_config_file(shell: str) -> Path:
@@ -317,24 +314,7 @@ def _get_shell_config_file(shell: str) -> Path:
     Returns:
         Path to shell config file
     """
-    home = Path.home()
-
-    if shell == "bash":
-        # Prefer .bashrc on Linux, .bash_profile on macOS
-        bashrc = home / ".bashrc"
-        bash_profile = home / ".bash_profile"
-        if bashrc.exists():
-            return bashrc
-        return bash_profile
-
-    if shell == "zsh":
-        return home / ".zshrc"
-
-    if shell == "fish":
-        # For fish, we create a completion file directly
-        return home / ".config" / "fish" / "completions" / "amplifier.fish"
-
-    return home / f".{shell}rc"  # Fallback
+    return _completion_config_file(shell)
 
 
 def _completion_already_installed(config_file: Path, shell: str) -> bool:
@@ -347,18 +327,10 @@ def _completion_already_installed(config_file: Path, shell: str) -> bool:
     Returns:
         True if completion marker found in file
     """
-    if not config_file.exists():
-        return False
-
-    try:
-        content = config_file.read_text(encoding="utf-8")
-        completion_marker = f"_AMPLIFIER_COMPLETE={shell}_source"
-        return completion_marker in content
-    except OSError:
-        return False
+    return _completion_is_installed(config_file, shell)
 
 
-def _can_safely_modify(config_file: Path) -> bool:
+def _can_safely_modify(config_file: Path, shell: str = "bash") -> bool:
     """Check if it's safe to modify the config file.
 
     Args:
@@ -367,21 +339,7 @@ def _can_safely_modify(config_file: Path) -> bool:
     Returns:
         True if safe to append to file
     """
-    # If file exists, must be writable
-    if config_file.exists():
-        return os.access(config_file, os.W_OK)
-
-    # If file doesn't exist, parent directory must be writable
-    parent = config_file.parent
-    if not parent.exists():
-        # Need to create parent directories - check if we can
-        try:
-            parent.mkdir(parents=True, exist_ok=True)
-            return True
-        except OSError:
-            return False
-
-    return os.access(parent, os.W_OK)
+    return _completion_can_safely_modify(config_file, shell)
 
 
 def _install_completion_to_config(config_file: Path, shell: str) -> bool:
@@ -394,35 +352,7 @@ def _install_completion_to_config(config_file: Path, shell: str) -> bool:
     Returns:
         True if successful
     """
-    try:
-        # Ensure parent directory exists
-        config_file.parent.mkdir(parents=True, exist_ok=True)
-
-        # For fish, write the actual completion script
-        if shell == "fish":
-            # Fish uses a different approach - we need to invoke Click's completion
-            import subprocess
-
-            result = subprocess.run(
-                ["amplifier"],
-                env={**os.environ, "_AMPLIFIER_COMPLETE": "fish_source"},
-                capture_output=True,
-                text=True,
-            )
-            if result.returncode == 0:
-                config_file.write_text(result.stdout, encoding="utf-8")
-                return True
-            return False
-
-        # For bash/zsh, append eval line
-        with open(config_file, "a", encoding="utf-8") as f:
-            f.write("\n# Amplifier shell completion\n")
-            f.write(f'eval "$(_AMPLIFIER_COMPLETE={shell}_source amplifier)"\n')
-
-        return True
-
-    except OSError:
-        return False
+    return _install_completion(config_file, shell, cli)
 
 
 def _show_manual_instructions(shell: str, config_file: Path):
@@ -432,18 +362,18 @@ def _show_manual_instructions(shell: str, config_file: Path):
         shell: Shell name
         config_file: Suggested config file path
     """
-    console.print(f"\n[yellow]Add this line to {config_file}:[/yellow]")
-
-    if shell == "fish":
-        console.print(
-            f"  [cyan]_AMPLIFIER_COMPLETE=fish_source amplifier > {config_file}[/cyan]"
-        )
-    else:
-        console.print(
-            f'  [cyan]eval "$(_AMPLIFIER_COMPLETE={shell}_source amplifier)"[/cyan]'
-        )
-
-    console.print("\n[dim]Then reload your shell or start a new terminal.[/dim]")
+    console.print("\n[yellow]Activate completion in the current shell:[/yellow]")
+    console.print(
+        f"  {manual_installation_instruction(shell, config_file)}",
+        markup=False,
+        soft_wrap=True,
+    )
+    console.print(
+        f"\nFor persistence, merge the completion setup into {config_file}; "
+        "the existing file was not changed.",
+        markup=False,
+        soft_wrap=True,
+    )
 
 
 def _parse_config_flags(
@@ -3264,10 +3194,10 @@ def get_module_search_paths() -> list[Path]:
 )
 @click.option(
     "--install-completion",
-    is_flag=False,
+    is_flag=True,
     flag_value="auto",
     default=None,
-    help="Install shell completion for the specified shell (bash, zsh, or fish)",
+    help="Install completion for the shell detected from $SHELL (bash, zsh, or fish)",
 )
 @click.pass_context
 def cli(ctx, install_completion):
@@ -3288,7 +3218,7 @@ def cli(ctx, install_completion):
                 '  [cyan]Zsh:   eval "$(_AMPLIFIER_COMPLETE=zsh_source amplifier)"[/cyan]'
             )
             console.print(
-                "  [cyan]Fish:  _AMPLIFIER_COMPLETE=fish_source amplifier > ~/.config/fish/completions/amplifier.fish[/cyan]"
+                "  [cyan]Fish:  _AMPLIFIER_COMPLETE=fish_source amplifier | source[/cyan]"
             )
             ctx.exit(1)
 
@@ -3305,22 +3235,23 @@ def cli(ctx, install_completion):
                 f"[green]✓ Completion already configured in {config_file}[/green]\n"
             )
             console.print("[dim]To use in this terminal:[/dim]")
-            if shell == "fish":
-                console.print(f"  [cyan]source {config_file}[/cyan]")
-            else:
-                console.print(f"  [cyan]source {config_file}[/cyan]")
+            console.print(
+                f"  source {shlex.quote(str(config_file))}", markup=False, soft_wrap=True
+            )
             console.print("\n[dim]Already active in new terminals.[/dim]")
             ctx.exit(0)
 
         # Check if safe to auto-install
-        if _can_safely_modify(config_file):
+        if _can_safely_modify(config_file, shell):
             # Auto-install!
             success = _install_completion_to_config(config_file, shell)
 
             if success:
                 console.print(f"[green]✓ Added completion to {config_file}[/green]\n")
                 console.print("[dim]To activate:[/dim]")
-                console.print(f"  [cyan]source {config_file}[/cyan]")
+                console.print(
+                    f"  source {shlex.quote(str(config_file))}", markup=False, soft_wrap=True
+                )
                 console.print("\n[dim]Or start a new terminal.[/dim]")
                 ctx.exit(0)
 
@@ -4985,6 +4916,13 @@ def _activate_home_env() -> None:
 
 def main():
     """Main entry point."""
+    completion_instruction = os.environ.get("_AMPLIFIER_COMPLETE")
+    if completion_instruction:
+        if not is_click_completion_instruction(completion_instruction):
+            click.echo("Error: Unsupported shell completion instruction.", err=True)
+            raise click.exceptions.Exit(2)
+        cli()
+        return
     _ensure_utf8_output()
     _configure_console_logging()
     _attach_llm_error_filter()

--- a/amplifier_app_cli/utils/settings_manager.py
+++ b/amplifier_app_cli/utils/settings_manager.py
@@ -23,13 +23,16 @@ host, and this module's only writer -- the update-check timestamp -- fires at
    uses for the global scope (``settings.yaml.lock``).
 """
 
+from __future__ import annotations
+
 import logging
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 import yaml
-from filelock import BaseFileLock
-from filelock import FileLock
-from filelock import Timeout
+
+if TYPE_CHECKING:
+    from filelock import BaseFileLock
 
 from amplifier_foundation.paths.resolution import get_amplifier_home
 from .atomic_write import atomic_write_yaml
@@ -58,6 +61,8 @@ def _settings_lock() -> BaseFileLock:
     just the write -- locking only the write does not close the lost-update
     race. Same lock file as ``lib/settings.py``'s global scope.
     """
+    from filelock import FileLock
+
     SETTINGS_FILE.parent.mkdir(parents=True, exist_ok=True)
     return FileLock(str(SETTINGS_FILE) + ".lock", timeout=LOCK_TIMEOUT_SECONDS)
 
@@ -87,6 +92,8 @@ def load_settings() -> dict:
     Creates the file with defaults if it doesn't exist.
     """
     if not SETTINGS_FILE.exists():
+        from filelock import Timeout
+
         try:
             with _settings_lock():
                 # Re-check under the lock: another process may have created it
@@ -144,6 +151,8 @@ def save_update_last_check(timestamp: datetime):
     Read and write happen under one lock, so this cannot clobber a bundle
     registration written by another process in between.
     """
+    from filelock import Timeout
+
     try:
         with _settings_lock():
             settings, trustworthy = _read_settings_file()

--- a/amplifier_app_cli/utils/shell_completion.py
+++ b/amplifier_app_cli/utils/shell_completion.py
@@ -1,0 +1,411 @@
+"""Read-only candidates and installation helpers for Click shell completion."""
+
+from __future__ import annotations
+
+import json
+import os
+import unicodedata
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+import click
+from click.shell_completion import CompletionItem, get_completion_class
+
+from amplifier_foundation.paths.resolution import get_amplifier_home
+
+from ..lib.bundle_loader.discovery import WELL_KNOWN_BUNDLES
+from ..lib.settings import AppSettings
+from ..project_utils import get_project_slug
+
+MANAGED_MARKER = "# amplifier shell completion (managed)"
+_SUPPORTED_SHELLS = ("bash", "zsh", "fish")
+_COMPLETION_HELP = {
+    "bundle": "Available bundle",
+    "provider": "Configured provider",
+    "session": "Current-project session",
+}
+
+
+def _is_safe_candidate(value: object) -> bool:
+    """Return whether *value* is safe to emit in Click's line protocol."""
+    if not isinstance(value, str) or not value or value in {".", ".."}:
+        return False
+    if any(
+        character.isspace()
+        or character in ",*?[]$`'\";|&()<>{}!~#%"
+        or character in {"/", "\\"}
+        or unicodedata.category(character).startswith("C")
+        for character in value
+    ):
+        return False
+    return True
+
+
+def _completion_items(
+    values: set[str], incomplete: str, kind: str
+) -> list[CompletionItem]:
+    """Filter and deterministically render safe completion records."""
+    return [
+        CompletionItem(value, help=_COMPLETION_HELP[kind])
+        for value in sorted(
+            value
+            for value in values
+            if isinstance(value, str)
+            and _is_safe_candidate(value)
+            and value.startswith(incomplete)
+        )
+    ]
+
+
+def _merged_settings() -> dict[str, Any]:
+    """Load merged settings without calling mutation-capable convenience APIs."""
+    try:
+        settings = AppSettings().get_merged_settings()
+    except Exception:
+        return {}
+    return settings if isinstance(settings, dict) else {}
+
+
+def _added_bundle_names(settings: dict[str, Any]) -> set[str]:
+    bundle = settings.get("bundle")
+    added = bundle.get("added") if isinstance(bundle, dict) else None
+    if not isinstance(added, dict):
+        return set()
+    return {
+        name
+        for name, uri in added.items()
+        if _is_safe_candidate(name) and isinstance(uri, str) and uri.strip()
+    }
+
+
+def _legacy_bundle_names() -> set[str]:
+    """Read unmigrated legacy bundle names without triggering their migration."""
+    legacy_path = get_amplifier_home() / "bundle-registry.yaml"
+    migrated_path = get_amplifier_home() / "bundle-registry.yaml.migrated"
+    if migrated_path.exists() or not legacy_path.is_file():
+        return set()
+    try:
+        import yaml
+
+        data = yaml.safe_load(legacy_path.read_text(encoding="utf-8")) or {}
+        bundles = data.get("bundles") if isinstance(data, dict) else None
+        if not isinstance(bundles, dict):
+            return set()
+        return {
+            name
+            for name, entry in bundles.items()
+            if _is_safe_candidate(name)
+            and isinstance(entry, dict)
+            and isinstance(entry.get("uri"), str)
+            and entry["uri"].strip()
+        }
+    except Exception:
+        return set()
+
+
+def _explicitly_requested_bundle_names() -> set[str]:
+    """Read only user-requested cached registry roots, never transitive entries."""
+    registry_path = get_amplifier_home() / "registry.json"
+    if not registry_path.is_file():
+        return set()
+    try:
+        data = json.loads(registry_path.read_text(encoding="utf-8"))
+        bundles = data.get("bundles") if isinstance(data, dict) else None
+        if not isinstance(bundles, dict):
+            return set()
+        return {
+            name
+            for name, entry in bundles.items()
+            if _is_safe_candidate(name)
+            and isinstance(entry, dict)
+            and entry.get("explicitly_requested") is True
+            and isinstance(entry.get("uri"), str)
+            and entry["uri"].strip()
+        }
+    except Exception:
+        return set()
+
+
+def _local_bundle_names() -> set[str]:
+    """Return valid immediate bundle entries from the execution search paths."""
+    package_bundles = Path(__file__).parent.parent / "data" / "bundles"
+    search_paths = (
+        Path.cwd() / ".amplifier" / "bundles",
+        get_amplifier_home() / "bundles",
+        package_bundles,
+    )
+    names: set[str] = set()
+    for base_path in search_paths:
+        try:
+            if not base_path.is_dir():
+                continue
+            for entry in base_path.iterdir():
+                if entry.is_dir():
+                    if (entry / "bundle.md").is_file() or (
+                        entry / "bundle.yaml"
+                    ).is_file():
+                        names.add(entry.name)
+                elif entry.is_file() and entry.suffix in {".yaml", ".md"}:
+                    names.add(entry.stem)
+        except OSError:
+            continue
+    return names
+
+
+def _extract_app_bundle_name(uri: object) -> str | None:
+    """Match bundle removal's URI-to-name interpretation without exposing URIs."""
+    if not isinstance(uri, str):
+        return None
+    # Do not derive display text from credential-bearing or query-bearing URIs.
+    # Keep the execution command's name interpretation below, but only for
+    # unambiguous URI forms and local names/paths. Other values remain manual.
+    try:
+        parsed = urlsplit(uri.removeprefix("git+"))
+        if (
+            parsed.scheme not in {"", "file", "https", "http"}
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or (parsed.scheme in {"https", "http"} and not parsed.hostname)
+            or (not parsed.scheme and parsed.netloc)
+        ):
+            return None
+    except ValueError:
+        return None
+    if uri.startswith("file://"):
+        name = uri[7:].rstrip("/").split("/")[-1]
+    elif "github.com" in uri or "gitlab.com" in uri:
+        parts = uri.split("/")
+        name = ""
+        for index, part in enumerate(parts):
+            if ("github.com" in part or "gitlab.com" in part) and index + 2 < len(
+                parts
+            ):
+                name = parts[index + 2].split("@")[0].split("#")[0]
+                for prefix in ("amplifier-bundle-", "amplifier-", "bundle-"):
+                    if name.startswith(prefix):
+                        name = name[len(prefix) :]
+                        break
+                break
+    else:
+        name = uri.split("/")[-1].split("@")[0].split("#")[0]
+    return name if _is_safe_candidate(name) else None
+
+
+def _app_bundle_names(settings: dict[str, Any]) -> set[str]:
+    bundle = settings.get("bundle")
+    app_bundles = bundle.get("app") if isinstance(bundle, dict) else None
+    if not isinstance(app_bundles, list):
+        return set()
+    return {name for uri in app_bundles if (name := _extract_app_bundle_name(uri))}
+
+
+def complete_bundle_names(
+    ctx: click.Context, param: click.Parameter, incomplete: str
+) -> list[CompletionItem]:
+    """Complete selectable local bundle names without discovery or migration."""
+    settings = _merged_settings()
+    names = {
+        name
+        for name, info in WELL_KNOWN_BUNDLES.items()
+        if info.get("show_in_list", True)
+    }
+    names.update(_added_bundle_names(settings))
+    names.update(_legacy_bundle_names())
+    names.update(_explicitly_requested_bundle_names())
+    names.update(_local_bundle_names())
+    return _completion_items(names, incomplete, "bundle")
+
+
+def complete_removable_bundle_names(
+    ctx: click.Context, param: click.Parameter, incomplete: str
+) -> list[CompletionItem]:
+    """Complete configured registrations that the current remove mode can remove."""
+    settings = _merged_settings()
+    app_names = _app_bundle_names(settings)
+    app_mode = bool(ctx.params.get("app"))
+    names = app_names if app_mode else _added_bundle_names(settings) | app_names
+    if not app_mode:
+        names.update(_legacy_bundle_names())
+    return _completion_items(names, incomplete, "bundle")
+
+
+def _configured_provider_names(providers: object) -> set[str]:
+    if not isinstance(providers, list):
+        return set()
+    names: set[str] = set()
+    for entry in providers:
+        if not isinstance(entry, dict):
+            continue
+        module = entry.get("module")
+        if (
+            not isinstance(module, str)
+            or not module.startswith("provider-")
+            or not _is_safe_candidate(module.removeprefix("provider-"))
+        ):
+            continue
+        identifier = entry.get("id")
+        if not isinstance(identifier, str) or not identifier:
+            identifier = module.removeprefix("provider-")
+        if _is_safe_candidate(identifier):
+            names.add(identifier)
+    return names
+
+
+def _configured_provider_entries() -> list[dict[str, Any]]:
+    """Read providers using the same scope-aware merge as provider commands."""
+    try:
+        providers = AppSettings().get_provider_overrides()
+    except Exception:
+        return []
+    return providers if isinstance(providers, list) else []
+
+
+def complete_configured_provider_names(
+    ctx: click.Context, param: click.Parameter, incomplete: str
+) -> list[CompletionItem]:
+    """Complete configured execution identities, not provider modules or sources."""
+    return _completion_items(
+        _configured_provider_names(_configured_provider_entries()),
+        incomplete,
+        "provider",
+    )
+
+
+def _current_project_session_ids(incomplete: str) -> list[str]:
+    """List at most 100 matching top-level sessions without constructing SessionStore."""
+    sessions_dir = get_amplifier_home() / "projects" / get_project_slug() / "sessions"
+    try:
+        entries = [
+            (entry.name, entry.stat().st_mtime)
+            for entry in sessions_dir.iterdir()
+            if entry.is_dir()
+            and not entry.name.startswith(".")
+            and "_" not in entry.name
+            and _is_safe_candidate(entry.name)
+            and entry.name.startswith(incomplete)
+        ]
+    except OSError:
+        return []
+    entries.sort(key=lambda entry: (-entry[1], entry[0]))
+    return [name for name, _mtime in entries[:100]]
+
+
+def complete_current_project_session_ids(
+    ctx: click.Context, param: click.Parameter, incomplete: str
+) -> list[CompletionItem]:
+    """Complete recent current-project root sessions, based only on directory stats."""
+    return [
+        CompletionItem(value, help=_COMPLETION_HELP["session"])
+        for value in _current_project_session_ids(incomplete)
+    ]
+
+
+def detect_shell() -> str | None:
+    """Detect one of the supported shells from ``$SHELL``."""
+    shell_name = Path(os.environ.get("SHELL", "")).name.lower()
+    return next((shell for shell in _SUPPORTED_SHELLS if shell in shell_name), None)
+
+
+def get_shell_config_file(shell: str) -> Path:
+    """Return the conventional completion destination for *shell*."""
+    home = Path.home()
+    if shell == "bash":
+        bashrc = home / ".bashrc"
+        profile = home / ".bash_profile"
+        # A fresh interactive non-login Bash reads .bashrc. Retain an existing
+        # profile-only setup rather than silently moving a user's installation.
+        return profile if profile.exists() and not bashrc.exists() else bashrc
+    if shell == "zsh":
+        return home / ".zshrc"
+    if shell == "fish":
+        return home / ".config" / "fish" / "completions" / "amplifier.fish"
+    return home / f".{shell}rc"
+
+
+def is_completion_installed(config_file: Path, shell: str) -> bool:
+    """Recognize managed and legacy Click completion snippets without modifying files."""
+    try:
+        content = config_file.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return False
+    lines = {line.strip().removesuffix(";") for line in content.splitlines()}
+    if shell in {"bash", "zsh"}:
+        directive = f'eval "$(_AMPLIFIER_COMPLETE={shell}_source amplifier)"'
+        return directive in lines
+    if shell == "fish":
+        return "function _amplifier_completion" in lines and any(
+            line.startswith("complete --no-files --command amplifier ")
+            and "_amplifier_completion" in line
+            for line in lines
+        )
+    return False
+
+
+def can_safely_modify(config_file: Path, shell: str) -> bool:
+    """Check for a writable destination without creating directories as a probe."""
+    try:
+        if config_file.exists():
+            if (
+                shell == "fish"
+                and config_file.stat().st_size
+                and not is_completion_installed(config_file, shell)
+            ):
+                return False
+            return os.access(config_file, os.W_OK)
+    except OSError:
+        return False
+    parent = config_file.parent
+    while not parent.exists() and parent != parent.parent:
+        parent = parent.parent
+    return parent.is_dir() and os.access(parent, os.W_OK)
+
+
+def completion_source(command: click.Command, shell: str) -> str:
+    """Render Click's native completion source in-process, never via ``PATH``."""
+    completion_class = get_completion_class(shell)
+    if completion_class is None:
+        raise ValueError(f"Unsupported shell: {shell}")
+    return completion_class(command, {}, "amplifier", "_AMPLIFIER_COMPLETE").source()
+
+
+def install_completion_to_config(
+    config_file: Path, shell: str, command: click.Command
+) -> bool:
+    """Install native source once, preserving unmanaged Fish completion files."""
+    if shell not in _SUPPORTED_SHELLS or not can_safely_modify(config_file, shell):
+        return False
+    if is_completion_installed(config_file, shell):
+        return True
+    try:
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        if shell == "fish":
+            config_file.write_text(
+                f"{MANAGED_MARKER}\n{completion_source(command, shell)}",
+                encoding="utf-8",
+            )
+        else:
+            with config_file.open("a", encoding="utf-8") as config:
+                config.write(
+                    f"\n{MANAGED_MARKER}\n"
+                    f'eval "$(_AMPLIFIER_COMPLETE={shell}_source amplifier)"\n'
+                )
+        return True
+    except OSError:
+        return False
+
+
+def manual_installation_instruction(shell: str, config_file: Path) -> str:
+    """Return a non-overwriting command to activate completion in this shell."""
+    if shell == "fish":
+        return "_AMPLIFIER_COMPLETE=fish_source amplifier | source"
+    return f'eval "$(_AMPLIFIER_COMPLETE={shell}_source amplifier)"'
+
+
+def is_click_completion_instruction(value: str | None) -> bool:
+    """Return whether *value* is a native instruction that Click can handle."""
+    if not value or "_" not in value:
+        return False
+    shell, instruction = value.split("_", 1)
+    return shell in _SUPPORTED_SHELLS and instruction in {"source", "complete"}

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -536,15 +536,24 @@ def test_invalid_completion_instruction_does_not_execute_cli_or_bypass_guard(
     assert calls == []
 
 
-@pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])
+@pytest.mark.parametrize(
+    ("shell", "original"),
+    [
+        ("bash", b"# preserve user configuration\n"),
+        ("bash", b"# preserve user configuration\r\n"),
+        ("zsh", b"# preserve user configuration\n"),
+        ("zsh", b"# preserve user configuration\r\n"),
+        ("fish", b""),
+    ],
+)
 def test_install_flag_repeats_without_modifying_other_content(
-    shell, isolated_completion_state, monkeypatch
+    shell, original, isolated_completion_state, monkeypatch
 ):
     home, _ = isolated_completion_state
     monkeypatch.setenv("SHELL", f"/bin/{shell}")
     config = completion.get_shell_config_file(shell)
     if shell != "fish":
-        config.write_text("# preserve user configuration\n", encoding="utf-8")
+        config.write_bytes(original)
     runner = CliRunner()
     first = runner.invoke(main_module.cli, ["--install-completion"])
     assert first.exit_code == 0, first.output
@@ -555,7 +564,7 @@ def test_install_flag_repeats_without_modifying_other_content(
     assert "already configured" in second.output
     assert config.read_bytes() == first_bytes
     if shell != "fish":
-        assert first_bytes.startswith(b"# preserve user configuration\n")
+        assert first_bytes.startswith(original)
     assert home.is_dir()
 
 

--- a/tests/test_shell_completion.py
+++ b/tests/test_shell_completion.py
@@ -1,0 +1,784 @@
+"""Read-only Click shell-completion and installer regressions."""
+
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+
+import click
+import pytest
+from click.testing import CliRunner
+
+main_module = importlib.import_module("amplifier_app_cli.main")
+completion = importlib.import_module("amplifier_app_cli.utils.shell_completion")
+
+
+def _values(items):
+    return [item.value for item in items]
+
+
+class _Settings:
+    def __init__(self, merged=None, providers=None):
+        self.merged = merged or {}
+        self.providers = providers or []
+
+    def get_merged_settings(self):
+        return self.merged
+
+    def get_provider_overrides(self):
+        return self.providers
+
+
+@pytest.fixture(autouse=True)
+def isolated_completion_state(tmp_path, monkeypatch):
+    """Every callback sees an empty scratch home and current project by default."""
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    home.mkdir()
+    project.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("USERPROFILE", str(home))
+    monkeypatch.setenv("AMPLIFIER_HOME", str(home))
+    monkeypatch.chdir(project)
+    monkeypatch.setattr(completion, "get_amplifier_home", lambda: home)
+    return home, project
+
+
+def _context(params=None):
+    ctx = click.Context(click.Command("test"))
+    ctx.params = params or {}
+    return ctx
+
+
+def _parameter(command, name):
+    return next(param for param in command.params if param.name == name)
+
+
+def _custom_callback(command, name):
+    return _parameter(command, name)._custom_shell_complete
+
+
+def test_bundle_callback_uses_only_safe_local_sources_without_migration(
+    isolated_completion_state, monkeypatch
+):
+    home, project = isolated_completion_state
+    monkeypatch.setattr(
+        completion,
+        "AppSettings",
+        lambda: _Settings(
+            {"bundle": {"added": {"added": "uri", "bad value": "uri", 9: "uri"}}}
+        ),
+    )
+    local = project / ".amplifier" / "bundles" / "local"
+    local.mkdir(parents=True)
+    (local / "bundle.yaml").write_text("name: local", encoding="utf-8")
+    (home / "registry.json").write_text(
+        json.dumps(
+            {
+                "bundles": {
+                    "cached": {"uri": "file:///cached", "explicitly_requested": True},
+                    "transitive": {
+                        "uri": "file:///dependency",
+                        "explicitly_requested": False,
+                    },
+                    "unsafe\nname": {
+                        "uri": "file:///unsafe",
+                        "explicitly_requested": True,
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (home / "bundle-registry.yaml").write_text(
+        "bundles:\n  legacy:\n    uri: file:///bundle\n", encoding="utf-8"
+    )
+
+    values = _values(completion.complete_bundle_names(_context(), None, ""))
+
+    assert {"anchors", "added", "cached", "legacy", "local"} <= set(values)
+    assert "transitive" not in values
+    assert "bad value" not in values
+    assert not (home / "bundle-registry.yaml.migrated").exists()
+
+
+def test_removable_bundle_callback_excludes_defaults_and_respects_app_mode(monkeypatch):
+    monkeypatch.setattr(
+        completion,
+        "AppSettings",
+        lambda: _Settings(
+            {
+                "bundle": {
+                    "added": {"added": "uri"},
+                    "app": ["git+https://example.test/app-bundle@main"],
+                }
+            }
+        ),
+    )
+    monkeypatch.setattr(completion, "_legacy_bundle_names", lambda: set())
+
+    assert _values(
+        completion.complete_removable_bundle_names(_context(), None, "")
+    ) == ["added", "app-bundle"]
+    assert _values(
+        completion.complete_removable_bundle_names(_context({"app": True}), None, "")
+    ) == ["app-bundle"]
+
+
+@pytest.mark.parametrize("app_mode", [False, True])
+@pytest.mark.parametrize(
+    "source", ["my-bundle", "relative/path/my-bundle", "./my-bundle"]
+)
+def test_removable_local_app_bundle_names_are_suggested(source, app_mode, monkeypatch):
+    monkeypatch.setattr(
+        completion,
+        "AppSettings",
+        lambda: _Settings({"bundle": {"app": [source]}}),
+    )
+    assert _values(
+        completion.complete_removable_bundle_names(
+            _context({"app": app_mode}), None, "my-"
+        )
+    ) == ["my-bundle"]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "relative/my-bundle?token=synthetic-secret",
+        "//user:password@example.test/my-bundle",
+        "//example.test/my-bundle",
+    ],
+)
+def test_schemeless_app_sources_do_not_expose_query_or_authority(source):
+    assert completion._extract_app_bundle_name(source) is None
+
+
+def test_provider_callback_uses_execution_identity_without_config_values(monkeypatch):
+    monkeypatch.setattr(
+        completion,
+        "AppSettings",
+        lambda: _Settings(
+            providers=[
+                {"id": "named", "module": "provider-openai", "source": "secret-source"},
+                {"module": "provider-anthropic", "config": {"api_key": "secret"}},
+                {"id": "unsafe\tname", "module": "provider-ignored"},
+                {"module": "not-a-provider"},
+            ]
+        ),
+    )
+
+    items = completion.complete_configured_provider_names(_context(), None, "")
+
+    assert _values(items) == ["anthropic", "named"]
+    assert all(item.help == "Configured provider" for item in items)
+    assert "secret" not in repr(items)
+    assert "secret-source" not in repr(items)
+
+
+def test_callbacks_handle_absent_and_malformed_local_state(
+    isolated_completion_state, monkeypatch
+):
+    home, _project = isolated_completion_state
+    monkeypatch.setattr(
+        completion,
+        "AppSettings",
+        lambda: _Settings({"bundle": []}, providers=[None, {"id": 3}]),
+    )
+    (home / "registry.json").write_text("not json", encoding="utf-8")
+    (home / "bundle-registry.yaml").write_text("bundles: [not-a-map]", encoding="utf-8")
+
+    assert completion.complete_bundle_names(_context(), None, "missing-") == []
+    assert completion.complete_configured_provider_names(_context(), None, "") == []
+    assert completion.complete_current_project_session_ids(_context(), None, "") == []
+
+
+def test_session_callback_ignores_an_unreadable_sessions_directory(
+    isolated_completion_state, monkeypatch
+):
+    home, _project = isolated_completion_state
+    sessions = home / "projects" / completion.get_project_slug() / "sessions"
+    sessions.mkdir(parents=True)
+
+    def unreadable_iterdir(path):
+        if path == sessions:
+            raise PermissionError
+        return original_iterdir(path)
+
+    original_iterdir = Path.iterdir
+    monkeypatch.setattr(Path, "iterdir", unreadable_iterdir)
+
+    assert completion.complete_current_project_session_ids(_context(), None, "") == []
+
+
+def test_session_callback_is_project_scoped_root_only_and_prefix_capped(
+    isolated_completion_state,
+):
+    home, _project = isolated_completion_state
+    sessions = home / "projects" / completion.get_project_slug() / "sessions"
+    sessions.mkdir(parents=True)
+    for index in range(101):
+        (sessions / f"match-{index:03d}").mkdir()
+    (sessions / "match-child_agent").mkdir()
+    (sessions / ".match-hidden").mkdir()
+    (sessions / "other").mkdir()
+
+    values = _values(
+        completion.complete_current_project_session_ids(_context(), None, "match-")
+    )
+
+    assert len(values) == 100
+    assert all(value.startswith("match-") for value in values)
+    assert "match-child_agent" not in values
+
+
+def test_callbacks_never_construct_mutating_services(monkeypatch):
+    class Forbidden:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("must not be constructed during completion")
+
+    monkeypatch.setattr(completion, "AppSettings", lambda: _Settings())
+    monkeypatch.setattr("amplifier_app_cli.session_store.SessionStore", Forbidden)
+    monkeypatch.setattr("amplifier_app_cli.key_manager.KeyManager", Forbidden)
+
+    assert completion.complete_bundle_names(_context(), None, "")
+    assert completion.complete_configured_provider_names(_context(), None, "") == []
+    assert completion.complete_current_project_session_ids(_context(), None, "") == []
+
+
+@pytest.mark.parametrize(
+    "kind, words, expected_value",
+    [
+        ("bundle", "amplifier run --bundle tea", "team"),
+        ("provider", "amplifier run --provider na", "named"),
+        ("session", "amplifier run --resume se", "session-1"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("shell", "cword", "expected"),
+    [
+        ("bash", "3", "plain,{value}\n"),
+        ("zsh", "3", "plain\n{value}\n{help}\n"),
+        ("fish", "{incomplete}", "plain,{value}\t{help}\n"),
+    ],
+)
+def test_actual_cli_protocol_emits_native_dynamic_records(
+    kind,
+    words,
+    expected_value,
+    shell,
+    cword,
+    expected,
+    isolated_completion_state,
+    monkeypatch,
+):
+    home, _project = isolated_completion_state
+    sessions = (
+        home / "projects" / completion.get_project_slug() / "sessions" / "session-1"
+    )
+    sessions.mkdir(parents=True)
+    monkeypatch.setattr(
+        completion,
+        "AppSettings",
+        lambda: _Settings(
+            {"bundle": {"added": {"team": "uri"}}},
+            providers=[{"id": "named", "module": "provider-openai"}],
+        ),
+    )
+
+    result = CliRunner().invoke(
+        main_module.cli,
+        [],
+        prog_name="amplifier",
+        env={
+            "_AMPLIFIER_COMPLETE": f"{shell}_complete",
+            "COMP_WORDS": words,
+            "COMP_CWORD": cword.format(incomplete=words.rsplit(" ", 1)[-1]),
+        },
+    )
+
+    assert result.exit_code == 0
+    assert result.output == expected.format(
+        value=expected_value,
+        help={
+            "bundle": "Available bundle",
+            "provider": "Configured provider",
+            "session": "Current-project session",
+        }[kind],
+    )
+
+
+@pytest.mark.parametrize(
+    ("words", "cword", "expected_records"),
+    [
+        ("amplifier bun", "1", {"plain,bundle"}),
+        (
+            "amplifier run --",
+            "2",
+            {
+                "plain,--bundle",
+                "plain,--help",
+                "plain,--max-tokens",
+                "plain,--mode",
+                "plain,--model",
+                "plain,--output-format",
+                "plain,--provider",
+                "plain,--resume",
+                "plain,--verbose",
+            },
+        ),
+        ("amplifier run --mode ", "3", {"plain,chat", "plain,single"}),
+    ],
+)
+def test_bash_protocol_retains_static_command_flag_and_choice_completion(
+    words, cword, expected_records
+):
+    result = CliRunner().invoke(
+        main_module.cli,
+        [],
+        prog_name="amplifier",
+        env={
+            "_AMPLIFIER_COMPLETE": "bash_complete",
+            "COMP_WORDS": words,
+            "COMP_CWORD": cword,
+        },
+    )
+
+    assert result.exit_code == 0
+    assert set(result.output.splitlines()) == expected_records
+    assert len(result.output.splitlines()) == len(expected_records)
+
+
+def test_wiring_uses_custom_callbacks_for_all_semantic_parameters():
+    cli = main_module.cli
+    assert (
+        _custom_callback(cli.commands["run"], "bundle")
+        is completion.complete_bundle_names
+    )
+    assert (
+        _custom_callback(cli.commands["run"], "provider")
+        is completion.complete_configured_provider_names
+    )
+    assert (
+        _custom_callback(cli.commands["run"], "resume")
+        is completion.complete_current_project_session_ids
+    )
+
+    bundle = cli.commands["bundle"]
+    for name in ("show", "use", "update"):
+        assert (
+            _custom_callback(bundle.commands[name], "name")
+            is completion.complete_bundle_names
+        )
+    assert (
+        _custom_callback(bundle.commands["remove"], "name")
+        is completion.complete_removable_bundle_names
+    )
+
+    for name in ("list", "info", "invoke"):
+        assert (
+            _custom_callback(cli.commands["tool"].commands[name], "bundle")
+            is completion.complete_bundle_names
+        )
+    assert (
+        _custom_callback(cli.commands["agents"].commands["list"], "bundle")
+        is completion.complete_bundle_names
+    )
+
+    session = cli.commands["session"]
+    for name in ("show", "fork", "delete", "resume"):
+        assert (
+            _custom_callback(session.commands[name], "session_id")
+            is completion.complete_current_project_session_ids
+        )
+    assert (
+        _custom_callback(session.commands["list"], "tree_session")
+        is completion.complete_current_project_session_ids
+    )
+    for command in (
+        cli.commands["continue"],
+        session.commands["resume"],
+        cli.commands["resume"],
+    ):
+        assert (
+            _custom_callback(command, "force_bundle")
+            is completion.complete_bundle_names
+        )
+    assert (
+        _custom_callback(cli.commands["resume"], "session_id")
+        is completion.complete_current_project_session_ids
+    )
+
+    providers = cli.commands["provider"]
+    for name, parameter_name in (
+        ("remove", "name"),
+        ("edit", "name"),
+        ("test", "name"),
+        ("models", "provider_id"),
+    ):
+        assert (
+            _custom_callback(providers.commands[name], parameter_name)
+            is completion.complete_configured_provider_names
+        )
+    for name, parameter_name in (
+        ("add", "provider_type"),
+        ("install", "provider_ids"),
+        ("login", "provider_id"),
+    ):
+        assert _custom_callback(providers.commands[name], parameter_name) is None
+
+
+def test_freeform_dynamic_values_remain_unconstrained_by_resilient_parse():
+    context = main_module.cli.make_context(
+        "amplifier",
+        ["run", "--bundle", "manual-bundle", "--provider", "manual-provider"],
+        resilient_parsing=True,
+    )
+    command = main_module.cli.commands["run"]
+    run_context = command.make_context(
+        "run",
+        ["--bundle", "manual-bundle", "--provider", "manual-provider"],
+        parent=context,
+        resilient_parsing=True,
+    )
+    assert run_context.params["bundle"] == "manual-bundle"
+    assert run_context.params["provider"] == "manual-provider"
+
+
+@pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])
+def test_installer_writes_real_click_source_once_and_preserves_rc_content(
+    tmp_path, monkeypatch, shell
+):
+    config = tmp_path / ".config" / shell / "amplifier.rc"
+    if shell != "fish":
+        config.parent.mkdir(parents=True)
+        config.write_text("# keep this\n", encoding="utf-8")
+    monkeypatch.setattr(
+        click.shell_completion.BashComplete,
+        "_check_version",
+        staticmethod(lambda: None),
+    )
+
+    assert completion.install_completion_to_config(config, shell, main_module.cli)
+    first = config.read_text(encoding="utf-8")
+    assert completion.install_completion_to_config(config, shell, main_module.cli)
+    assert config.read_text(encoding="utf-8") == first
+    assert completion.MANAGED_MARKER in first
+    instruction = "complete" if shell == "fish" else "source"
+    assert f"_AMPLIFIER_COMPLETE={shell}_{instruction}" in first
+    if shell != "fish":
+        assert "# keep this" in first
+
+
+def test_installer_recognizes_legacy_and_preserves_protected_fish(tmp_path):
+    zshrc = tmp_path / ".zshrc"
+    zshrc.write_text(
+        'eval "$(_AMPLIFIER_COMPLETE=zsh_source amplifier)"\n', encoding="utf-8"
+    )
+    fish = tmp_path / "amplifier.fish"
+    fish.write_text(
+        'function _amplifier_completion\nend\ncomplete --no-files --command amplifier --arguments "(_amplifier_completion)"\n',
+        encoding="utf-8",
+    )
+    protected = tmp_path / "protected.fish"
+    protected.write_text("complete --command other\n", encoding="utf-8")
+
+    assert completion.is_completion_installed(zshrc, "zsh")
+    assert completion.is_completion_installed(fish, "fish")
+    assert not completion.install_completion_to_config(
+        protected, "fish", main_module.cli
+    )
+    assert protected.read_text(encoding="utf-8") == "complete --command other\n"
+    assert not completion.install_completion_to_config(
+        tmp_path / "unsupported", "powershell", main_module.cli
+    )
+
+
+def test_fish_manual_fallback_is_non_overwriting_source_pipeline(tmp_path):
+    assert (
+        completion.manual_installation_instruction(
+            "fish", tmp_path / "a path" / "amplifier.fish"
+        )
+        == "_AMPLIFIER_COMPLETE=fish_source amplifier | source"
+    )
+
+
+def test_main_completion_instruction_skips_normal_startup(monkeypatch):
+    calls = []
+    monkeypatch.setenv("_AMPLIFIER_COMPLETE", "bash_source")
+    monkeypatch.setattr(main_module, "cli", lambda: calls.append("cli"))
+    monkeypatch.setattr(
+        main_module, "_guard_shared_venv_home", lambda: calls.append("guard")
+    )
+    monkeypatch.setattr(
+        main_module, "_activate_home_env", lambda: calls.append("activate")
+    )
+
+    main_module.main()
+
+    assert calls == ["cli"]
+
+
+def test_invalid_completion_instruction_does_not_execute_cli_or_bypass_guard(
+    monkeypatch,
+):
+    calls = []
+    monkeypatch.setenv("_AMPLIFIER_COMPLETE", "invalid_complete")
+    monkeypatch.setattr(main_module, "cli", lambda: calls.append("cli"))
+    monkeypatch.setattr(
+        main_module, "_guard_shared_venv_home", lambda: calls.append("guard")
+    )
+
+    with pytest.raises(click.exceptions.Exit):
+        main_module.main()
+
+    assert calls == []
+
+
+@pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])
+def test_install_flag_repeats_without_modifying_other_content(
+    shell, isolated_completion_state, monkeypatch
+):
+    home, _ = isolated_completion_state
+    monkeypatch.setenv("SHELL", f"/bin/{shell}")
+    config = completion.get_shell_config_file(shell)
+    if shell != "fish":
+        config.write_text("# preserve user configuration\n", encoding="utf-8")
+    runner = CliRunner()
+    first = runner.invoke(main_module.cli, ["--install-completion"])
+    assert first.exit_code == 0, first.output
+    assert config.is_file()
+    first_bytes = config.read_bytes()
+    second = runner.invoke(main_module.cli, ["--install-completion"])
+    assert second.exit_code == 0, second.output
+    assert "already configured" in second.output
+    assert config.read_bytes() == first_bytes
+    if shell != "fish":
+        assert first_bytes.startswith(b"# preserve user configuration\n")
+    assert home.is_dir()
+
+
+def test_install_flag_preserves_custom_fish_and_prints_safe_fallback(
+    isolated_completion_state, monkeypatch
+):
+    monkeypatch.setenv("SHELL", "/bin/fish")
+    config = completion.get_shell_config_file("fish")
+    config.parent.mkdir(parents=True)
+    original = b"# my custom completions\ncomplete --command amplifier -a custom\n"
+    config.write_bytes(original)
+    result = CliRunner().invoke(main_module.cli, ["--install-completion"])
+    assert result.exit_code == 1
+    assert "| source" in result.output
+    assert "current shell" in result.output
+    assert " > " not in result.output
+    assert config.read_bytes() == original
+
+
+@pytest.mark.parametrize("shell", ["bash", "zsh", "fish"])
+def test_marker_alone_is_not_installed(tmp_path, shell):
+    config = tmp_path / "rc"
+    config.write_text(
+        f"{completion.MANAGED_MARKER}\n# _AMPLIFIER_COMPLETE={shell}_source\n",
+        encoding="utf-8",
+    )
+    assert not completion.is_completion_installed(config, shell)
+
+
+@pytest.mark.parametrize(
+    "unsafe",
+    [
+        "bad,name",
+        "bad\nname",
+        "bad\tname",
+        "bad name",
+        "*",
+        "foo?",
+        "[a-z]",
+        "foo;bar",
+        "$(command)",
+        "foo`bar",
+        "foo#secret",
+        "foo%3Fsecret",
+        "../name",
+        "name/child",
+        "name\\child",
+        "hidden\u202ename",
+    ],
+)
+def test_unsafe_candidate_values_are_never_emitted(unsafe):
+    assert (
+        completion._completion_items({unsafe, "safe-name"}, "", "bundle")[0].value
+        == "safe-name"
+    )
+    assert len(completion._completion_items({unsafe, "safe-name"}, "", "bundle")) == 1
+
+
+def test_malformed_records_and_unresolvable_yml_are_not_candidates(
+    isolated_completion_state, monkeypatch
+):
+    home, project = isolated_completion_state
+    monkeypatch.setattr(
+        completion,
+        "AppSettings",
+        lambda: _Settings(
+            {
+                "bundle": {
+                    "added": {"broken": None, "blank": "", "valid": "file:///valid"}
+                }
+            },
+            providers=[
+                {"id": "broken"},
+                {"id": "wrong", "module": "tool-bash"},
+                {"id": "blank", "module": "provider-"},
+                {"id": "valid-provider", "module": "provider-openai"},
+            ],
+        ),
+    )
+    (home / "registry.json").write_text(
+        json.dumps(
+            {
+                "bundles": {
+                    "bad-cache": {"explicitly_requested": True},
+                    "valid-cache": {
+                        "uri": "file:///valid-cache",
+                        "explicitly_requested": True,
+                    },
+                }
+            }
+        )
+    )
+    bundles = project / ".amplifier" / "bundles"
+    bundles.mkdir(parents=True)
+    (bundles / "unresolvable.yml").write_text("bundle: {}")
+    assert _values(completion.complete_bundle_names(_context(), None, "valid")) == [
+        "valid",
+        "valid-cache",
+    ]
+    for prefix in ("broken", "blank", "bad-cache", "unresolvable"):
+        assert completion.complete_bundle_names(_context(), None, prefix) == []
+    assert _values(
+        completion.complete_configured_provider_names(_context(), None, "")
+    ) == ["valid-provider"]
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "https://user:password@example.test/repo",
+        "https://example.test/repo?token=synthetic-secret",
+        "file:///repo#synthetic-secret",
+        "ssh://user@example.test/repo",
+        "https://[malformed/repo",
+    ],
+)
+def test_app_bundle_uri_details_are_not_exposed(uri):
+    assert completion._extract_app_bundle_name(uri) is None
+
+
+def test_session_prefix_filter_precedes_limit_and_excludes_other_project(
+    isolated_completion_state,
+):
+    import os
+
+    home, _ = isolated_completion_state
+    sessions = home / "projects" / completion.get_project_slug() / "sessions"
+    for index in range(105):
+        entry = sessions / f"new-{index:03}"
+        entry.mkdir(parents=True)
+        os.utime(entry, (2000 + index, 2000 + index))
+    old = sessions / "old-matching-session"
+    old.mkdir()
+    os.utime(old, (1000, 1000))
+    other_project = (
+        home / "projects" / "different-project" / "sessions" / "old-foreign-session"
+    )
+    other_project.mkdir(parents=True)
+    assert _values(
+        completion.complete_current_project_session_ids(_context(), None, "old-")
+    ) == ["old-matching-session"]
+    assert (
+        _values(completion.complete_current_project_session_ids(_context(), None, ""))[
+            0
+        ]
+        == "new-104"
+    )
+
+
+def test_absent_home_stays_absent(tmp_path, monkeypatch):
+    absent = tmp_path / "never-created"
+    monkeypatch.setenv("AMPLIFIER_HOME", str(absent))
+    monkeypatch.setattr(completion, "get_amplifier_home", lambda: absent)
+    completion.complete_bundle_names(_context(), None, "")
+    completion.complete_configured_provider_names(_context(), None, "")
+    completion.complete_current_project_session_ids(_context(), None, "")
+    assert not absent.exists()
+
+
+def test_normal_main_keeps_ownership_guard_before_activation_and_dispatch(monkeypatch):
+    calls = []
+    monkeypatch.delenv("_AMPLIFIER_COMPLETE", raising=False)
+    for name in (
+        "_ensure_utf8_output",
+        "_configure_console_logging",
+        "_attach_llm_error_filter",
+    ):
+        monkeypatch.setattr(main_module, name, lambda: None)
+    monkeypatch.setattr(
+        main_module, "_guard_shared_venv_home", lambda: calls.append("guard")
+    )
+    monkeypatch.setattr(
+        main_module, "_activate_home_env", lambda: calls.append("activate")
+    )
+    monkeypatch.setattr(main_module, "cli", lambda: calls.append("cli"))
+    main_module.main()
+    assert calls == ["guard", "activate", "cli"]
+
+
+def test_bash_fresh_home_uses_bashrc_and_keeps_existing_profile_only_setup(
+    isolated_completion_state,
+):
+    home, _ = isolated_completion_state
+    assert completion.get_shell_config_file("bash") == home / ".bashrc"
+    (home / ".bash_profile").write_text("# existing login setup\n")
+    assert completion.get_shell_config_file("bash") == home / ".bash_profile"
+    (home / ".bashrc").write_text("# existing interactive setup\n")
+    assert completion.get_shell_config_file("bash") == home / ".bashrc"
+
+
+@pytest.mark.parametrize(
+    "module_name",
+    [
+        "amplifier_app_cli.key_manager",
+        "amplifier_app_cli.lib.settings",
+        "amplifier_app_cli.utils.settings_manager",
+    ],
+)
+def test_read_only_module_import_does_not_load_locking_dependency(
+    module_name, monkeypatch
+):
+    import builtins
+    import sys
+    import types
+
+    module = importlib.import_module(module_name)
+    code = compile(
+        Path(module.__file__).read_text(encoding="utf-8"), module.__file__, "exec"
+    )
+    probe = types.ModuleType(module_name + "_completion_probe")
+    probe.__package__ = module_name.rpartition(".")[0]
+    monkeypatch.setitem(sys.modules, probe.__name__, probe)
+    imports = []
+    real_import = builtins.__import__
+
+    def forbid_filelock(name, *args, **kwargs):
+        if name == "filelock" or name.startswith("filelock."):
+            imports.append(name)
+            raise AssertionError(
+                "Read-only import loaded a filesystem-probing dependency"
+            )
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", forbid_filelock)
+    exec(code, probe.__dict__)
+    assert imports == []


### PR DESCRIPTION
## Summary

- Add local-value shell completions for bundle names, configured provider instance names, and current-project top-level session IDs across the relevant CLI commands and options.
- Fix the documented no-argument `amplifier --install-completion` flag; make Bash, Zsh, and Fish installation repeat-safe, use `.bashrc` for fresh Bash homes, and preserve custom Fish completion files.
- Keep completion read-only: avoid provider/key initialization, registry migration, session-content reads, network calls, and import-time lock-library filesystem probes. Normal locking paths and timeouts are unchanged.
- Include logical-name and relative-path app-bundle removal candidates, while rejecting credential/query-bearing source values and unsafe emitted names.

The shell keeps control of its native menu/key behavior. This does not change interactive slash completion or `ui.slash_popup.enabled`. PowerShell is out of scope.

## Verification

- `uv run --with truststore pytest -q tests/test_shell_completion.py`: **75 passed**, including explicit LF/CRLF Bash and Zsh fixtures and the empty Fish fixture.
- `uv run --with truststore pytest -q`: **2,258 passed**, 1 existing skip, 1 expected failure; integration tests deselected here.
- `uv run --with truststore pytest -q -m integration`: **13 passed**.
- Ruff on all changed Python files: **passed**.
- Independently installed the final source snapshot in a Linux DTU: all **27 real Tab cases** passed across Bash 5.2.21, Zsh 5.9, and Fish 3.7.0, including the final local app-bundle cases.
- **34 strict protocol/audit checks passed**. The audit begins before CLI import and denies socket operations, filesystem mutation, and session transcript/event reads; absent Amplifier homes remained absent.
- First/repeat installation checks passed for all three shells, including custom Fish file preservation. All verification shell children exited and were reaped.
- Final source review passed. The original user-tested trial and existing settings/launchers were retained unchanged; the publication candidate was installed separately.

No model or provider API requests were needed. Native Windows execution is left to this PR's CI; no native macOS shell-testing claim is made.

## Scope and publication safety

Exactly 14 source/documentation/test paths. Verification artifacts, local configuration, and private workspace material are excluded. New fixtures use synthetic values; the public diff received a semantic leak review. No host installation or shell/settings configuration changes are part of this PR.
