### PR TITLE
fix(update): distinguish local sources and clarify bundle labels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,9 @@ Keep report labels separate from update eligibility: a missing mutable cache is
 a download, not a newer revision, and an unchecked source is not current.
 Use the same word-status vocabulary in every `amplifier update` section,
 including verbose output.
+Keep the exact configured URI as the update action identity, but derive only
+credential-safe, globally unique display labels; malformed app entries render
+as a generic failed check and never leak their configured payload.
 Exercise the real Click command in `tests/test_update_reporting.py`; mock only
 status/apply boundaries so tests never touch a user's caches or installation.
 

--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -3,9 +3,13 @@
 import asyncio
 from collections.abc import Iterable
 from dataclasses import dataclass
+import hashlib
+import nturl2path
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
-from urllib.parse import parse_qs, unquote, urlsplit
+from urllib.parse import SplitResult, parse_qs, unquote, urlsplit
+from urllib.request import url2pathname
 
 import click
 from rich.console import Console
@@ -94,13 +98,80 @@ _REPORT_STATE_LABELS: dict[SourceReportState, str] = {
 }
 
 
+_INVALID_APP_SOURCE_PREFIX = "<invalid-app-source:"
+
+
+def _safe_urlsplit(uri: str) -> SplitResult | None:
+    """Split a configured URI without allowing malformed input to break reporting."""
+
+    try:
+        return urlsplit(uri)
+    except ValueError:
+        return None
+
+
+def _invalid_app_source_key(value: object) -> str:
+    """Create a stable internal identity without rendering malformed settings."""
+
+    digest = hashlib.sha256(repr(value).encode("utf-8", errors="backslashreplace")).hexdigest()
+    return f"{_INVALID_APP_SOURCE_PREFIX}{digest}>"
+
+
+def _is_valid_app_source(uri: str) -> bool:
+    """Accept only location URIs the app-bundle setting can load."""
+
+    if uri.startswith(("git+", "zip+")):
+        parsed = _safe_urlsplit(uri.removeprefix("git+").removeprefix("zip+"))
+        return parsed is not None and bool(parsed.scheme)
+    if not uri.startswith(("file://", "http://", "https://")):
+        return False
+    parsed = _safe_urlsplit(uri)
+    return parsed is not None and parsed.scheme.lower() in {"file", "http", "https"}
+
+
+def _file_uri_path_value(uri: str, *, windows: bool) -> str | None:
+    """Return a local filename from a file URI for the named platform.
+
+    ``Path.as_uri()`` emits ``file:///C:/...`` on Windows, while the legacy
+    CLI interpolation emits ``file://C:\\...``.  Both forms name a local drive
+    there.  A named host is a UNC path only on Windows; on POSIX it is remote
+    and deliberately not reinterpreted as a local path.
+    """
+
+    parsed = _safe_urlsplit(uri)
+    if parsed is None or parsed.scheme.lower() != "file":
+        return None
+
+    netloc = parsed.netloc
+    if not netloc or netloc.lower() == "localhost":
+        encoded_path = parsed.path
+    elif windows and len(netloc) >= 2 and netloc[1] == ":" and netloc[0].isalpha():
+        # Legacy ``file://C:\path`` serialization.  ``nturl2path`` accepts
+        # both backslash and slash separators after the drive.
+        encoded_path = netloc + parsed.path
+    elif windows and "@" not in netloc and ":" not in netloc:
+        # Standard UNC syntax: file://server/share/path -> \\server\share\path.
+        try:
+            hostname = parsed.hostname
+        except ValueError:
+            return None
+        if not hostname or hostname.lower() != netloc.lower():
+            return None
+        encoded_path = f"//{hostname}{parsed.path}"
+    else:
+        return None
+
+    converter = nturl2path.url2pathname if windows else url2pathname
+    return converter(encoded_path)
+
+
 def _file_uri_path(uri: str) -> Path | None:
     """Return the local path represented by a file URI, without its fragment."""
 
-    parsed = urlsplit(uri)
-    if parsed.scheme != "file" or parsed.netloc not in ("", "localhost"):
+    path_value = _file_uri_path_value(uri, windows=os.name == "nt")
+    if path_value is None:
         return None
-    return Path(unquote(parsed.path))
+    return Path(path_value)
 
 
 def _app_cli_packaged_bundle_root() -> Path | None:
@@ -134,6 +205,8 @@ def _check_failure_reason(error: object) -> str:
     """Map arbitrary checker failures to a safe, stable user-facing reason."""
 
     message = str(error).lower()
+    if message == "invalid source":
+        return message
     if isinstance(error, TimeoutError) or "timeout" in message or "timed out" in message:
         return "timeout"
     if "rate limit" in message or "too many requests" in message or " 429" in message:
@@ -516,119 +589,177 @@ def _strip_uri_fragment(uri: str) -> str:
     return uri.split("#", 1)[0]
 
 
-def _legacy_bundle_display_names(bundle_keys: Iterable[str]) -> dict[str, str]:
-    """Map bundle result keys to the label shown to the user.
+def _is_bundle_source_key(key: str) -> bool:
+    """Whether a key represents a source rather than a registry alias."""
 
-    Registry-backed bundles are already keyed by a friendly name. App bundles
-    are keyed by their configured source URI, because that URI *is* the update
-    target's identity and has to survive round-tripping into
-    ``update_bundle``. Printing it as a table row's Name, though, is
-    unreadable and drags the table past any sane terminal width:
-
-        git+https://github.com/org/amplifier-bundle-x@main#subdirectory=behaviors/x.yaml
-
-    So the key stays the URI and only the label changes.
-
-    A derived label that would collide with another row's - two repos both
-    shipping ``behaviors/main.yaml``, or a derived name equal to a registry
-    alias - falls back to the full URI for the colliding rows. Two rows
-    showing the same name is worse than one long name, because it silently
-    misidentifies which one has an update.
-    """
-    labels = {
-        key: (_extract_behavior_name(key) if "://" in key else key)
-        for key in bundle_keys
-    }
-
-    seen: dict[str, int] = {}
-    for label in labels.values():
-        seen[label] = seen.get(label, 0) + 1
-
-    return {
-        key: (label if seen[label] == 1 else key) for key, label in labels.items()
-    }
+    return key.startswith(
+        (_INVALID_APP_SOURCE_PREFIX, "git+", "zip+", "file://", "http://", "https://")
+    )
 
 
-def _bundle_display_base_name(key: str) -> str:
-    """Return a safe friendly name for a bundle key without exposing its URI."""
+def _safe_bundle_display_base_name(key: str) -> str:
+    """Return a readable label without falling back to a raw malformed URI."""
 
+    if key.startswith(_INVALID_APP_SOURCE_PREFIX):
+        return "invalid source"
     if "://" not in key:
         return key
-    file_path = _file_uri_path(key)
-    if file_path is not None:
-        fragment = parse_qs(urlsplit(key).fragment).get("subdirectory", [])
-        candidate = fragment[0] if fragment else file_path.name
-        return Path(candidate).stem or file_path.name or "local bundle"
-
-    derived = _extract_behavior_name(key)
-    # The shared helper deliberately falls back to the raw URI for unfamiliar
-    # hosts. Update output must never turn that fallback into a credential leak.
+    parsed = _safe_urlsplit(key.removeprefix("git+"))
+    if parsed is None:
+        return "bundle"
+    if parsed.scheme.lower() == "file":
+        fragment = parse_qs(parsed.fragment).get("subdirectory", [])
+        candidate = fragment[0] if fragment else unquote(parsed.path).rstrip("/").rsplit("/", 1)[-1]
+        return Path(candidate).stem or candidate or "local bundle"
+    try:
+        derived = _extract_behavior_name(key)
+    except (TypeError, ValueError):
+        derived = key
     if "://" not in derived:
         return derived
-    parsed = urlsplit(key.removeprefix("git+"))
-    return Path(parsed.path).name.split("@", 1)[0].removesuffix(".git") or "bundle"
+    leaf = unquote(parsed.path).rstrip("/").rsplit("/", 1)[-1]
+    return leaf.split("@", 1)[0].removesuffix(".git") or "bundle"
 
 
-def _bundle_uri_label_parts(uri: str) -> tuple[str, str, str]:
-    """Return safe repo/ref/subpath discriminators for an app-source URI."""
+def _bundle_source_label_parts(key: str) -> tuple[str, ...]:
+    """Return progressively more-specific safe source discriminators."""
 
-    parsed = urlsplit(uri.removeprefix("git+"))
-    path_parts = [part for part in parsed.path.split("/") if part]
-    leaf = path_parts[-1] if path_parts else ""
-    repo, marker, ref = leaf.rpartition("@")
+    if key.startswith(_INVALID_APP_SOURCE_PREFIX):
+        return ("invalid source",)
+    parsed = _safe_urlsplit(key.removeprefix("git+"))
+    if parsed is None:
+        return ("app source",)
+    if parsed.scheme.lower() == "file":
+        path_value = _file_uri_path_value(key, windows=os.name == "nt")
+        if not path_value:
+            return ("local source",)
+        components = [
+            component
+            for component in path_value.replace("\\", "/").rstrip("/").split("/")
+            if component
+        ]
+        parents = list(reversed(components[:-1]))
+        return tuple([f"local {parents[0]}", *parents[1:]]) if parents else ("local source",)
+
+    repo_path, marker, ref = unquote(parsed.path).rpartition("@")
     if not marker:
-        repo, ref = leaf, ""
-    repo = repo.removesuffix(".git")
+        repo_path, ref = unquote(parsed.path), ""
+    path_parts = [part for part in repo_path.split("/") if part]
+    repo = path_parts[-1].removesuffix(".git") if path_parts else ""
     owner = path_parts[-2] if len(path_parts) > 1 else ""
     repository = "/".join(part for part in (owner, repo) if part)
     subdirectory = parse_qs(parsed.fragment).get("subdirectory", [""])[0]
-    return repository, f"@{ref}" if ref else "", subdirectory
+    try:
+        host = parsed.hostname or ""
+    except ValueError:
+        host = ""
+    scheme = key.split(":", 1)[0].lower()
+    return tuple(part for part in (repository, f"@{ref}" if ref else "", subdirectory, host, scheme) if part)
 
 
-def _bundle_display_names(
-    bundle_keys: Iterable[str],
-    statuses: dict[str, "BundleStatus"] | None = None,
-) -> dict[str, str]:
-    """Map update keys to compact, unique, credential-safe display labels."""
+def _minimal_unique_qualifiers(keys: list[str]) -> dict[str, str]:
+    """Find the shortest safe qualifier that distinguishes each source."""
 
-    # Identity is carried by the result key today. Retain the optional status
-    # map so every reporting surface can share this function as source-aware
-    # presentation grows without changing its public call shape.
-    del statuses
+    parts = {key: _bundle_source_label_parts(key) for key in keys}
+    for width in range(1, max((len(value) for value in parts.values()), default=0) + 1):
+        candidates = {key: " ".join(value[:width]) for key, value in parts.items()}
+        if all(candidates.values()) and len(set(candidates.values())) == len(candidates):
+            return candidates
+    return {key: " ".join(value) for key, value in parts.items()}
+
+
+def _source_hash_suffixes(keys: list[str]) -> dict[str, str]:
+    """Return full deterministic opaque digests for irreducible source collisions."""
+
+    digests = {
+        key: hashlib.sha256(
+            b"amplifier-update-label\x00"
+            + key.encode("utf-8", errors="surrogatepass")
+        ).hexdigest()
+        for key in keys
+    }
+    return digests
+
+
+def _resolve_remaining_label_collisions(labels: dict[str, str]) -> None:
+    """Append source-derived hashes until every generated label is globally unique."""
+
+    source_bases: dict[str, str] = {}
+    for _ in range(15):
+        groups: dict[str, list[str]] = {}
+        for key, label in labels.items():
+            groups.setdefault(label, []).append(key)
+        conflicting_sources = [
+            key
+            for keys in groups.values()
+            if len(keys) > 1
+            for key in keys
+            if _is_bundle_source_key(key)
+        ]
+        if not conflicting_sources:
+            return
+
+        for key in conflicting_sources:
+            source_bases.setdefault(key, labels[key])
+        fixed_labels = {
+            label
+            for key, label in labels.items()
+            if key not in conflicting_sources
+        }
+        digests = _source_hash_suffixes(conflicting_sources)
+        for length in range(8, 65, 4):
+            candidates = {
+                key: f"{source_bases[key]} [{digests[key][:length]}]"
+                for key in conflicting_sources
+            }
+            if (
+                len(set(candidates.values())) == len(candidates)
+                and not fixed_labels.intersection(candidates.values())
+            ):
+                labels.update(candidates)
+                break
+        else:
+            labels.update(
+                {
+                    key: f"{source_bases[key]} [{digests[key]}]"
+                    for key in conflicting_sources
+                }
+            )
+    raise RuntimeError("could not derive globally unique bundle display labels")
+
+
+def _bundle_display_names(bundle_keys: Iterable[str]) -> dict[str, str]:
+    """Map update keys to globally unique, credential-safe display labels."""
+
     keys = list(bundle_keys)
-    labels = {key: _bundle_display_base_name(key) for key in keys}
+    labels = {key: _safe_bundle_display_base_name(key) for key in keys}
     grouped: dict[str, list[str]] = {}
     for key, label in labels.items():
         grouped.setdefault(label, []).append(key)
 
     for base, colliding in grouped.items():
-        if len(colliding) == 1:
+        source_keys = [key for key in colliding if _is_bundle_source_key(key)]
+        alias_keys = [key for key in colliding if not _is_bundle_source_key(key)]
+        if len(colliding) < 2 or not source_keys:
             continue
-        uri_keys = [key for key in colliding if "://" in key]
-        alias_keys = [key for key in colliding if "://" not in key]
-        # A registry alias is already the user's compact stable handle. A
-        # single colliding app source only needs its role to become distinct.
-        if alias_keys and len(uri_keys) == 1:
-            labels[uri_keys[0]] = f"{base} (app source)"
+        if alias_keys and len(source_keys) == 1:
+            labels[source_keys[0]] = f"{base} (app source)"
             continue
+        qualifiers = _minimal_unique_qualifiers(source_keys)
+        for key in source_keys:
+            labels[key] = f"{base} ({qualifiers[key] or 'app source'})"
 
-        parts = {key: _bundle_uri_label_parts(key) for key in uri_keys}
-        qualifiers = [""] * len(uri_keys)
-        for index in range(3):
-            candidate = {
-                key: " ".join(part for part in parts[key][: index + 1] if part)
-                for key in uri_keys
-            }
-            if all(candidate.values()) and len(set(candidate.values())) == len(candidate):
-                qualifiers = [candidate[key] for key in uri_keys]
-                break
-        for key, qualifier in zip(uri_keys, qualifiers, strict=True):
-            labels[key] = f"{base} ({qualifier or 'app source'})"
-        # Multiple aliases with the same spelling should not normally exist,
-        # but leave their exact user-facing aliases intact rather than invent
-        # an order-dependent suffix.
-        for key in alias_keys:
-            labels[key] = key
+    regrouped: dict[str, list[str]] = {}
+    for key, label in labels.items():
+        regrouped.setdefault(label, []).append(key)
+    for label, colliding in regrouped.items():
+        source_keys = [key for key in colliding if _is_bundle_source_key(key)]
+        if len(colliding) > 1 and source_keys:
+            for key in source_keys:
+                hint = " ".join(_bundle_source_label_parts(key))
+                labels[key] = f"{label} ({hint or 'app source'})"
+
+    _resolve_remaining_label_collisions(labels)
     return labels
 
 
@@ -943,15 +1074,19 @@ async def _check_all_bundle_status() -> dict[str, "BundleStatus"]:
         """Keep a direct configured source visible when its status check fails."""
 
         uri = source_uri or ""
+        safe_error = _check_failure_reason(error)
         return BundleStatus(
             bundle_name=bundle_name,
             bundle_source=uri,
             sources=[
                 SourceStatus(
-                    source_uri=uri,
+                    # The status has no update action, so keep the exact URI on
+                    # BundleStatus for identity but never render or retain a
+                    # malformed source's potentially private payload here.
+                    source_uri="",
                     is_cached=False,
                     has_update=None,
-                    error=str(error),
+                    error=safe_error,
                 )
             ],
         )
@@ -1036,7 +1171,18 @@ async def _check_all_bundle_status() -> dict[str, "BundleStatus"]:
     # Scoped to the root URIs deliberately: two app entries that share a repo
     # are both things the user asked for by name, and stay independent.
     root_bases = {_strip_uri_fragment(uri) for uri in checked_uris}
-    for uri in AppSettings().get_app_bundles():
+    for configured_source in AppSettings().get_app_bundles():
+        if (
+            not isinstance(configured_source, str)
+            or not configured_source.strip()
+            or not _is_valid_app_source(configured_source)
+        ):
+            invalid_key = _invalid_app_source_key(configured_source)
+            results[invalid_key] = _failed_bundle_status(
+                invalid_key, None, ValueError("invalid source")
+            )
+            continue
+        uri = configured_source
         if uri in checked_uris or _strip_uri_fragment(uri) in root_bases:
             continue
         checked_uris.add(uri)
@@ -1081,7 +1227,7 @@ async def _check_transitive_bundle_status(
 
     # Seed the walk with the label each direct row already displays, so a
     # transitive row can name a parent the user can actually find in the table.
-    seed_labels = _bundle_display_names(direct_results.keys(), direct_results)
+    seed_labels = _bundle_display_names(direct_results.keys())
     roots = {
         seed_labels.get(key, key): status.bundle_source
         for key, status in direct_results.items()
@@ -1415,7 +1561,7 @@ def _show_concise_report(
         table.add_column("Remote", style="dim", justify="right")
         table.add_column("Status", justify="center")
 
-        display_names = _bundle_display_names(bundle_results.keys(), bundle_results)
+        display_names = _bundle_display_names(bundle_results.keys())
         bundle_plan = bundle_plan or _bundle_report_plan(bundle_results)
 
         for bundle_name in sorted(
@@ -1646,7 +1792,7 @@ def _show_verbose_report(
     # === BUNDLES ===
     if bundle_results:
         active_bundle = _get_active_bundle_name()
-        display_names = _bundle_display_names(bundle_results.keys(), bundle_results)
+        display_names = _bundle_display_names(bundle_results.keys())
         bundle_plan = bundle_plan or _bundle_report_plan(bundle_results)
         for bundle_name in sorted(
             bundle_results.keys(),
@@ -1914,7 +2060,7 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
         console.print("  Checking bundles...")
     bundle_results = asyncio.run(_check_all_bundle_status())
     bundle_plan = _bundle_report_plan(bundle_results)
-    bundle_labels = _bundle_display_names(bundle_results.keys(), bundle_results)
+    bundle_labels = _bundle_display_names(bundle_results.keys())
     has_bundle_updates = (
         any(s.has_updates for s in bundle_results.values()) if bundle_results else False
     )

--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -120,13 +120,18 @@ def _invalid_app_source_key(value: object) -> str:
 def _is_valid_app_source(uri: str) -> bool:
     """Accept only location URIs the app-bundle setting can load."""
 
-    if uri.startswith(("git+", "zip+")):
-        parsed = _safe_urlsplit(uri.removeprefix("git+").removeprefix("zip+"))
-        return parsed is not None and bool(parsed.scheme)
-    if not uri.startswith(("file://", "http://", "https://")):
+    transport_uri = uri.removeprefix("git+").removeprefix("zip+")
+    parsed = _safe_urlsplit(transport_uri)
+    if parsed is None:
         return False
-    parsed = _safe_urlsplit(uri)
-    return parsed is not None and parsed.scheme.lower() in {"file", "http", "https"}
+    if parsed.scheme.lower() == "file":
+        return _file_uri_path_value(transport_uri, windows=os.name == "nt") is not None
+    if parsed.scheme.lower() not in {"http", "https", "ssh", "git"}:
+        return False
+    try:
+        return bool(parsed.hostname)
+    except ValueError:
+        return False
 
 
 def _file_uri_path_value(uri: str, *, windows: bool) -> str | None:
@@ -157,12 +162,18 @@ def _file_uri_path_value(uri: str, *, windows: bool) -> str | None:
             return None
         if not hostname or hostname.lower() != netloc.lower():
             return None
+        if not parsed.path.strip("/"):
+            return None
         encoded_path = f"//{hostname}{parsed.path}"
     else:
         return None
 
     converter = nturl2path.url2pathname if windows else url2pathname
-    return converter(encoded_path)
+    try:
+        path_value = converter(encoded_path)
+    except (OSError, ValueError):
+        return None
+    return path_value if path_value and "\x00" not in path_value else None
 
 
 def _file_uri_path(uri: str) -> Path | None:

--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -3,7 +3,9 @@
 import asyncio
 from collections.abc import Iterable
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
+from urllib.parse import parse_qs, unquote, urlsplit
 
 import click
 from rich.console import Console
@@ -68,6 +70,10 @@ SourceReportState = Literal[
     "pinned_missing",
     "local_changes",
     "mixed_actions",
+    "local",
+    "packaged",
+    "missing_path",
+    "check_failed",
 ]
 
 _ACTIONABLE_REPORT_STATES = {"download", "update", "refresh_cache"}
@@ -81,7 +87,84 @@ _REPORT_STATE_LABELS: dict[SourceReportState, str] = {
     "pinned_missing": "Pinned; not cached",
     "local_changes": "Local changes",
     "mixed_actions": "Mixed actions",
+    "local": "Local",
+    "packaged": "Packaged",
+    "missing_path": "Missing path",
+    "check_failed": "Check failed",
 }
+
+
+def _file_uri_path(uri: str) -> Path | None:
+    """Return the local path represented by a file URI, without its fragment."""
+
+    parsed = urlsplit(uri)
+    if parsed.scheme != "file" or parsed.netloc not in ("", "localhost"):
+        return None
+    return Path(unquote(parsed.path))
+
+
+def _app_cli_packaged_bundle_root() -> Path | None:
+    """Return the wheel-only app-cli bundle directory, if this is a wheel install.
+
+    A source checkout deliberately does *not* count: its overlay is at the
+    repository root, whereas a built wheel force-includes it under the Python
+    package's ``_bundle`` directory.
+    """
+
+    import amplifier_app_cli
+
+    candidate = Path(amplifier_app_cli.__file__).resolve().parent / "_bundle"
+    return candidate if candidate.is_dir() else None
+
+
+def _is_packaged_app_cli_bundle(path: Path) -> bool:
+    """Whether *path* is physically inside this installed wheel's overlay."""
+
+    root = _app_cli_packaged_bundle_root()
+    if root is None:
+        return False
+    try:
+        path.resolve().relative_to(root.resolve())
+    except ValueError:
+        return False
+    return True
+
+
+def _check_failure_reason(error: object) -> str:
+    """Map arbitrary checker failures to a safe, stable user-facing reason."""
+
+    message = str(error).lower()
+    if isinstance(error, TimeoutError) or "timeout" in message or "timed out" in message:
+        return "timeout"
+    if "rate limit" in message or "too many requests" in message or " 429" in message:
+        return "rate limit"
+    if (
+        "authentication" in message
+        or "unauthorized" in message
+        or "credential" in message
+        or " 401" in message
+    ):
+        return "authentication"
+    if "permission" in message or "forbidden" in message or " 403" in message:
+        return "permission"
+    if "not found" in message or " 404" in message:
+        return "not found"
+    if any(
+        token in message
+        for token in ("network", "connection", "dns", "socket", "connect", "proxy")
+    ):
+        return "network"
+    return "status check failed"
+
+
+def _source_report_state_text(source: Any, state: SourceReportState | None = None) -> Text:
+    """Render one source status, exposing failures without exposing exception text."""
+
+    state = state or _classify_source_status(source)
+    text = _report_state_text(state)
+    if state == "check_failed":
+        text.append(f": {_check_failure_reason(source.error)}", style="dim")
+    return text
 
 
 def _classify_source_status(
@@ -90,7 +173,32 @@ def _classify_source_status(
     """Return a presentation-only status without deriving action eligibility."""
 
     if getattr(source, "error", None):
-        return "not_checked"
+        return "check_failed"
+
+    file_path = _file_uri_path(getattr(source, "source_uri", ""))
+    if file_path is not None:
+        if not file_path.exists():
+            return "missing_path"
+        if getattr(source, "is_pinned", False):
+            return "pinned" if source.is_cached else "pinned_missing"
+        if has_local_changes:
+            return "local_changes"
+        # A file URI is a local artifact first. A well-known editable bundle
+        # retains Current/Update only after a complete remote comparison.
+        has_confirmed_remote_comparison = (
+            source.has_update is True
+            and bool(source.cached_commit and source.remote_commit)
+        ) or (
+            source.has_update is False
+            and bool(source.cached_commit)
+            and source.cached_commit == source.remote_commit
+        )
+        if has_confirmed_remote_comparison:
+            # Continue into the established Current/Update classification.
+            pass
+        else:
+            return "packaged" if _is_packaged_app_cli_bundle(file_path) else "local"
+
     if getattr(source, "is_pinned", False):
         return "pinned" if source.is_cached else "pinned_missing"
     if has_local_changes:
@@ -176,6 +284,14 @@ def _classify_bundle_status(status: "BundleStatus") -> SourceReportState:
         return action_states[0]
     if "local_changes" in states:
         return "local_changes"
+    if "check_failed" in states:
+        return "check_failed"
+    if "missing_path" in states:
+        return "missing_path"
+    if "local" in states:
+        return "local"
+    if "packaged" in states:
+        return "packaged"
     if "not_checked" in states:
         return "not_checked"
     if "pinned_missing" in states:
@@ -216,10 +332,29 @@ def _bundle_report_state_text(
 ) -> Text:
     """Describe a bundle's composite action plan without changing its selection."""
 
-    if state != "mixed_actions":
-        return _report_state_text(state)
-    actions = " + ".join(_REPORT_STATE_LABELS[action].lower() for action in _bundle_action_states(status))
-    return Text(f"Mixed actions ({actions})", style="yellow")
+    if state == "mixed_actions":
+        actions = " + ".join(
+            _REPORT_STATE_LABELS[action].lower()
+            for action in _bundle_action_states(status)
+        )
+        text = Text(f"Mixed actions ({actions})", style="yellow")
+    else:
+        text = _report_state_text(state)
+
+    failure_reasons = sorted(
+        {
+            _check_failure_reason(source.error)
+            for source in status.sources
+            if getattr(source, "error", None)
+        }
+    )
+    if failure_reasons:
+        # An actionable sibling must stay actionable, but a failed check must
+        # never disappear behind its sibling's Update label.
+        if state != "check_failed":
+            text.append("; check failed", style="dim")
+        text.append(f": {', '.join(failure_reasons)}", style="dim")
+    return text
 
 
 def _bundle_action_phrase(status: "BundleStatus") -> str:
@@ -263,10 +398,17 @@ def _bundle_action_lines(
         f"Process {count} bundle{'s' if count != 1 else ''} with {phrase}"
         for phrase, count in mixed.items()
     )
+    neutral_phrases = {
+        "local_changes": "local changes",
+        "local": "local sources",
+        "packaged": "packaged sources",
+        "missing_path": "missing paths",
+        "check_failed": "failed checks",
+        "not_checked": "unconfirmed sources",
+    }
     lines.extend(
-        f"Process {count} bundle{'s' if count != 1 else ''} with "
-        f"{'local changes' if state == 'local_changes' else 'unconfirmed sources'}"
-        for state in ("local_changes", "not_checked")
+        f"Process {count} bundle{'s' if count != 1 else ''} with {phrase}"
+        for state, phrase in neutral_phrases.items()
         if (count := counts.get(state, 0))
     )
     return lines
@@ -310,7 +452,7 @@ def _unconfirmed_source_counts(
             state = _classify_source_status(
                 source, has_local_changes=bool(getattr(source, "_has_local_changes", False))
             )
-            if state == "not_checked":
+            if state in ("not_checked", "check_failed", "missing_path", "local", "packaged"):
                 unchecked.add(key)
             elif state == "local_changes":
                 local_changes.add(key)
@@ -374,7 +516,7 @@ def _strip_uri_fragment(uri: str) -> str:
     return uri.split("#", 1)[0]
 
 
-def _bundle_display_names(bundle_keys: Iterable[str]) -> dict[str, str]:
+def _legacy_bundle_display_names(bundle_keys: Iterable[str]) -> dict[str, str]:
     """Map bundle result keys to the label shown to the user.
 
     Registry-backed bundles are already keyed by a friendly name. App bundles
@@ -405,6 +547,89 @@ def _bundle_display_names(bundle_keys: Iterable[str]) -> dict[str, str]:
     return {
         key: (label if seen[label] == 1 else key) for key, label in labels.items()
     }
+
+
+def _bundle_display_base_name(key: str) -> str:
+    """Return a safe friendly name for a bundle key without exposing its URI."""
+
+    if "://" not in key:
+        return key
+    file_path = _file_uri_path(key)
+    if file_path is not None:
+        fragment = parse_qs(urlsplit(key).fragment).get("subdirectory", [])
+        candidate = fragment[0] if fragment else file_path.name
+        return Path(candidate).stem or file_path.name or "local bundle"
+
+    derived = _extract_behavior_name(key)
+    # The shared helper deliberately falls back to the raw URI for unfamiliar
+    # hosts. Update output must never turn that fallback into a credential leak.
+    if "://" not in derived:
+        return derived
+    parsed = urlsplit(key.removeprefix("git+"))
+    return Path(parsed.path).name.split("@", 1)[0].removesuffix(".git") or "bundle"
+
+
+def _bundle_uri_label_parts(uri: str) -> tuple[str, str, str]:
+    """Return safe repo/ref/subpath discriminators for an app-source URI."""
+
+    parsed = urlsplit(uri.removeprefix("git+"))
+    path_parts = [part for part in parsed.path.split("/") if part]
+    leaf = path_parts[-1] if path_parts else ""
+    repo, marker, ref = leaf.rpartition("@")
+    if not marker:
+        repo, ref = leaf, ""
+    repo = repo.removesuffix(".git")
+    owner = path_parts[-2] if len(path_parts) > 1 else ""
+    repository = "/".join(part for part in (owner, repo) if part)
+    subdirectory = parse_qs(parsed.fragment).get("subdirectory", [""])[0]
+    return repository, f"@{ref}" if ref else "", subdirectory
+
+
+def _bundle_display_names(
+    bundle_keys: Iterable[str],
+    statuses: dict[str, "BundleStatus"] | None = None,
+) -> dict[str, str]:
+    """Map update keys to compact, unique, credential-safe display labels."""
+
+    # Identity is carried by the result key today. Retain the optional status
+    # map so every reporting surface can share this function as source-aware
+    # presentation grows without changing its public call shape.
+    del statuses
+    keys = list(bundle_keys)
+    labels = {key: _bundle_display_base_name(key) for key in keys}
+    grouped: dict[str, list[str]] = {}
+    for key, label in labels.items():
+        grouped.setdefault(label, []).append(key)
+
+    for base, colliding in grouped.items():
+        if len(colliding) == 1:
+            continue
+        uri_keys = [key for key in colliding if "://" in key]
+        alias_keys = [key for key in colliding if "://" not in key]
+        # A registry alias is already the user's compact stable handle. A
+        # single colliding app source only needs its role to become distinct.
+        if alias_keys and len(uri_keys) == 1:
+            labels[uri_keys[0]] = f"{base} (app source)"
+            continue
+
+        parts = {key: _bundle_uri_label_parts(key) for key in uri_keys}
+        qualifiers = [""] * len(uri_keys)
+        for index in range(3):
+            candidate = {
+                key: " ".join(part for part in parts[key][: index + 1] if part)
+                for key in uri_keys
+            }
+            if all(candidate.values()) and len(set(candidate.values())) == len(candidate):
+                qualifiers = [candidate[key] for key in uri_keys]
+                break
+        for key, qualifier in zip(uri_keys, qualifiers, strict=True):
+            labels[key] = f"{base} ({qualifier or 'app source'})"
+        # Multiple aliases with the same spelling should not normally exist,
+        # but leave their exact user-facing aliases intact rather than invent
+        # an order-dependent suffix.
+        for key in alias_keys:
+            labels[key] = key
+    return labels
 
 
 def _bundle_row_sort_key(
@@ -712,6 +937,25 @@ async def _check_all_bundle_status() -> dict[str, "BundleStatus"]:
     cache_dir = get_amplifier_home() / "cache"
     git_handler = GitSourceHandler()
 
+    def _failed_bundle_status(
+        bundle_name: str, source_uri: str | None, error: Exception
+    ) -> BundleStatus:
+        """Keep a direct configured source visible when its status check fails."""
+
+        uri = source_uri or ""
+        return BundleStatus(
+            bundle_name=bundle_name,
+            bundle_source=uri,
+            sources=[
+                SourceStatus(
+                    source_uri=uri,
+                    is_cached=False,
+                    has_update=None,
+                    error=str(error),
+                )
+            ],
+        )
+
     async def _check_bundle_uri(bundle_name: str, uri: str) -> BundleStatus:
         """Check one configured source without loading it."""
         parsed = parse_uri(uri)
@@ -764,12 +1008,16 @@ async def _check_all_bundle_status() -> dict[str, "BundleStatus"]:
         try:
             # Get URI without loading (avoids download side effect).
             uri = registry.find(bundle_name)
-            if not uri:
-                continue
-            checked_uris.add(uri)
+        except Exception as exc:
+            results[bundle_name] = _failed_bundle_status(bundle_name, None, exc)
+            continue
+        if not uri:
+            continue
+        checked_uris.add(uri)
+        try:
             results[bundle_name] = await _check_bundle_uri(bundle_name, uri)
-        except Exception:
-            continue  # Skip bundles that fail status check
+        except Exception as exc:
+            results[bundle_name] = _failed_bundle_status(bundle_name, uri, exc)
 
     # App bundles are configured source URIs rather than registry aliases, so
     # the exact URI stays the result key: different refs are genuinely
@@ -794,8 +1042,8 @@ async def _check_all_bundle_status() -> dict[str, "BundleStatus"]:
         checked_uris.add(uri)
         try:
             results[uri] = await _check_bundle_uri(uri, uri)
-        except Exception:
-            continue  # Skip bundles that fail status check
+        except Exception as exc:
+            results[uri] = _failed_bundle_status(uri, uri, exc)
 
     # Everything above enumerates sources somebody REGISTERED: registry roots
     # and app-bundle settings entries. A bundle that reaches the active
@@ -833,7 +1081,7 @@ async def _check_transitive_bundle_status(
 
     # Seed the walk with the label each direct row already displays, so a
     # transitive row can name a parent the user can actually find in the table.
-    seed_labels = _bundle_display_names(direct_results.keys())
+    seed_labels = _bundle_display_names(direct_results.keys(), direct_results)
     roots = {
         seed_labels.get(key, key): status.bundle_source
         for key, status in direct_results.items()
@@ -932,13 +1180,14 @@ async def _get_file_bundle_status(
 
     # Get remote SHA using the git handler
     remote_sha = None
+    remote_error: Exception | None = None
     try:
         remote_parsed = parse_uri(remote_uri)
         if git_handler.can_handle(remote_parsed):
             remote_status = await git_handler.get_status(remote_parsed, cache_dir)
             remote_sha = remote_status.remote_commit
-    except Exception:
-        pass  # Failed to get remote SHA, will show as unknown
+    except Exception as exc:
+        remote_error = exc
 
     # Determine if there's an update available
     has_update = None
@@ -956,6 +1205,7 @@ async def _get_file_bundle_status(
         cached_commit=local_sha,
         remote_commit=remote_sha,
         summary=summary,
+        error=str(remote_error) if remote_error else None,
     )
     status._has_local_changes = has_local_changes
     return status
@@ -1165,7 +1415,7 @@ def _show_concise_report(
         table.add_column("Remote", style="dim", justify="right")
         table.add_column("Status", justify="center")
 
-        display_names = _bundle_display_names(bundle_results.keys())
+        display_names = _bundle_display_names(bundle_results.keys(), bundle_results)
         bundle_plan = bundle_plan or _bundle_report_plan(bundle_results)
 
         for bundle_name in sorted(
@@ -1396,7 +1646,7 @@ def _show_verbose_report(
     # === BUNDLES ===
     if bundle_results:
         active_bundle = _get_active_bundle_name()
-        display_names = _bundle_display_names(bundle_results.keys())
+        display_names = _bundle_display_names(bundle_results.keys(), bundle_results)
         bundle_plan = bundle_plan or _bundle_report_plan(bundle_results)
         for bundle_name in sorted(
             bundle_results.keys(),
@@ -1437,7 +1687,7 @@ def _show_verbose_report(
                     )
                     _print_verbose_item(
                         name=source_name,
-                        status_symbol=_report_state_text(source_state),
+                        status_symbol=_source_report_state_text(source, source_state),
                         local_sha=source.cached_commit,
                         remote_sha=source.remote_commit,
                         local_path=(
@@ -1664,7 +1914,7 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
         console.print("  Checking bundles...")
     bundle_results = asyncio.run(_check_all_bundle_status())
     bundle_plan = _bundle_report_plan(bundle_results)
-    bundle_labels = _bundle_display_names(bundle_results.keys())
+    bundle_labels = _bundle_display_names(bundle_results.keys(), bundle_results)
     has_bundle_updates = (
         any(s.has_updates for s in bundle_results.values()) if bundle_results else False
     )
@@ -1823,7 +2073,7 @@ def update(check_only: bool, yes: bool, force: bool, verbose: bool):
             ]
             # Progress lines are read by a human; the key stays the URI because
             # bundle_source below has to round-trip into update_bundle.
-            update_labels = _bundle_display_names(bundles_to_update)
+            update_labels = bundle_labels
 
             from amplifier_foundation.paths.resolution import get_amplifier_home
 

--- a/amplifier_app_cli/commands/update.py
+++ b/amplifier_app_cli/commands/update.py
@@ -9,7 +9,6 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import SplitResult, parse_qs, unquote, urlsplit
-from urllib.request import url2pathname
 
 import click
 from rich.console import Console
@@ -168,7 +167,9 @@ def _file_uri_path_value(uri: str, *, windows: bool) -> str | None:
     else:
         return None
 
-    converter = nturl2path.url2pathname if windows else url2pathname
+    # urllib.request.url2pathname follows the host OS. Use percent-decoding
+    # explicitly for POSIX so the requested platform, not the host, wins.
+    converter = nturl2path.url2pathname if windows else unquote
     try:
         path_value = converter(encoded_path)
     except (OSError, ValueError):

--- a/tests/test_bundle_commands.py
+++ b/tests/test_bundle_commands.py
@@ -273,7 +273,7 @@ async def test_global_update_reports_registry_failure_and_checks_later_bundles(m
     broken = results["broken"]
     assert broken.bundle_name == "broken"
     assert broken.bundle_source == ""
-    assert broken.sources[0].error == "registry unavailable"
+    assert broken.sources[0].error == "status check failed"
     assert results[working_bundle].bundle_source == working_uri
     assert registry.find.call_args_list == [(("broken",),), ((working_bundle,),)]
 
@@ -312,8 +312,8 @@ async def test_global_update_reports_direct_app_check_failure_by_exact_uri(monke
 
     assert set(results) == {failing_uri}
     assert results[failing_uri].bundle_source == failing_uri
-    assert results[failing_uri].sources[0].source_uri == failing_uri
-    assert results[failing_uri].sources[0].error
+    assert results[failing_uri].sources[0].source_uri == ""
+    assert results[failing_uri].sources[0].error == "timeout"
 
 
 def test_global_update_loads_an_app_target_by_source_uri(monkeypatch):
@@ -518,3 +518,83 @@ def test_colliding_app_bundle_labels_distinguish_refs_and_ignore_credentials():
     assert labels[release] == "team (org/amplifier-bundle-team @release)"
     assert all("secret" not in label for label in labels.values())
     assert labels == update_module._bundle_display_names([main, release])
+
+
+def test_bundle_labels_are_globally_unique_without_changing_registry_aliases():
+    """Generated labels yield to literal aliases, then use source-only context."""
+
+    uri = (
+        "git+https://example.invalid/org/amplifier-bundle-team@main"
+        "#subdirectory=behaviors/team.yaml"
+    )
+    keys = ["team", "team (app source)", uri]
+
+    labels = update_module._bundle_display_names(keys)
+
+    assert labels["team"] == "team"
+    assert labels["team (app source)"] == "team (app source)"
+    assert len(set(labels.values())) == len(labels)
+    assert labels == update_module._bundle_display_names(list(reversed(keys)))
+
+
+def test_bundle_labels_distinguish_local_hosts_schemes_and_equivalent_uri_shapes():
+    """Readable parts come first; opaque hashes resolve only safe-part ties."""
+
+    local_one = "file:///work/one/behaviors/team.yaml"
+    local_two = "file:///work/two/behaviors/team.yaml"
+    host_one = (
+        "git+https://one.invalid/org/amplifier-bundle-team@feature/next"
+        "#subdirectory=behaviors/team.yaml"
+    )
+    host_two = (
+        "https://two.invalid/org/amplifier-bundle-team@feature/next"
+        "#subdirectory=behaviors/team.yaml"
+    )
+    exact_one = (
+        "git+https://same.invalid/org/amplifier-bundle-team@main"
+        "?mirror=one#subdirectory=behaviors/team.yaml"
+    )
+    exact_two = (
+        "git+https://same.invalid/org/amplifier-bundle-team@main"
+        "?mirror=two#subdirectory=behaviors/team.yaml"
+    )
+    keys = [local_one, local_two, host_one, host_two, exact_one, exact_two]
+
+    labels = update_module._bundle_display_names(keys)
+
+    assert len(set(labels.values())) == len(labels)
+    assert labels[local_one] != labels[local_two]
+    assert "one.invalid" in labels[host_one]
+    assert "two.invalid" in labels[host_two]
+    assert labels[exact_one].endswith("]")
+    assert labels[exact_two].endswith("]")
+    assert all("mirror=" not in label for label in labels.values())
+    assert labels == update_module._bundle_display_names(list(reversed(keys)))
+
+
+def test_bundle_labels_remain_unique_when_an_alias_matches_a_hash_candidate():
+    """A literal alias also wins over a source label introduced by final hashing."""
+
+    first = (
+        "git+https://same.invalid/org/amplifier-bundle-team@main"
+        "?mirror=one#subdirectory=behaviors/team.yaml"
+    )
+    second = (
+        "git+https://same.invalid/org/amplifier-bundle-team@main"
+        "?mirror=two#subdirectory=behaviors/team.yaml"
+    )
+    generated_alias = update_module._bundle_display_names([first, second])[first]
+
+    labels = update_module._bundle_display_names([generated_alias, first, second])
+
+    assert labels[generated_alias] == generated_alias
+    assert len(set(labels.values())) == len(labels)
+
+
+def test_malformed_uri_never_breaks_or_leaks_through_bundle_labels():
+    malformed = "git+https://user:token@[broken/team"
+
+    labels = update_module._bundle_display_names([malformed])
+
+    assert labels[malformed] == "bundle"
+    assert "token" not in labels[malformed]

--- a/tests/test_bundle_commands.py
+++ b/tests/test_bundle_commands.py
@@ -233,8 +233,8 @@ async def test_global_update_checks_app_only_sources_by_exact_uri(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_global_update_skips_bundle_when_registry_lookup_fails(monkeypatch):
-    """A failed registry lookup must not prevent later bundles from being checked."""
+async def test_global_update_reports_registry_failure_and_checks_later_bundles(monkeypatch):
+    """A failed registry lookup remains visible and does not stop later checks."""
     from amplifier_foundation.sources.git import GitSourceHandler
 
     working_bundle = "working"
@@ -269,9 +269,51 @@ async def test_global_update_skips_bundle_when_registry_lookup_fails(monkeypatch
 
     results = await update_module._check_all_bundle_status()
 
-    assert set(results) == {working_bundle}
+    assert set(results) == {"broken", working_bundle}
+    broken = results["broken"]
+    assert broken.bundle_name == "broken"
+    assert broken.bundle_source == ""
+    assert broken.sources[0].error == "registry unavailable"
     assert results[working_bundle].bundle_source == working_uri
     assert registry.find.call_args_list == [(("broken",),), ((working_bundle,),)]
+
+
+@pytest.mark.asyncio
+async def test_global_update_reports_direct_app_check_failure_by_exact_uri(monkeypatch):
+    """A configured app URI remains a row when its direct status request fails."""
+
+    from amplifier_foundation.sources.git import GitSourceHandler
+
+    failing_uri = (
+        "git+https://person:secret@example.invalid/org/amplifier-bundle-failing@main"
+    )
+    monkeypatch.setattr(
+        update_module,
+        "AppBundleDiscovery",
+        lambda: SimpleNamespace(list_cached_root_bundles=lambda: []),
+    )
+    monkeypatch.setattr(update_module, "create_bundle_registry", MagicMock())
+    monkeypatch.setattr(
+        update_module,
+        "AppSettings",
+        lambda: SimpleNamespace(get_app_bundles=lambda: [failing_uri]),
+    )
+
+    async def failing_get_status(self, parsed, cache_dir):
+        raise TimeoutError("token in https://person:secret@example.invalid")
+
+    async def no_transitives(*args, **kwargs):
+        return {}
+
+    monkeypatch.setattr(GitSourceHandler, "get_status", failing_get_status)
+    monkeypatch.setattr(update_module, "_check_transitive_bundle_status", no_transitives)
+
+    results = await update_module._check_all_bundle_status()
+
+    assert set(results) == {failing_uri}
+    assert results[failing_uri].bundle_source == failing_uri
+    assert results[failing_uri].sources[0].source_uri == failing_uri
+    assert results[failing_uri].sources[0].error
 
 
 def test_global_update_loads_an_app_target_by_source_uri(monkeypatch):
@@ -435,15 +477,15 @@ def test_app_bundle_rows_display_a_friendly_name():
     assert labels[_FRAGMENT_URI] == "team"
 
 
-def test_colliding_app_bundle_labels_fall_back_to_the_full_uri():
-    """Two rows showing the same name would misidentify which one updates."""
+def test_colliding_app_bundle_labels_use_compact_repo_qualifiers():
+    """Colliding app rows remain identifiable without exposing raw URIs."""
     first = "git+https://github.com/a/repo-one@main#subdirectory=behaviors/main.yaml"
     second = "git+https://github.com/b/repo-two@main#subdirectory=behaviors/main.yaml"
 
     labels = update_module._bundle_display_names([first, second])
 
-    assert labels[first] == first
-    assert labels[second] == second
+    assert labels[first] == "main (a/repo-one)"
+    assert labels[second] == "main (b/repo-two)"
 
 
 def test_an_app_bundle_label_never_shadows_a_registry_alias():
@@ -455,4 +497,24 @@ def test_an_app_bundle_label_never_shadows_a_registry_alias():
     labels = update_module._bundle_display_names(["modes", collides])
 
     assert labels["modes"] == "modes", "the registry alias keeps its name"
-    assert labels[collides] == collides
+    assert labels[collides] == "modes (app source)"
+
+
+def test_colliding_app_bundle_labels_distinguish_refs_and_ignore_credentials():
+    """Ref is added only when needed, and userinfo/query never reach the table."""
+
+    main = (
+        "git+https://user:secret@example.invalid/org/amplifier-bundle-team@main"
+        "#subdirectory=behaviors/team.yaml"
+    )
+    release = (
+        "git+https://user:secret@example.invalid/org/amplifier-bundle-team@release"
+        "#subdirectory=behaviors/team.yaml"
+    )
+
+    labels = update_module._bundle_display_names([release, main])
+
+    assert labels[main] == "team (org/amplifier-bundle-team @main)"
+    assert labels[release] == "team (org/amplifier-bundle-team @release)"
+    assert all("secret" not in label for label in labels.values())
+    assert labels == update_module._bundle_display_names([main, release])

--- a/tests/test_update_reporting.py
+++ b/tests/test_update_reporting.py
@@ -163,6 +163,28 @@ def test_file_uri_parser_rejects_windows_authorities_that_are_not_unc_hosts(uri)
     assert update_module._file_uri_path_value(uri, windows=True) is None
 
 
+def test_file_uri_parser_rejects_windows_conversion_errors():
+    assert update_module._file_uri_path_value(
+        "file:///work/|malformed", windows=True
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "file://",
+        "http://",
+        "https://",
+        "git+https://",
+        "zip+file://",
+        "file://user:token@server/share/bundle",
+        "file:///tmp/%00invalid",
+    ],
+)
+def test_app_sources_require_usable_locations(uri):
+    assert not update_module._is_valid_app_source(uri)
+
+
 @pytest.mark.parametrize(
     ("error", "expected"),
     [
@@ -482,6 +504,12 @@ def test_check_only_presentation_preserves_existing_registry_settings_and_cache(
                 "    - 'git+https://token@[broken/source'",
                 "    - 7",
                 "    - {private: value}",
+                "    - 'file://'",
+                "    - 'http://'",
+                "    - 'https://'",
+                "    - 'git+https://'",
+                "    - 'zip+file://'",
+                "    - 'file://userinfo:token@server/share/bundle'",
                 "",
             ]
         ),

--- a/tests/test_update_reporting.py
+++ b/tests/test_update_reporting.py
@@ -13,6 +13,7 @@ from rich.console import Console
 
 from amplifier_app_cli.commands import update as update_module
 from amplifier_app_cli.commands.update import _classify_source_status
+from amplifier_app_cli.commands.update import _check_failure_reason
 from amplifier_app_cli.commands.update import _revision_report_state
 from amplifier_app_cli.commands.update import TransitiveBundleStatus
 from amplifier_app_cli.commands.update import update
@@ -72,6 +73,64 @@ def test_source_status_current_requires_a_confirmed_equal_comparison(
     )
 
     assert _classify_source_status(source) == expected
+
+
+def test_file_sources_distinguish_local_packaged_missing_and_confirmed_remote(
+    tmp_path, monkeypatch
+):
+    """Filesystem facts are visible without changing successful remote comparisons."""
+
+    local_path = tmp_path / "local"
+    local_path.mkdir()
+    wheel_root = tmp_path / "site-packages" / "amplifier_app_cli" / "_bundle"
+    wheel_root.mkdir(parents=True)
+    packaged_path = wheel_root / "behaviors"
+    packaged_path.mkdir()
+    monkeypatch.setattr(update_module, "_app_cli_packaged_bundle_root", lambda: wheel_root)
+
+    assert _classify_source_status(
+        _source(f"file://{local_path}", is_cached=True, has_update=None)
+    ) == "local"
+    assert _classify_source_status(
+        _source(f"file://{packaged_path}", is_cached=True, has_update=None)
+    ) == "packaged"
+    assert _classify_source_status(
+        _source(f"file://{tmp_path / 'missing'}", is_cached=True, has_update=None)
+    ) == "missing_path"
+    assert _classify_source_status(
+        _source(
+            f"file://{local_path}",
+            is_cached=True,
+            has_update=False,
+            cached_commit="a" * 40,
+            remote_commit="a" * 40,
+        )
+    ) == "current"
+    assert _classify_source_status(
+        _source(
+            f"file://{local_path}",
+            is_cached=True,
+            has_update=True,
+            cached_commit="a" * 40,
+            remote_commit="b" * 40,
+        )
+    ) == "update"
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        (TimeoutError(), "timeout"),
+        (RuntimeError("HTTP 401 credential rejected"), "authentication"),
+        (RuntimeError("HTTP 403 forbidden"), "permission"),
+        (RuntimeError("HTTP 404 not found"), "not found"),
+        (RuntimeError("HTTP 429 too many requests"), "rate limit"),
+        (RuntimeError("DNS connection failed"), "network"),
+        (RuntimeError("unexpected response"), "status check failed"),
+    ],
+)
+def test_check_failure_reason_uses_only_safe_vocabulary(error, expected):
+    assert _check_failure_reason(error) == expected
 
 
 @pytest.mark.parametrize(
@@ -271,7 +330,7 @@ def test_missing_bundle_caches_are_downloads_not_updates(monkeypatch):
     assert "Available actions:" in checked.output
     assert "Updates available:" not in checked.output
     assert "Download" in checked.output
-    assert "Not checked" in checked.output
+    assert "Missing path" in checked.output
     assert "Current" in checked.output
     assert direct_loads == [direct_uri]
     assert direct_updates == [direct_uri]
@@ -348,6 +407,29 @@ def test_all_confirmed_current_sources_keep_the_green_summary():
     assert result.exit_code == 0, result.output
     assert "All sources up to date" in result.output
     assert "No confirmed updates" not in result.output
+
+
+def test_check_only_leaves_registry_settings_and_cache_bytes_unchanged(tmp_path):
+    """The real Click command reports through mocked boundaries without mutating state."""
+
+    registry = tmp_path / "registry.json"
+    settings = tmp_path / "settings.yaml"
+    cache_sentinel = tmp_path / "cache" / "sentinel.bin"
+    registry.write_bytes(b'{"bundle":"original"}\n')
+    settings.write_bytes(b"bundle:\n  app: []\n")
+    cache_sentinel.parent.mkdir()
+    cache_sentinel.write_bytes(b"\x00unchanged-cache\xff")
+    before = {path: path.read_bytes() for path in (registry, settings, cache_sentinel)}
+
+    report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+    patches = _command_patches(report, {})
+    with ExitStack() as stack:
+        for boundary in patches:
+            stack.enter_context(boundary)
+        result = CliRunner().invoke(update, ["--check-only"])
+
+    assert result.exit_code == 0, result.output
+    assert {path: path.read_bytes() for path in before} == before
 
 
 def test_local_umbrella_dependency_prevents_a_false_all_current_summary():
@@ -694,7 +776,14 @@ def test_mixed_bundle_states_render_the_same_plan_in_both_reports():
     assert concise.exit_code == 0, concise.output
     assert verbose.exit_code == 0, verbose.output
     assert before == after == ["stale", "missing", "unreadable", "dirty", "error"]
-    for label in ("Update", "Download", "Refresh cache", "Not checked", "Local changes", "Pinned"):
+    for label in (
+        "Update",
+        "Download",
+        "Refresh cache",
+        "Missing path",
+        "Pinned",
+        "Check failed: status check failed",
+    ):
         assert label in concise.output
         assert label in verbose.output
     assert "Pinned; not cached" in concise.output
@@ -770,7 +859,7 @@ def test_mixed_actions_process_one_bundle_once_and_report_its_composition():
     assert "Download 1 bundle" not in checked.output
     assert "Update 1 bundle" not in checked.output
     assert accepted.exit_code == 0, accepted.output
-    assert "Not checked" in accepted.output
+    assert "Missing path" in accepted.output
     assert "Processed bundle: mixed" in accepted.output
     assert loads == [uri]
     assert updates == ["called"]
@@ -848,7 +937,7 @@ def test_selected_neutral_bundle_states_are_confirmed_and_processed_once():
     assert result.exit_code == 0, result.output
     assert "Process 1 bundle with downloads and updates" in result.output
     assert "Process 1 bundle with local changes" in result.output
-    assert "Process 1 bundle with unconfirmed sources" in result.output
+    assert "Process 1 bundle with failed checks" in result.output
     assert loads == [mixed_uri, dirty_uri, error_uri]
     assert "Processed bundle: dirty" in result.output
     assert "Processed bundle: error" in result.output
@@ -946,3 +1035,67 @@ def test_mixed_bundle_failure_reports_processing_not_a_successful_action():
     assert result.exit_code == 0, result.output
     assert "Failed to process bundle: mixed-failure: cannot process mixed" in result.output
     assert "Processed bundle: mixed-failure" not in result.output
+
+
+@pytest.mark.parametrize("verbose", [False, True])
+def test_failed_check_is_visible_but_never_prints_credentials(verbose):
+    """A failure reports a classified reason in every renderer, never exception text."""
+
+    secret = "https://person:secret-token@example.invalid/private"
+    failed = _bundle(
+        "failed",
+        _source(
+            "git+https://example.invalid/failed@main",
+            is_cached=True,
+            has_update=False,
+            error=f"authentication failed for {secret}",
+        ),
+    )
+    report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+    patches = _command_patches(report, {"failed": failed})
+    with ExitStack() as stack:
+        for boundary in patches:
+            stack.enter_context(boundary)
+        result = CliRunner().invoke(
+            update, ["--check-only", *(["--verbose"] if verbose else [])]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Check failed: authentication" in result.output
+    assert secret not in result.output
+
+
+@pytest.mark.parametrize("verbose", [False, True])
+def test_bundle_update_keeps_a_sibling_check_failure_visible(verbose):
+    """An action stays actionable while an independent failed check stays visible."""
+
+    updating = _source(
+        "git+https://example.invalid/updating@main",
+        is_cached=True,
+        has_update=True,
+        cached_commit="a" * 40,
+        remote_commit="b" * 40,
+    )
+    failed = _source(
+        "git+https://example.invalid/failed@main",
+        is_cached=True,
+        has_update=None,
+        error="network connection refused",
+    )
+    bundle = BundleStatus(
+        bundle_name="mixed-outcome",
+        bundle_source=updating.source_uri,
+        sources=[updating, failed],
+    )
+    report = UpdateReport(local_file_sources=[], cached_git_sources=[])
+    patches = _command_patches(report, {"mixed-outcome": bundle})
+    with ExitStack() as stack:
+        for boundary in patches:
+            stack.enter_context(boundary)
+        result = CliRunner().invoke(
+            update, ["--check-only", *(["--verbose"] if verbose else [])]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert "Update; check failed: network" in result.output
+    assert "Update 1 bundle" in result.output

--- a/tests/test_update_reporting.py
+++ b/tests/test_update_reporting.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from contextlib import ExitStack
 import io
+from pathlib import PureWindowsPath
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -115,6 +116,51 @@ def test_file_sources_distinguish_local_packaged_missing_and_confirmed_remote(
             remote_commit="b" * 40,
         )
     ) == "update"
+
+
+@pytest.mark.parametrize(
+    ("uri", "windows_path", "posix_path"),
+    [
+        (
+            "file:///C:/Program%20Files/Amplifier",
+            PureWindowsPath("C:/Program Files/Amplifier"),
+            "/C:/Program Files/Amplifier",
+        ),
+        (
+            r"file://C:\Program%20Files\Amplifier",
+            PureWindowsPath(r"C:\Program Files\Amplifier"),
+            None,
+        ),
+        ("file://server/share/Amplifier", PureWindowsPath("//server/share/Amplifier"), None),
+    ],
+)
+def test_file_uri_parser_accepts_standard_legacy_and_unc_windows_forms(
+    uri, windows_path, posix_path
+):
+    """Windows file URI forms stay local only when interpreted as Windows paths."""
+
+    assert PureWindowsPath(update_module._file_uri_path_value(uri, windows=True)) == windows_path
+    assert update_module._file_uri_path_value(uri, windows=False) == posix_path
+
+
+def test_file_uri_parser_accepts_localhost_and_rejects_remote_posix_authority():
+    assert update_module._file_uri_path_value(
+        "file://localhost/tmp/space%20name", windows=False
+    ) == "/tmp/space name"
+    assert update_module._file_uri_path_value(
+        "file://remote-host/tmp/space%20name", windows=False
+    ) is None
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "file://user:token@server/share/bundle",
+        "file://server:8443/share/bundle",
+    ],
+)
+def test_file_uri_parser_rejects_windows_authorities_that_are_not_unc_hosts(uri):
+    assert update_module._file_uri_path_value(uri, windows=True) is None
 
 
 @pytest.mark.parametrize(
@@ -409,27 +455,93 @@ def test_all_confirmed_current_sources_keep_the_green_summary():
     assert "No confirmed updates" not in result.output
 
 
-def test_check_only_leaves_registry_settings_and_cache_bytes_unchanged(tmp_path):
-    """The real Click command reports through mocked boundaries without mutating state."""
+def test_check_only_presentation_preserves_existing_registry_settings_and_cache(
+    tmp_path, monkeypatch
+):
+    """The real checker renders configured sources without presentation writes.
 
-    registry = tmp_path / "registry.json"
-    settings = tmp_path / "settings.yaml"
-    cache_sentinel = tmp_path / "cache" / "sentinel.bin"
-    registry.write_bytes(b'{"bundle":"original"}\n')
-    settings.write_bytes(b"bundle:\n  app: []\n")
-    cache_sentinel.parent.mkdir()
-    cache_sentinel.write_bytes(b"\x00unchanged-cache\xff")
-    before = {path: path.read_bytes() for path in (registry, settings, cache_sentinel)}
+    Foundation validates stale registry cache paths while constructing a
+    registry.  This fixture deliberately provides an empty, valid registry,
+    so the assertion covers this CLI's presentation and routing boundary
+    rather than claiming all historical ``--check-only`` paths are write-free.
+    """
 
-    report = UpdateReport(local_file_sources=[], cached_git_sources=[])
-    patches = _command_patches(report, {})
+    home = tmp_path / "amplifier-home"
+    cache = home / "cache"
+    configured_path = tmp_path / "configured bundle"
+    configured_path.mkdir()
+    home.mkdir()
+    cache.mkdir()
+    (home / "registry.json").write_bytes(b'{"bundles": {}}\n')
+    (home / "settings.yaml").write_text(
+        "\n".join(
+            [
+                "bundle:",
+                "  app:",
+                f"    - {configured_path.as_uri()}",
+                "    - 'git+https://token@[broken/source'",
+                "    - 7",
+                "    - {private: value}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (cache / "sentinel.bin").write_bytes(b"\x00unchanged-cache\xff")
+    before = {
+        path.relative_to(home): path.read_bytes()
+        for path in home.rglob("*")
+        if path.is_file()
+    }
+    monkeypatch.setenv("AMPLIFIER_HOME", str(home))
+    monkeypatch.setenv("HOME", str(tmp_path / "decoy-home"))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path / "decoy-home"))
+    output = io.StringIO()
+    monkeypatch.setattr(update_module, "console", Console(file=output, width=200))
+
+    async def fake_check_all_sources(**kwargs):
+        return UpdateReport(local_file_sources=[], cached_git_sources=[])
+
+    async def no_transitive_discovery(*args, **kwargs):
+        return {}
+
     with ExitStack() as stack:
-        for boundary in patches:
-            stack.enter_context(boundary)
+        stack.enter_context(
+            patch(
+                "amplifier_app_cli.commands.update.check_all_sources",
+                side_effect=fake_check_all_sources,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "amplifier_app_cli.commands.update._check_transitive_bundle_status",
+                side_effect=no_transitive_discovery,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "amplifier_app_cli.commands.update.AppBundleDiscovery",
+                return_value=SimpleNamespace(list_cached_root_bundles=lambda: []),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "amplifier_app_cli.utils.umbrella_discovery.discover_umbrella_source",
+                return_value=None,
+            )
+        )
         result = CliRunner().invoke(update, ["--check-only"])
 
+    after = {
+        path.relative_to(home): path.read_bytes()
+        for path in home.rglob("*")
+        if path.is_file()
+    }
     assert result.exit_code == 0, result.output
-    assert {path: path.read_bytes() for path in before} == before
+    assert after == before
+    assert "Check failed: invalid source" in output.getvalue()
+    assert "token" not in output.getvalue()
+    assert "private" not in output.getvalue()
 
 
 def test_local_umbrella_dependency_prevents_a_false_all_current_summary():


### PR DESCRIPTION
## What changed
- Report `Local`, `Packaged`, `Missing path`, and `Check failed` with safe reasons while retaining `Not checked` and normal confirmed comparisons.
- Keep compact, distinct, stable labels for local aliases versus app source/ref/owner/host, adding a residual source hash only when needed; the original URI remains the action key.
- Handle malformed app entries safely, and support standard/legacy Windows URIs, UNC paths, and POSIX conversion independently of the host.

## Why
Update output previously conflated local cache state, packaged sources, missing paths, and failed checks, making source identity and remediation unclear. This makes the report truthful without changing registry cleanup, remapping, or local-override behavior.

## Verification
- 2,323 tests passed, 5 skipped, 13 deselected, 1 xfail; POSIX-focused integration set: 13 passed, 2,329 deselected.
- Real Click fixtures cover exact URI application and byte preservation, normal and verbose 80/120-column reports, cross-platform path cases, and malformed entries.
- Check-only reporting is globally write-free; no new runtime writes or provider/API changes.

## Trade-offs
Labels are intentionally compact and may include a short source hash only for residual collisions. The report is safer than exposing malformed payloads, at the cost of a generic `Check failed` row when details are not safe to display.

## Breaking changes
None. Existing action keys and update eligibility are unchanged.