### PR TITLE
fix: scan .agents/skills for skill discovery, and honour AMPLIFIER_SKILLS_DIR

### DIFF
--- a/amplifier_app_cli/runtime/config.py
+++ b/amplifier_app_cli/runtime/config.py
@@ -905,6 +905,21 @@ def _ensure_default_skills_dirs(tools: list[dict[str, Any]]) -> list[dict[str, A
     configure explicit remote skill sources, the module's get_default_skills_dirs()
     fallback is bypassed and workspace skills become invisible.
 
+    The same two scopes are also scanned under .agents/skills/, the
+    cross-tool location other agent CLIs install user- and project-scoped
+    skills into. Which directories a CLI session scans is app-layer policy,
+    so it is decided here rather than in the tool-skills module. Within each
+    scope the .amplifier/ path is listed first: discovery is
+    first-match-wins, so on a name collision the Amplifier-native skill wins.
+
+    AMPLIFIER_SKILLS_DIR, when set, is prepended ahead of every configured
+    source. The module's get_default_skills_dirs() treats it as the
+    highest-priority override, but that function is only reached when
+    config.skills is empty -- which never happens under this CLI, because the
+    skills behavior always configures a curated source and this function
+    always appends to it. Honouring the variable here is what makes the
+    documented override behave as documented.
+
     Also appends the CLI's own packaged skills directory
     (amplifier_app_cli/data/skills/), resolved from the installed package's
     location on disk -- never a git URI. This keeps packaged skills
@@ -916,14 +931,18 @@ def _ensure_default_skills_dirs(tools: list[dict[str, Any]]) -> list[dict[str, A
         tools: List of tool configurations
 
     Returns:
-        Tools with workspace, user, and packaged skill dirs in tool-skills's config.skills
+        Tools with override, workspace, user, and packaged skill dirs in
+        tool-skills's config.skills
     """
     packaged_skills_dir = Path(__file__).parent.parent / "data" / "skills"
     default_paths = [
         ".amplifier/skills",
+        ".agents/skills",
         "~/.amplifier/skills",
+        "~/.agents/skills",
         str(packaged_skills_dir),
     ]
+    override_dir = os.environ.get("AMPLIFIER_SKILLS_DIR")
 
     result = []
     for tool in tools:
@@ -931,6 +950,8 @@ def _ensure_default_skills_dirs(tools: list[dict[str, Any]]) -> list[dict[str, A
             tool = tool.copy()
             config = (tool.get("config") or {}).copy()
             skills = list(config.get("skills", []))
+            if override_dir and override_dir not in skills:
+                skills.insert(0, override_dir)
             for path in default_paths:
                 if path not in skills:
                     skills.append(path)

--- a/tests/test_merge_utils.py
+++ b/tests/test_merge_utils.py
@@ -305,6 +305,8 @@ class TestEnsureDefaultSkillsDirs:
         assert "git+https://example.com/skills" in skills
         assert ".amplifier/skills" in skills
         assert "~/.amplifier/skills" in skills
+        assert ".agents/skills" in skills
+        assert "~/.agents/skills" in skills
 
     def test_preserves_existing_paths(self):
         """Default paths should not be duplicated if already present."""
@@ -316,6 +318,8 @@ class TestEnsureDefaultSkillsDirs:
                         "git+https://example.com/skills",
                         ".amplifier/skills",
                         "~/.amplifier/skills",
+                        ".agents/skills",
+                        "~/.agents/skills",
                     ]
                 },
             }
@@ -324,6 +328,8 @@ class TestEnsureDefaultSkillsDirs:
         skills = result[0]["config"]["skills"]
         assert skills.count(".amplifier/skills") == 1
         assert skills.count("~/.amplifier/skills") == 1
+        assert skills.count(".agents/skills") == 1
+        assert skills.count("~/.agents/skills") == 1
 
     def test_handles_empty_config(self):
         """Should handle tool-skills with no config."""
@@ -364,7 +370,13 @@ class TestEnsureDefaultSkillsDirs:
         assert original_skills == ["git+https://example.com/skills"]
 
     def test_default_paths_appended_after_configured(self):
-        """Default paths should come after explicitly configured sources."""
+        """Default paths should come after explicitly configured sources.
+
+        Scope order is project-then-user, and within each scope the
+        .amplifier/ path precedes the cross-tool .agents/ path: discovery is
+        first-match-wins, so an Amplifier-native skill wins a name collision
+        against a skill of the same name installed by another agent CLI.
+        """
         tools = [
             {
                 "module": "tool-skills",
@@ -380,9 +392,66 @@ class TestEnsureDefaultSkillsDirs:
             "url1",
             "url2",
             ".amplifier/skills",
+            ".agents/skills",
             "~/.amplifier/skills",
+            "~/.agents/skills",
             packaged_skills_dir,
         ]
+
+    def test_agents_skills_dirs_are_injected(self, monkeypatch):
+        """.agents/skills at both scopes must be scanned.
+
+        This is the cross-tool location other agent CLIs install skills into.
+        Regression guard: before this was CLI policy, the only implementation
+        lived in the tool-skills module's get_default_skills_dirs(), which is
+        unreachable under this CLI because config.skills is never empty here.
+        """
+        monkeypatch.delenv("AMPLIFIER_SKILLS_DIR", raising=False)
+        tools = [
+            {
+                "module": "tool-skills",
+                "config": {"skills": ["git+https://example.com/skills"]},
+            }
+        ]
+        result = _ensure_default_skills_dirs(tools)
+        skills = result[0]["config"]["skills"]
+        assert ".agents/skills" in skills
+        assert "~/.agents/skills" in skills
+
+    def test_env_override_is_prepended_ahead_of_configured_sources(
+        self, monkeypatch, tmp_path
+    ):
+        """AMPLIFIER_SKILLS_DIR must outrank every other source.
+
+        It is documented as the highest-priority override. Appending it would
+        leave the curated source ahead of it and silently invert that.
+        """
+        monkeypatch.setenv("AMPLIFIER_SKILLS_DIR", str(tmp_path))
+        tools = [
+            {
+                "module": "tool-skills",
+                "config": {"skills": ["git+https://example.com/skills"]},
+            }
+        ]
+        result = _ensure_default_skills_dirs(tools)
+        skills = result[0]["config"]["skills"]
+        assert skills[0] == str(tmp_path)
+        assert "git+https://example.com/skills" in skills
+        assert ".amplifier/skills" in skills
+
+    def test_env_override_absent_leaves_order_unchanged(self, monkeypatch):
+        """No AMPLIFIER_SKILLS_DIR means no extra entry."""
+        monkeypatch.delenv("AMPLIFIER_SKILLS_DIR", raising=False)
+        tools = [{"module": "tool-skills", "config": {"skills": ["url1"]}}]
+        result = _ensure_default_skills_dirs(tools)
+        assert result[0]["config"]["skills"][0] == "url1"
+
+    def test_env_override_not_duplicated(self, monkeypatch, tmp_path):
+        """An override already configured explicitly must not be added twice."""
+        monkeypatch.setenv("AMPLIFIER_SKILLS_DIR", str(tmp_path))
+        tools = [{"module": "tool-skills", "config": {"skills": [str(tmp_path)]}}]
+        result = _ensure_default_skills_dirs(tools)
+        assert result[0]["config"]["skills"].count(str(tmp_path)) == 1
 
     def test_packaged_skills_dir_is_package_relative(self):
         """Packaged skills dir must resolve from the installed package location,


### PR DESCRIPTION
## Problem

Skills installed into `.agents/skills/` — the cross-tool directory other agent CLIs
install user- and project-scoped skills into — are invisible to Amplifier. Nothing
scans them.

Separately, `AMPLIFIER_SKILLS_DIR` does nothing under this CLI, despite being
documented in three places as the highest-priority discovery override.

Both have the same root cause.

## Root cause

`tool-skills` has a `get_default_skills_dirs()` fallback that handles
`AMPLIFIER_SKILLS_DIR` and the default directories. It is only reached when
`config.skills` is empty.

Under this CLI, `config.skills` is never empty:

- `runtime/config.py:104` always composes the skills behavior, which sets
  `config.skills` to a curated source.
- `_ensure_default_skills_dirs()` then always appends to it.

So `_resolve_skill_sources` takes the `"skills" in config` branch every time and the
module's defaults are unreachable. Confirmed by observation, not inference: setting
`AMPLIFIER_SKILLS_DIR` to a directory containing a valid skill and running
`amplifier tool invoke load_skill list=true` does not surface it.

That also means fixing this in the module would ship a no-op for CLI users.

## Fix

Both belong at the app layer — which directories a CLI session scans is app policy,
and `_ensure_default_skills_dirs()` is where that policy already lives, next to
`_ensure_cwd_in_write_paths()`.

- Add `.agents/skills` and `~/.agents/skills` to the injected defaults. Project
  scope before user scope; within each scope `.amplifier/` precedes `.agents/`, so
  first-match-wins resolution gives the Amplifier-native skill the name collision.
- Prepend `AMPLIFIER_SKILLS_DIR` ahead of every configured source when set.
  Appending would leave the curated source ahead of it and quietly invert the
  documented priority.

Purely additive. Nonexistent directories are skipped during discovery, so anyone
without these directories sees no change.

## Testing

Full suite: 2224 passed, 39 skipped, 1 xfailed (baseline 2220 — four new tests).
ruff check and ruff format --check clean.

End-to-end, same `amplifier tool invoke load_skill list=true` before and after, with
probe skills planted in each location:

| Probe | before | after |
|---|---|---|
| `./.amplifier/skills/` (control) | found | found |
| `./.agents/skills/` | not found | found |
| `~/.agents/skills/` | not found | found |
| `AMPLIFIER_SKILLS_DIR` | not found | found |
| total visible | 51 | 54 |

No previously-visible skill was lost.

New tests cover `.agents/skills` injection at both scopes, env-override prepending,
absence of the env var, and no-duplication when the override is already configured
explicitly. `test_default_paths_appended_after_configured` was updated — it pins the
exact injected ordering.
